### PR TITLE
Add a make_benchmark() API for LLVM

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -13,6 +13,7 @@ py_library(
     name = "CompilerGym",
     data = [
         "//compiler_gym/third_party/cBench:benchmarks_list",
+        "//compiler_gym/third_party/cBench:crc32",
     ],
     deps = [
         "//compiler_gym",

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ Install the latest CompilerGym release using:
 
     $ pip install compiler_gym
 
-The binary works on MacOS and Linux (on Ubuntu 18.04, Fedora 28, Debian 10 or newer equivalents)
+The binary works on macOS and Linux (on Ubuntu 18.04, Fedora 28, Debian 10 or
+newer equivalents).
 
 ### Building from Source
 

--- a/compiler_gym/bin/service.py
+++ b/compiler_gym/bin/service.py
@@ -20,7 +20,7 @@ Query the capabilities of a service using:
 
 .. code-block::
 
-    $ python -m compiler_gym.bin.service --env=<env> [--tablefmt=<fmt>] [--heading_level=<num>]
+    $ python -m compiler_gym.bin.service --env=<env> [--heading_level=<num>]
 
 For example:
 

--- a/compiler_gym/envs/llvm/BUILD
+++ b/compiler_gym/envs/llvm/BUILD
@@ -11,7 +11,21 @@ py_library(
     ],
     visibility = ["//compiler_gym/envs:__pkg__"],
     deps = [
+        ":benchmarks",
         ":llvm_env",
+        "//compiler_gym/util",
+    ],
+)
+
+py_library(
+    name = "benchmarks",
+    srcs = ["benchmarks.py"],
+    data = [
+        "//compiler_gym/third_party/llvm:clang",
+        "//compiler_gym/third_party/llvm:llvm-link",
+    ],
+    deps = [
+        "//compiler_gym/service/proto",
         "//compiler_gym/util",
     ],
 )

--- a/compiler_gym/envs/llvm/__init__.py
+++ b/compiler_gym/envs/llvm/__init__.py
@@ -5,11 +5,16 @@
 """Register the LLVM environments."""
 from itertools import product
 
+from compiler_gym.envs.llvm.benchmarks import (
+    ClangInvocation,
+    get_system_includes,
+    make_benchmark,
+)
 from compiler_gym.envs.llvm.llvm_env import LlvmEnv
 from compiler_gym.util.registration import register
 from compiler_gym.util.runfiles_path import runfiles_path
 
-__all__ = ["LlvmEnv"]
+__all__ = ["LlvmEnv", "make_benchmark", "ClangInvocation", "get_system_includes"]
 
 _LLVM_SERVICE_BINARY = runfiles_path(
     "CompilerGym/compiler_gym/envs/llvm/service/service"

--- a/compiler_gym/envs/llvm/benchmarks.py
+++ b/compiler_gym/envs/llvm/benchmarks.py
@@ -1,0 +1,304 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""This module defines a utility function for constructing LLVM benchmarks."""
+import multiprocessing
+import os
+import random
+import subprocess
+import sys
+import tempfile
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable, List, Optional, Union
+
+from compiler_gym.service.proto import Benchmark, File
+from compiler_gym.util.runfiles_path import cache_path, runfiles_path
+
+CLANG = runfiles_path("CompilerGym/compiler_gym/third_party/llvm/clang")
+LLVM_LINK = runfiles_path("CompilerGym/compiler_gym/third_party/llvm/llvm-link")
+
+
+def _communicate(process, input=None, timeout=None):
+    """subprocess.communicate() which kills subprocess on timeout."""
+    try:
+        return process.communicate(input=input, timeout=timeout)
+    except subprocess.TimeoutExpired as e:
+        # kill() was added in Python 3.7.
+        if sys.version_info >= (3, 7, 0):
+            process.kill()
+        else:
+            process.terminate()
+        raise
+
+
+def _get_system_includes() -> Iterable[Path]:
+    """Run the system compiler in verbose mode on a dummy input to get the
+    system header search path.
+    """
+    system_compiler = os.environ.get("CXX", "c++")
+    # Create a temporary directory to write the compiled 'binary' to, since
+    # GNU assembler does not support piping to stdout.
+    with tempfile.TemporaryDirectory() as d:
+        process = subprocess.Popen(
+            [system_compiler, "-xc++", "-v", "-c", "-", "-o", str(Path(d) / "a.out")],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            stdin=subprocess.PIPE,
+            universal_newlines=True,
+        )
+        _, stderr = _communicate(process, input="", timeout=30)
+    if process.returncode:
+        raise OSError(
+            f"Failed to invoke {system_compiler}. "
+            f"Is there a working system compiler?\n"
+            f"Error: {stderr.strip()}"
+        )
+
+    in_search_list = False
+    for line in stderr.split("\n"):
+        if in_search_list and line.startswith("End of search list"):
+            break
+        elif in_search_list:
+            yield Path(line.strip())
+        elif line.startswith("#include <...> search starts here:"):
+            in_search_list = True
+    else:
+        raise OSError(
+            f"Failed to parse '#include <...>' search paths from {system_compiler}:\n"
+            f"{stderr.strip()}"
+        )
+
+
+# Memoized search paths.
+_SYSTEM_INCLUDES = None
+
+
+def get_system_includes() -> List[Path]:
+    """Determine the system include paths for C/C++ compilation jobs.
+
+    This uses the system compiler to determine the search paths for C/C++ system
+    headers. By default, :code:`c++` is invoked. This can be overridden by
+    setting :code:`os.environ["CXX"]`.
+
+    :return: A list of paths to system header directories.
+    :raises OSError: If the compiler fails, or if the search paths cannot be
+        determined.
+    """
+    # Memoize the system includes paths.
+    global _SYSTEM_INCLUDES
+    if _SYSTEM_INCLUDES is None:
+        _SYSTEM_INCLUDES = list(_get_system_includes())
+    return _SYSTEM_INCLUDES
+
+
+class ClangInvocation(object):
+    """Class to represent a single invocation of the clang compiler."""
+
+    def __init__(
+        self, args: List[str], system_includes: bool = True, timeout: int = 600
+    ):
+        """Create a clang invocation.
+
+        :param args: The list of arguments to pass to clang.
+        :param system_includes: Whether to include the system standard libraries
+            during compilation jobs. This requires a system toolchain. See
+            :func:`get_system_includes`.
+        :param timeout: The maximum number of seconds to allow clang to run
+            before terminating.
+        """
+        self.args = args
+        self.system_includes = system_includes
+        self.timeout = timeout
+
+    def command(self, outpath: Path) -> List[str]:
+        cmd = [str(CLANG)]
+        if self.system_includes:
+            for directory in get_system_includes():
+                cmd += ["-isystem", str(directory)]
+
+        cmd += [str(s) for s in self.args]
+        cmd += ["-c", "-emit-llvm", "-o", str(outpath)]
+
+        return cmd
+
+
+def _run_command(args):
+    cmd, timeout = args
+    process = subprocess.Popen(
+        cmd, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, universal_newlines=True
+    )
+    _, stderr = _communicate(process, timeout=timeout)
+    if process.returncode:
+        raise OSError(
+            f"Compilation job failed with returncode {process.returncode}\n"
+            f"Command: {' '.join(cmd)}\n"
+            f"Stderr: {stderr.strip()}"
+        )
+
+
+def make_benchmark(
+    inputs: Union[str, Path, ClangInvocation, List[Union[str, Path, ClangInvocation]]],
+    copt: Optional[List[str]] = None,
+    system_includes: bool = True,
+    timeout: int = 600,
+) -> Benchmark:
+    """Create a benchmark for use by LLVM environments.
+
+    This function takes one or more inputs and uses them to create a benchmark
+    that can be passed to :meth:`compiler_gym.envs.LlvmEnv.reset`.
+
+    For single-source C/C++ programs, you can pass the path of the source file:
+
+    >>> benchmark = make_benchmark('my_app.c')
+    >>> env = gym.make("llvm-v0")
+    >>> env.reset(benchmark=benchmark)
+
+    The clang invocation used is roughly equivalent to:
+
+    .. code-block::
+
+        $ clang my_app.c -O0 -c -emit-llvm -o benchmark.bc
+
+    Additional compile-time arguments to clang can be provided using the
+    :code:`copt` argument:
+
+    >>> benchmark = make_benchmark('/path/to/my_app.cpp', copt=['-O2'])
+
+    If you need more fine-grained control over the options, you can directly
+    construct a :class:`ClangInvocation <compiler_gym.envs.llvm.ClangInvocation>`
+    to pass a list of arguments to clang:
+
+    >>> benchmark = make_benchmark(
+        ClangInvocation(['/path/to/my_app.c'], timeout=10)
+    )
+
+    For multi-file programs, pass a list of inputs that will be compiled
+    separately and then linked to a single module:
+
+    >>> benchmark = make_benchmark([
+        'main.c',
+        'lib.cpp',
+        'lib2.bc',
+    ])
+
+    If you already have prepared bitcode files, those can be linked and used
+    directly:
+
+    >>> benchmark = make_benchmark([
+        'bitcode1.bc',
+        'bitcode2.bc',
+    ])
+
+    :param inputs: An input, or list of inputs.
+    :param copt: A list of command line options to pass to clang when compiling
+        source files.
+    :param system_includes: Whether to include the system standard libraries
+        during compilation jobs. This requires a system toolchain. See
+        :func:`get_system_includes`.
+    :param timeout: The maximum number of seconds to allow clang to run before
+        terminating.
+    :return: A :code:`Benchmark` message.
+    :raises FileNotFoundError: If any input sources are not found.
+    :raises TypeError: If the inputs are of unsupported types.
+    :raises OSError: If a compilation job fails.
+    :raises TimeoutExpired: If a compilation job exceeds :code:`timeout` seconds.
+    """
+    copt = copt or []
+
+    bitcodes: List[Path] = []
+    clang_jobs: List[ClangInvocation] = []
+
+    def _add_path(path: Path):
+        if not path.is_file():
+            raise FileNotFoundError(path)
+
+        if path.suffix == ".bc":
+            bitcodes.append(path)
+        elif path.suffix in {".c", ".cxx", ".cpp", ".cc"}:
+            clang_jobs.append(
+                ClangInvocation(
+                    [
+                        str(path),
+                        "-O0",
+                        "-Xclang",
+                        "-disable-O0-optnone",
+                        "-Xclang",
+                        "-disable-llvm-passes",
+                    ]
+                    + copt,
+                    system_includes=system_includes,
+                    timeout=timeout,
+                )
+            )
+        else:
+            raise ValueError(f"Unrecognized file type: {path.name}")
+
+    # Determine from inputs the list of pre-compiled bitcodes and the clang
+    # invocations required to compile the bitcodes.
+    if isinstance(inputs, str) or isinstance(inputs, Path):
+        _add_path(Path(inputs))
+    elif isinstance(inputs, ClangInvocation):
+        clang_jobs.append(inputs)
+    else:
+        for input in inputs:
+            if isinstance(input, str) or isinstance(input, Path):
+                _add_path(Path(input))
+            elif isinstance(input, ClangInvocation):
+                clang_jobs.append(input)
+            else:
+                raise TypeError(f"Invalid input type: {type(input).__name__}")
+
+    if not bitcodes and not clang_jobs:
+        raise ValueError("No inputs")
+
+    # Shortcut if we only have a single pre-compiled bitcode.
+    if len(bitcodes) == 1 and not clang_jobs:
+        bitcode = bitcodes[0]
+        return Benchmark(
+            uri=f"file:///{bitcode}", program=File(uri=f"file:///{bitcode}")
+        )
+
+    with tempfile.TemporaryDirectory(dir=cache_path(".")) as d:
+        working_dir = Path(d)
+
+        # Run the clang invocations in parallel.
+        clang_outs = [
+            working_dir / f"out-{i}.bc" for i in range(1, len(clang_jobs) + 1)
+        ]
+        clang_cmds = [
+            (job.command(out), job.timeout) for job, out in zip(clang_jobs, clang_outs)
+        ]
+        with multiprocessing.Pool() as pool:
+            list(pool.imap_unordered(_run_command, clang_cmds))
+
+        # Check that the expected files were generated.
+        for i, b in enumerate(clang_outs):
+            if not b.is_file():
+                raise OSError(
+                    f"Clang invocation failed to produce a file: {' '.join(clang_cmds[i])}"
+                )
+
+        if len(bitcodes + clang_outs) > 1:
+            # Link all of the bitcodes into a single module.
+            llvm_link_cmd = [str(LLVM_LINK), "-o", "-"] + [
+                str(path) for path in bitcodes + clang_outs
+            ]
+            llvm_link = subprocess.Popen(
+                llvm_link_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            )
+            bitcode, stderr = _communicate(llvm_link, timeout=timeout)
+            if llvm_link.returncode:
+                raise OSError(
+                    f"Failed to link LLVM bitcodes with error: {stderr.decode('utf-8')}"
+                )
+        else:
+            # We only have a single bitcode so read it.
+            with open(str(list(bitcodes + clang_outs)[0]), "rb") as f:
+                bitcode = f.read()
+
+    timestamp = datetime.now().strftime(f"%Y%m%HT%H%M%S-{random.randrange(16**4):04x}")
+    return Benchmark(
+        uri=f"benchmark://user/{timestamp}", program=File(contents=bitcode)
+    )

--- a/compiler_gym/envs/llvm/benchmarks.py
+++ b/compiler_gym/envs/llvm/benchmarks.py
@@ -191,6 +191,13 @@ def make_benchmark(
         'bitcode2.bc',
     ])
 
+    .. note::
+        LLVM bitcode compatibility is
+        `not guaranteed <https://llvm.org/docs/DeveloperPolicy.html#ir-backwards-compatibility>`_,
+        so you must ensure that any precompiled bitcodes are compatible with the
+        LLVM version used by CompilerGym, which can be queried using
+        :func:`LlvmEnv.compiler_version <compiler_gym.envs.CompilerEnv.compiler_version>`.
+
     :param inputs: An input, or list of inputs.
     :param copt: A list of command line options to pass to clang when compiling
         source files.

--- a/compiler_gym/envs/llvm/llvm_env.py
+++ b/compiler_gym/envs/llvm/llvm_env.py
@@ -12,6 +12,7 @@ import numpy as np
 from gym.spaces import Dict as DictSpace
 
 from compiler_gym.envs.compiler_env import CompilerEnv, step_t
+from compiler_gym.envs.llvm.benchmarks import make_benchmark
 from compiler_gym.envs.llvm.datasets import LLVM_DATASETS
 from compiler_gym.spaces import Commandline, CommandlineFlag, Scalar, Sequence
 from compiler_gym.third_party.autophase import AUTOPHASE_FEATURE_NAMES
@@ -142,6 +143,11 @@ class LlvmEnv(CompilerEnv):
         self.inactive_datasets_site_path.mkdir(parents=True, exist_ok=True)
         for dataset in LLVM_DATASETS:
             self.register_dataset(dataset)
+
+    @staticmethod
+    def make_benchmark(*args, **kwargs):
+        """Alias to :func:`compiler_gym.envs.llvm.make_benchmark`."""
+        return make_benchmark(*args, **kwargs)
 
     @property
     def _observation_view_type(self):

--- a/compiler_gym/random_search.py
+++ b/compiler_gym/random_search.py
@@ -8,7 +8,7 @@ from multiprocessing import cpu_count
 from pathlib import Path
 from threading import Thread
 from time import sleep, time
-from typing import Callable, List, Optional
+from typing import Callable, List, Optional, Union
 
 import humanize
 
@@ -98,7 +98,7 @@ class RandomAgentWorker(Thread):
 
 def random_search(
     make_env: Callable[[], CompilerEnv],
-    outdir: Optional[Path] = None,
+    outdir: Optional[Union[str, Path]] = None,
     total_runtime: Optional[float] = 600,
     patience: int = 100,
     nproc: int = cpu_count(),
@@ -115,6 +115,7 @@ def random_search(
     if not outdir:
         sanitized_benchmark_name = "/".join(benchmark_name.split("/")[-2:])
         outdir = create_logging_dir(f"random/{sanitized_benchmark_name}")
+    outdir = Path(outdir)
 
     if not env.reward_space:
         raise ValueError("Eager reward must be specified for random search")

--- a/compiler_gym/third_party/llvm/BUILD
+++ b/compiler_gym/third_party/llvm/BUILD
@@ -17,3 +17,18 @@ genrule(
     cmd = "cp $< $@",
     visibility = ["//visibility:public"],
 )
+
+genrule(
+    name = "make_llvm-link",
+    srcs = select({
+        "@llvm//:darwin": [
+            "@clang-llvm-10.0.0-x86_64-apple-darwin//:llvm-link",
+        ],
+        "//conditions:default": [
+            "@clang-llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04//:llvm-link",
+        ],
+    }),
+    outs = ["llvm-link"],
+    cmd = "cp $< $@",
+    visibility = ["//visibility:public"],
+)

--- a/compiler_gym/util/tabulate.py
+++ b/compiler_gym/util/tabulate.py
@@ -6,33 +6,24 @@ import csv
 from io import StringIO
 from typing import Any, Iterable, Optional
 
-from absl import flags
 from tabulate import tabulate as tabulate_lib
-
-flags.DEFINE_string(
-    "tablefmt",
-    "grid",
-    "The format of tables to print. "
-    "For a full list of options, see: https://github.com/astanin/python-tabulate#table-format",
-)
-FLAGS = flags.FLAGS
 
 
 def tabulate(
     rows: Iterable[Iterable[Any]],
     headers: Iterable[str],
-    tablefmt: Optional[str] = None,
+    tablefmt: Optional[str] = "grid",
 ) -> str:
     """A wrapper around the third-party tabulate function that adds support
-    for a --tablefmt flag, and the ability to format to tab- or comma-separate
-    formats.
+    for tab- and comma-separate formats.
 
     :param rows: The data to tabulate.
     :param headers: A list of table headers.
-    :param tablefmt: A table format to override the --tablefmt flag.
+    :param tablefmt: The format of tables to print. For a full list of options,
+        see: https://github.com/astanin/python-tabulate#table-format.
     :return: A formatted table as a string.
     """
-    tablefmt = tablefmt or FLAGS.tablefmt
+    tablefmt
 
     if tablefmt == "tsv" or tablefmt == "csv":
         sep = {"tsv": "\t", "csv": ","}[tablefmt]

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -69,6 +69,7 @@ We can see what environments are available using:
     >>> compiler_gym.COMPILER_GYM_ENVS
     ['llvm-v0', 'llvm-ic-v0', 'llvm-autophase-ic-v0', 'llvm-ir-ic-v0']
 
+
 Selecting an environment
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -139,7 +140,7 @@ The compiler environment
 
 If you have experience using `OpenAI Gym <https://gym.openai.com/>`_, the
 CompilerGym environments will be familiar. If not, you can call :code:`help()`
-on any object to query the documentation:
+on any function, object, or method to query the documentation:
 
     >>> help(env)
 
@@ -239,20 +240,21 @@ information:
     >>> info
     {'action_had_no_effect': True, 'new_action_space': False}
 
-For this environment, reward represents the number of instructions in the
-LLVM-IR as a ratio compared to number of instructions when the code is compiled
-with LLVM's :code:`-Oz` optimizations enabled. A value greater than one means
+For this environment, reward represents the reduction in code size of the
+previous action, scaled to the total codesize reduction achieved with LLVM's
+:code:`-Oz` optimizations enabled. A cumulative reward greater than one means
 that the sequence of optimizations performed yields better results than LLVM's
-default pipeline. Let's run 100 random actions and see how close we can get:
+default optimizations. Let's run 100 random actions and see how close we can
+get:
 
     >>> env.reset(benchmark="benchmark://npb-v0/50")
-    >>> episode_returns = 0
+    >>> episode_reward = 0
     >>> for i in range(1, 101):
     ...     observation, reward, done, info = env.step(env.action_space.sample())
     ...     if done:
     ...         break
-    ...     episode_returns += reward
-    ...     print(f"Step {i}, quality={episode_returns:.3%}")
+    ...     episode_reward += reward
+    ...     print(f"Step {i}, quality={episode_reward:.3%}")
     ...
     Step 1, quality=44.299%
     Step 2, quality=44.299%

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -30,6 +30,7 @@ for applying reinforcement learning to compiler optimizations.
    compiler_gym/compiler_gym
    compiler_gym/datasets
    compiler_gym/envs
+   llvm/api
    compiler_gym/service
    compiler_gym/spaces
    compiler_gym/views

--- a/docs/source/llvm/api.rst
+++ b/docs/source/llvm/api.rst
@@ -1,0 +1,16 @@
+compiler_gym.envs.llvm
+======================
+
+The :code:`compiler_gym.envs.llvm` module contains supporting APIs for the
+:doc:`LLVM Environments <index>`.
+
+.. currentmodule:: compiler_gym.envs.llvm
+
+.. autofunction:: make_benchmark
+
+.. autoclass:: ClangInvocation
+   :members:
+
+   .. automethod:: __init__
+
+.. autofunction:: get_system_includes

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ setuptools.setup(
             "third_party/inst2vec/*.pickle",
             "third_party/cBench/benchmarks.txt",
             "third_party/llvm/clang",
+            "third_party/llvm/llvm-link",
         ]
     },
     install_requires=requirements,

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ setuptools.setup(
             "envs/llvm/service/libLLVMPolly.so",
             "third_party/inst2vec/*.pickle",
             "third_party/cBench/benchmarks.txt",
+            "third_party/cBench/cBench/crc32.bc",  # Needed for install-tests.
             "third_party/llvm/clang",
             "third_party/llvm/llvm-link",
         ]

--- a/tests/envs/llvm/custom_benchmarks_test.py
+++ b/tests/envs/llvm/custom_benchmarks_test.py
@@ -3,22 +3,27 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 """Tests for LLVM benchmark handling."""
+import os
+import re
 import tempfile
 from pathlib import Path
 
 import pytest
 
-from compiler_gym.envs import CompilerEnv
+from compiler_gym.envs import LlvmEnv, llvm
 from compiler_gym.service.proto import Benchmark, File
 from compiler_gym.util.runfiles_path import runfiles_path
 from tests.test_main import main
 
 pytest_plugins = ["tests.envs.llvm.fixtures"]
 
-EXAMPLE_BITCODE_FILE = runfiles_path("CompilerGym/third_party/cBench-v0/crc32.bc")
+EXAMPLE_BITCODE_FILE = runfiles_path(
+    "CompilerGym/compiler_gym/third_party/cBench/cBench/crc32.bc"
+)
+EXAMPLE_BITCODE_IR_INSTRUCTION_COUNT = 196
 
 
-def test_reset_invalid_benchmark(env: CompilerEnv):
+def test_reset_invalid_benchmark(env: LlvmEnv):
     invalid_benchmark = "an invalid benchmark"
     with pytest.raises(ValueError) as ctx:
         env.reset(benchmark=invalid_benchmark)
@@ -26,7 +31,7 @@ def test_reset_invalid_benchmark(env: CompilerEnv):
     assert str(ctx.value) == f'Unknown benchmark "{invalid_benchmark}"'
 
 
-def test_invalid_benchmark_data(env: CompilerEnv):
+def test_invalid_benchmark_data(env: LlvmEnv):
     benchmark = Benchmark(
         uri="benchmark://new", program=File(contents="Invalid bitcode".encode("utf-8"))
     )
@@ -37,7 +42,7 @@ def test_invalid_benchmark_data(env: CompilerEnv):
     assert str(ctx.value) == 'Failed to parse LLVM bitcode: "benchmark://new"'
 
 
-def test_invalid_benchmark_missing_file(env: CompilerEnv):
+def test_invalid_benchmark_missing_file(env: LlvmEnv):
     benchmark = Benchmark(
         uri="benchmark://new",
     )
@@ -48,7 +53,7 @@ def test_invalid_benchmark_missing_file(env: CompilerEnv):
     assert str(ctx.value) == "No program set"
 
 
-def test_benchmark_path_not_found(env: CompilerEnv):
+def test_benchmark_path_not_found(env: LlvmEnv):
     with tempfile.TemporaryDirectory() as tmpdir:
         tmpdir = Path(tmpdir)
         benchmark = Benchmark(
@@ -61,7 +66,7 @@ def test_benchmark_path_not_found(env: CompilerEnv):
     assert str(ctx.value) == f'File not found: "{tmpdir}/not_found"'
 
 
-def test_benchmark_path_empty_file(env: CompilerEnv):
+def test_benchmark_path_empty_file(env: LlvmEnv):
     with tempfile.TemporaryDirectory() as tmpdir:
         tmpdir = Path(tmpdir)
         (tmpdir / "test.bc").touch()
@@ -76,7 +81,7 @@ def test_benchmark_path_empty_file(env: CompilerEnv):
     assert str(ctx.value) == f'File is empty: "{tmpdir}/test.bc"'
 
 
-def test_invalid_benchmark_path_contents(env: CompilerEnv):
+def test_invalid_benchmark_path_contents(env: LlvmEnv):
     with tempfile.TemporaryDirectory() as tmpdir:
         tmpdir = Path(tmpdir)
         with open(str(tmpdir / "test.bc"), "w") as f:
@@ -92,7 +97,7 @@ def test_invalid_benchmark_path_contents(env: CompilerEnv):
     assert str(ctx.value) == 'Failed to parse LLVM bitcode: "benchmark://new"'
 
 
-def test_benchmark_path_invalid_protocol(env: CompilerEnv):
+def test_benchmark_path_invalid_protocol(env: LlvmEnv):
     benchmark = Benchmark(
         uri="benchmark://new", program=File(uri="invalid_protocol://test")
     )
@@ -104,6 +109,203 @@ def test_benchmark_path_invalid_protocol(env: CompilerEnv):
         str(ctx.value)
         == 'Unsupported benchmark URI protocol: "invalid_protocol://test"'
     )
+
+
+def test_custom_benchmark(env: LlvmEnv):
+    benchmark = Benchmark(
+        uri="benchmark://new", program=File(uri=f"file:///{EXAMPLE_BITCODE_FILE}")
+    )
+    env.reset(benchmark=benchmark)
+    assert env.benchmark == "benchmark://new"
+
+
+def test_make_benchmark_single_bitcode(env: LlvmEnv):
+    benchmark = llvm.make_benchmark(EXAMPLE_BITCODE_FILE)
+
+    assert benchmark.uri == f"file:///{EXAMPLE_BITCODE_FILE}"
+    assert benchmark.program.uri == f"file:///{EXAMPLE_BITCODE_FILE}"
+
+    env.reset(benchmark=benchmark)
+    assert env.benchmark == benchmark.uri
+    assert env.observation["IrInstructionCount"] == EXAMPLE_BITCODE_IR_INSTRUCTION_COUNT
+
+
+def test_make_benchmark_single_clang_job(env: LlvmEnv):
+    with tempfile.TemporaryDirectory() as d:
+        source = Path(d) / "input.c"
+        with open(str(source), "w") as f:
+            f.write("int A() { return 0; }")
+
+        benchmark = llvm.make_benchmark(str(source))
+
+    env.reset(benchmark=benchmark)
+    assert env.benchmark == benchmark.uri
+    print(env.observation["Ir"])
+    assert re.search(r"define (dso_local )?i32 @A\(\)", env.observation["Ir"])
+
+
+def test_make_benchmark_split_clang_job(env: LlvmEnv):
+    with tempfile.TemporaryDirectory() as d:
+        source_1 = Path(d) / "a.c"
+        source_2 = Path(d) / "b.c"
+        with open(str(source_1), "w") as f:
+            f.write("int B() { return A(); }")
+        with open(str(source_2), "w") as f:
+            f.write("int A() { return 0; }")
+
+        benchmark = llvm.make_benchmark(
+            [
+                str(source_1),
+                str(source_2),
+            ]
+        )
+
+    env.reset(benchmark=benchmark)
+    assert env.benchmark == benchmark.uri
+    print(env.observation["Ir"])
+    assert re.search(r"define (dso_local )?i32 @A\(\)", env.observation["Ir"])
+    assert re.search(r"define (dso_local )?i32 @B\(\)", env.observation["Ir"])
+
+
+def test_make_benchmark_single_clang_invocation_multiple_inputs():
+    with tempfile.TemporaryDirectory() as d:
+        source_1 = Path(d) / "a.c"
+        source_2 = Path(d) / "b.c"
+        with open(str(source_1), "w") as f:
+            f.write("int B() { return A(); }")
+        with open(str(source_2), "w") as f:
+            f.write("int A() { return 0; }")
+
+        # cannot specify -o when generating multiple output files
+        with pytest.raises(OSError):
+            llvm.make_benchmark(llvm.ClangInvocation([str(source_1), str(source_2)]))
+
+
+def test_make_benchmark_undefined_symbol(env: LlvmEnv):
+    with tempfile.TemporaryDirectory() as d:
+        source = Path(d) / "a.c"
+        with open(str(source), "w") as f:
+            f.write("int main() { return A(); }")
+
+        benchmark = llvm.make_benchmark(source)
+
+    env.reset(benchmark=benchmark)
+    assert env.benchmark == benchmark.uri
+    print(env.observation["Ir"])
+    assert re.search(r"declare (dso_local )?i32 @A\(\.\.\.\)", env.observation["Ir"])
+
+
+def test_make_benchmark_missing_file():
+    with tempfile.TemporaryDirectory() as d:
+        with pytest.raises(FileNotFoundError):
+            llvm.make_benchmark(Path(d) / "a.c")
+
+        with pytest.raises(FileNotFoundError):
+            llvm.make_benchmark(str(Path(d) / "a.c"))
+
+
+def test_make_benchmark_unrecognized_file_type():
+    with tempfile.TemporaryDirectory() as d:
+        path = Path(d) / "foo.txt"
+        path.touch()
+
+        with pytest.raises(ValueError) as ctx:
+            llvm.make_benchmark(path)
+
+        assert "Unrecognized file type" in str(ctx.value)
+
+
+def test_make_benchmark_clang_job_standard_libraries(env: LlvmEnv):
+    with tempfile.TemporaryDirectory() as d:
+        source = Path(d) / "input.cc"
+        with open(str(source), "w") as f:
+            f.write('#include <stdio.h>\nint A() { printf(""); return 0; }')
+
+        benchmark = llvm.make_benchmark(str(source))
+
+    env.reset(benchmark=benchmark)
+    assert env.benchmark == benchmark.uri
+    print(env.observation["Ir"])
+    assert re.search(r"define (dso_local )?i32 @_Z1Av\(\)", env.observation["Ir"])
+    assert re.search(r"declare (dso_local )?i32 @printf", env.observation["Ir"])
+
+
+def test_make_benchmark_invalid_clang_job():
+    with pytest.raises(OSError) as ctx:
+        llvm.make_benchmark(llvm.ClangInvocation(["-invalid-arg"]))
+
+    assert "Compilation job failed with returncode" in str(ctx.value)
+    assert "-invalid-arg" in str(ctx.value)
+
+
+def test_custom_benchmark_is_added_on_service_restart(env: LlvmEnv):
+    # When the service is restarted, the environment must send a custom
+    # benchmark to it again.
+    with tempfile.TemporaryDirectory() as d:
+        source = Path(d) / "a.c"
+        with open(str(source), "w") as f:
+            f.write("int main() { return 0; }")
+
+        benchmark = llvm.make_benchmark(source)
+
+    env.reset(benchmark=benchmark)
+    assert env.benchmark == benchmark.uri
+
+    # Kill the service so that the next call to reset() starts a new one.
+    env.service.close()
+    env.service = None
+
+    env.reset()
+    assert env.benchmark == benchmark.uri
+
+
+def test_two_custom_benchmarks_reset(env: LlvmEnv):
+    with tempfile.TemporaryDirectory() as d:
+        source = Path(d) / "a.c"
+        with open(str(source), "w") as f:
+            f.write("int main() { return 0; }")
+
+        benchmark1 = llvm.make_benchmark(source)
+        benchmark2 = llvm.make_benchmark(source)
+
+    assert benchmark1.uri != benchmark2.uri
+
+    env.reset(benchmark=benchmark1)
+    assert env.benchmark == benchmark1.uri
+    env.reset()
+    assert env.benchmark == benchmark1.uri
+    env.benchmark = benchmark2
+    # assert env.benchmark == benchmark1.uri
+    env.reset()
+    assert env.benchmark == benchmark2.uri
+
+
+def test_get_system_includes_nonzero_exit_status():
+    """Test that setting the $CXX to an invalid binary raises an error."""
+    old_cxx = os.environ.get("CXX")
+    os.environ["CXX"] = "false"
+    try:
+        with pytest.raises(OSError) as ctx:
+            list(llvm.benchmarks._get_system_includes())
+        assert "Failed to invoke false" in str(ctx.value)
+    finally:
+        if old_cxx:
+            os.environ["CXX"] = old_cxx
+
+
+def test_get_system_includes_output_parse_failure():
+    """Test that setting the $CXX to an invalid binary raises an error."""
+    old_cxx = os.environ.get("CXX")
+    os.environ["CXX"] = "echo"
+    try:
+        with pytest.raises(OSError) as ctx:
+            list(llvm.benchmarks._get_system_includes())
+        assert "Failed to parse '#include <...>' search paths from echo" in str(
+            ctx.value
+        )
+    finally:
+        if old_cxx:
+            os.environ["CXX"] = old_cxx
 
 
 if __name__ == "__main__":

--- a/tests/envs/llvm/llvm_env_test.py
+++ b/tests/envs/llvm/llvm_env_test.py
@@ -3,20 +3,13 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 """Integrations tests for the LLVM CompilerGym environments."""
-import os
-import sys
-from typing import Any, Dict, List
+from typing import List
 
-import networkx as nx
-import numpy as np
 import pytest
-from gym.spaces import Box
-from gym.spaces import Dict as DictSpace
 
 import compiler_gym
 from compiler_gym.envs import CompilerEnv
 from compiler_gym.envs.llvm.llvm_env import LlvmEnv
-from compiler_gym.spaces import Sequence
 from tests.test_main import main
 
 pytest_plugins = ["tests.envs.llvm.fixtures"]
@@ -128,6 +121,23 @@ def test_unset_forced_benchmark(env: CompilerEnv):
         pytest.fail(
             "Improbably selected the same benchmark 50 times! " "Expected random."
         )
+
+
+def test_change_benchmark_mid_episode(env: LlvmEnv):
+    """Test that changing the benchmark while in an episode has no effect until
+    the next call to reset()."""
+    env.reset(benchmark="benchmark://cBench-v0/crc32")
+    assert env.benchmark == "benchmark://cBench-v0/crc32"
+    env.benchmark = "benchmark://cBench-v0/dijkstra"
+    assert env.benchmark == "benchmark://cBench-v0/crc32"
+    env.reset()
+    assert env.benchmark == "benchmark://cBench-v0/dijkstra"
+
+
+def test_set_benchmark_invalid_type(env: LlvmEnv):
+    with pytest.raises(TypeError) as ctx:
+        env.benchmark = 10
+    assert str(ctx.value) == "Unsupported benchmark type: int"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This makes it much simpler to compile and use user-provided programs as benchmarks:

```
env = gym.make("llvm-v0")
benchmark = env.make_benchmark('my_app.c')
env.reset(benchmark=benchmark)
```