### PR TITLE
Fix random_search when max reward < 0

### DIFF
--- a/compiler_gym/bin/random_eval.py
+++ b/compiler_gym/bin/random_eval.py
@@ -59,8 +59,8 @@ def eval_logs(outdir: Path) -> None:
             (
                 benchmark,
                 humanize.intcomma(meta["num_instructions"]),
-                f"{meta['init_reward']:.2%}",
-                f"{best.reward:.2%}",
+                f"{meta['init_reward']:.4f}",
+                f"{best.reward:.4f}",
                 (
                     f"{humanize.intcomma(best.total_episode_count)} attempts "
                     f"in {humanize.naturaldelta(best.runtime_seconds)}"
@@ -74,8 +74,8 @@ def eval_logs(outdir: Path) -> None:
         (
             "Geomean",
             "",
-            f"{geometric_mean(totals['init_reward']):.2%}",
-            f"{geometric_mean(totals['max_reward']):.2%}",
+            f"{geometric_mean(totals['init_reward']):.4f}",
+            f"{geometric_mean(totals['max_reward']):.4f}",
             "",
             "",
         )
@@ -84,8 +84,8 @@ def eval_logs(outdir: Path) -> None:
         (
             "Average",
             humanize.intcomma(int(totals["instructions"] / row_count)),
-            f"{np.array(totals['init_reward']).mean():.2%}",
-            f"{np.array(totals['max_reward']).mean():.2%}",
+            f"{np.array(totals['init_reward']).mean():.4f}",
+            f"{np.array(totals['max_reward']).mean():.4f}",
             (
                 f"{humanize.intcomma(int(totals['attempts'] / row_count))} attempts "
                 f"in {humanize.naturaldelta(totals['time'] / row_count)}"

--- a/compiler_gym/random_replay.py
+++ b/compiler_gym/random_replay.py
@@ -19,7 +19,7 @@ def replay_actions(env: CompilerEnv, action_names: List[str], outdir: Path):
     start_time = time()
     init_reward = env.reward[env.eager_reward_space]
 
-    print(f"Step [{0:03d} / {len(action_names):03d}]: reward={init_reward:.2%}")
+    print(f"Step [{0:03d} / {len(action_names):03d}]: reward={init_reward:.4f}")
 
     with open(str(logs_path), "w") as f:
         progress = logs.ProgressLogEntry(
@@ -36,8 +36,8 @@ def replay_actions(env: CompilerEnv, action_names: List[str], outdir: Path):
             _, reward, done, _ = env.step(env.action_space.names.index(action))
             assert not done
             print(
-                f"Step [{i:03d} / {len(action_names):03d}]: reward={reward:.2%}, "
-                f"change={reward-previous_reward:.2%}, action={action}"
+                f"Step [{i:03d} / {len(action_names):03d}]: reward={reward:.4f}, "
+                f"change={reward-previous_reward:.4f}, action={action}"
             )
             progress = logs.ProgressLogEntry(
                 runtime_seconds=time() - start_time,

--- a/compiler_gym/random_search.py
+++ b/compiler_gym/random_search.py
@@ -37,7 +37,7 @@ class RandomAgentWorker(Thread):
         self.total_environment_count = 0
         self.total_episode_count = 0
         self.total_step_count = 0
-        self.best_reward = 0
+        self.best_reward = -float("inf")
         self.best_actions: List[int] = []
         self.best_commandline: List[int] = []
         self.best_found_at_time = time()
@@ -150,7 +150,7 @@ def random_search(
     best_actions = []
     best_commandline = ""
     started = time()
-    last_best_reward = 0
+    last_best_reward = -float("inf")
 
     print(
         f"Started {len(workers)} worker threads for "
@@ -203,7 +203,7 @@ def random_search(
                     f"({humanize.intcomma(int(total_episode_count / runtime))} / sec). "
                     f"Num restarts: {humanize.intcomma(total_environment_count - nproc)}.\n"
                     "\033[K"
-                    f"Best reward: {best_reward:.2%} "
+                    f"Best reward: {best_reward:.4f} "
                     f"({len(best_actions)} passes, "
                     f"found after {humanize.naturaldelta(best_worker.best_found_at_time - started)})",
                     end="",


### PR DESCRIPTION
For environments with negative reward values, best_reward will never
update.

Test strategy:

    $ bazel run -c opt //compiler_gym/bin:random_search -- --env=llvm-ic-v0 --benchmark=npb-v0/50
    Started 16 worker threads for benchmark://npb-v0/50 (3,008 instructions) using reward IrInstructionCountOz.
    Writing logs to /home/user/logs/compilergym/random/npb-v0/50/2020-12-21T18:57:27.592730
    === WARNING: This will loop forever! Use C-c to terminate. ===
    Runtime: 10 seconds. Num steps: 27,592 (2,736 / sec). Num episodes: 240 (23 / sec). Num restarts: 0.
    Best reward: 1.0452 (96 passes, found after 8 seconds)