### PR TITLE
Add version number to python modules

### DIFF
--- a/compiler_gym/__init__.py
+++ b/compiler_gym/__init__.py
@@ -18,6 +18,8 @@ is available through :code:`compiler_gym.COMPILER_GYM_ENVS`:
     >>> compiler_gym.COMPILER_GYM_ENVS
     ['llvm-v0', 'llvm-ic-v0', 'llvm-autophase-ic-v0', 'llvm-ir-ic-v0']
 """
+from compiler_gym.util.version import __version__  # isort:skip
+
 from compiler_gym.envs import COMPILER_GYM_ENVS, CompilerEnv, observation_t, step_t
 from compiler_gym.random_search import random_search
 from compiler_gym.util.download import download

--- a/compiler_gym/envs/llvm/service/BUILD
+++ b/compiler_gym/envs/llvm/service/BUILD
@@ -131,7 +131,9 @@ cc_library(
         ":RewardSpaces",
         "//compiler_gym/service/proto:compiler_gym_service_cc",
         "//compiler_gym/util:GrpcStatusMacros",
+        "//compiler_gym/util:Version",
         "@boost//:filesystem",
+        "@llvm//10.0.0",
     ],
 )
 

--- a/compiler_gym/envs/llvm/service/LlvmService.cc
+++ b/compiler_gym/envs/llvm/service/LlvmService.cc
@@ -14,6 +14,8 @@
 #include "compiler_gym/service/proto/compiler_gym_service.pb.h"
 #include "compiler_gym/util/EnumUtil.h"
 #include "compiler_gym/util/GrpcStatusMacros.h"
+#include "compiler_gym/util/Version.h"
+#include "llvm/Config/llvm-config.h"
 
 namespace compiler_gym::llvm_service {
 
@@ -24,6 +26,14 @@ namespace fs = boost::filesystem;
 
 LlvmService::LlvmService(const fs::path& workingDirectory)
     : workingDirectory_(workingDirectory), benchmarkFactory_(workingDirectory), nextSessionId_(0) {}
+
+Status LlvmService::GetVersion(ServerContext* /* unused */, const GetVersionRequest* /* unused */,
+                               GetVersionReply* reply) {
+  VLOG(2) << "GetSpaces()";
+  reply->set_service_version(COMPILER_GYM_VERSION);
+  reply->set_compiler_version(LLVM_VERSION_STRING);
+  return Status::OK;
+}
 
 Status LlvmService::GetSpaces(ServerContext* /* unused */, const GetSpacesRequest* /* unused */,
                               GetSpacesReply* reply) {

--- a/compiler_gym/envs/llvm/service/LlvmService.h
+++ b/compiler_gym/envs/llvm/service/LlvmService.h
@@ -23,6 +23,8 @@ class LlvmService final : public CompilerGymService::Service {
   explicit LlvmService(const boost::filesystem::path& workingDirectory);
 
   // RPC endpoints.
+  grpc::Status GetVersion(grpc::ServerContext* context, const GetVersionRequest* request,
+                          GetVersionReply* reply) final override;
 
   grpc::Status GetSpaces(grpc::ServerContext* context, const GetSpacesRequest* request,
                          GetSpacesReply* reply) final override;

--- a/compiler_gym/service/proto/__init__.py
+++ b/compiler_gym/service/proto/__init__.py
@@ -13,6 +13,8 @@ from compiler_gym.service.proto.compiler_gym_service_pb2 import (
     GetBenchmarksRequest,
     GetSpacesReply,
     GetSpacesRequest,
+    GetVersionReply,
+    GetVersionRequest,
     Int64List,
     Observation,
     ObservationRequest,
@@ -64,4 +66,6 @@ __all__ = [
     "ServiceIsClosed",
     "ServiceTransportError",
     "CompilerGymServiceConnection",
+    "GetVersionRequest",
+    "GetVersionReply",
 ]

--- a/compiler_gym/service/proto/compiler_gym_service.proto
+++ b/compiler_gym/service/proto/compiler_gym_service.proto
@@ -15,6 +15,7 @@ option java_outer_classname = "CompilerGymServiceProto";
 option java_package = "com.compiler_gym";
 
 service CompilerGymService {
+  rpc GetVersion(GetVersionRequest) returns (GetVersionReply);
   // Start a CompilerGym service episode. Must be called after Init().
   rpc StartEpisode(StartEpisodeRequest) returns (StartEpisodeReply);
   // Make an optimization decision. The set of valid actions is the last
@@ -37,6 +38,18 @@ service CompilerGymService {
   rpc GetBenchmarks(GetBenchmarksRequest) returns (GetBenchmarksReply);
   // Register a new benchmark.
   rpc AddBenchmark(AddBenchmarkRequest) returns (AddBenchmarkReply);
+}
+
+// ===========================================================================
+// GetVersion().
+
+message GetVersionRequest {}
+
+message GetVersionReply {
+  // The version string for this service.
+  string service_version = 1;
+  // The version string for the underlying compiler.
+  string compiler_version = 2;
 }
 
 // ===========================================================================

--- a/compiler_gym/util/BUILD
+++ b/compiler_gym/util/BUILD
@@ -17,6 +17,7 @@ py_library(
         "tabulate.py",
         "timer.py",
         "user_input.py",
+        "version.py",
     ],
     visibility = ["//visibility:public"],
     deps = [
@@ -81,4 +82,11 @@ cc_library(
     name = "StrLenConstexpr",
     hdrs = ["StrLenConstexpr.h"],
     visibility = ["//visibility:public"],
+)
+
+genrule(
+    name = "make_version",
+    srcs = ["//:VERSION"],
+    outs = ["version.py"],
+    cmd = "echo \"__version__ = \\\"$$(cat $<)\\\"\" > $@",
 )

--- a/compiler_gym/util/BUILD
+++ b/compiler_gym/util/BUILD
@@ -90,3 +90,16 @@ genrule(
     outs = ["version.py"],
     cmd = "echo \"__version__ = \\\"$$(cat $<)\\\"\" > $@",
 )
+
+cc_library(
+    name = "Version",
+    hdrs = ["Version.h"],
+    visibility = ["//visibility:public"],
+)
+
+genrule(
+    name = "make_version_header",
+    srcs = ["//:VERSION"],
+    outs = ["Version.h"],
+    cmd = "echo \"#define COMPILER_GYM_VERSION \\\"$$(cat $<)\\\"\" > $@",
+)

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -45,7 +45,7 @@ explore the optimization space.
 What features are going to be added in the future?
 --------------------------------------------------
 
-See :doc:`roadmap`.
+See :ref:`roadmap <about:roadmap>`.
 
 
 How do I run this on my own program?

--- a/examples/example_compiler_gym_service/BUILD
+++ b/examples/example_compiler_gym_service/BUILD
@@ -19,8 +19,7 @@ py_test(
     srcs = ["env_tests.py"],
     deps = [
         ":example_compiler_gym_service",
-        "//compiler_gym/envs",
-        "//compiler_gym/spaces",
+        "//compiler_gym",
         "//tests:test_main",
     ],
 )

--- a/examples/example_compiler_gym_service/env_tests.py
+++ b/examples/example_compiler_gym_service/env_tests.py
@@ -8,6 +8,7 @@ import numpy as np
 import pytest
 from gym.spaces import Box
 
+import compiler_gym
 import examples.example_compiler_gym_service  # Register environments.
 from compiler_gym.envs import CompilerEnv
 from compiler_gym.spaces import NamedDiscrete, Sequence
@@ -21,6 +22,11 @@ def env() -> CompilerEnv:
         yield env
     finally:
         env.close()
+
+
+def test_versions(env: CompilerEnv):
+    assert env.version == compiler_gym.__version__
+    assert env.compiler_version == "1.0.0"
 
 
 def test_action_space(env: CompilerEnv):

--- a/examples/example_compiler_gym_service/service/BUILD
+++ b/examples/example_compiler_gym_service/service/BUILD
@@ -21,6 +21,7 @@ cc_library(
         "//compiler_gym/service/proto:compiler_gym_service_cc",
         "//compiler_gym/service/proto:compiler_gym_service_cc_grpc",
         "//compiler_gym/util:GrpcStatusMacros",
+        "//compiler_gym/util:Version",
         "@boost//:filesystem",
         "@com_github_grpc_grpc//:grpc++",
     ],

--- a/examples/example_compiler_gym_service/service/ExampleService.cc
+++ b/examples/example_compiler_gym_service/service/ExampleService.cc
@@ -9,6 +9,7 @@
 
 #include "compiler_gym/service/proto/compiler_gym_service.pb.h"
 #include "compiler_gym/util/GrpcStatusMacros.h"
+#include "compiler_gym/util/Version.h"
 
 namespace compiler_gym::example_service {
 
@@ -53,6 +54,13 @@ ExampleService::ExampleService(const fs::path& workingDirectory)
   codesize.set_name("codesize");
   codesize.mutable_range()->mutable_max()->set_value(0);
   rewardSpaces_.push_back(codesize);
+}
+
+Status ExampleService::GetVersion(ServerContext* /* unused */,
+                                  const GetVersionRequest* /* unused */, GetVersionReply* reply) {
+  reply->set_service_version(COMPILER_GYM_VERSION);
+  reply->set_compiler_version("1.0.0");
+  return Status::OK;
 }
 
 Status ExampleService::GetSpaces(ServerContext* /* unused*/, const GetSpacesRequest* /* unused */,

--- a/examples/example_compiler_gym_service/service/ExampleService.h
+++ b/examples/example_compiler_gym_service/service/ExampleService.h
@@ -20,6 +20,8 @@ class ExampleService final : public CompilerGymService::Service {
   explicit ExampleService(const boost::filesystem::path& workingDirectory);
 
   // RPC endpoints.
+  grpc::Status GetVersion(grpc::ServerContext* context, const GetVersionRequest* request,
+                          GetVersionReply* reply) final override;
 
   grpc::Status GetSpaces(grpc::ServerContext* context, const GetSpacesRequest* request,
                          GetSpacesReply* reply) final override;

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -50,3 +50,12 @@ cc_library(
         "@gtest",
     ],
 )
+
+py_test(
+    name = "version_test",
+    srcs = ["version_test.py"],
+    deps = [
+        ":test_main",
+        "//compiler_gym",
+    ],
+)

--- a/tests/envs/llvm/BUILD
+++ b/tests/envs/llvm/BUILD
@@ -111,8 +111,7 @@ py_test(
     srcs = ["llvm_env_test.py"],
     deps = [
         ":fixtures",
-        "//compiler_gym/envs",
-        "//compiler_gym/spaces",
+        "//compiler_gym",
         "//tests:test_main",
     ],
 )

--- a/tests/envs/llvm/llvm_env_test.py
+++ b/tests/envs/llvm/llvm_env_test.py
@@ -13,12 +13,21 @@ import pytest
 from gym.spaces import Box
 from gym.spaces import Dict as DictSpace
 
+import compiler_gym
 from compiler_gym.envs import CompilerEnv
 from compiler_gym.envs.llvm.llvm_env import LlvmEnv
 from compiler_gym.spaces import Sequence
 from tests.test_main import main
 
 pytest_plugins = ["tests.envs.llvm.fixtures"]
+
+
+def test_service_version(env: LlvmEnv):
+    assert env.version == compiler_gym.__version__
+
+
+def test_compiler_version(env: LlvmEnv):
+    assert env.compiler_version.startswith("10.0.0")
 
 
 def test_action_space_names(env: CompilerEnv, action_names: List[str]):

--- a/tests/version_test.py
+++ b/tests/version_test.py
@@ -1,0 +1,37 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+import os
+
+import pkg_resources
+import pytest
+
+import compiler_gym
+from packaging import version
+from tests.test_main import main
+
+# Marker to skip a test if running under bazel.
+# This uses $TEST_WORKSPACE, set by the bazel test runner.
+# See: https://docs.bazel.build/versions/master/test-encyclopedia.html#initial-conditions
+install_test = pytest.mark.skipif(
+    bool(os.environ.get("TEST_WORKSPACE")), reason="Install test"
+)
+
+
+def test_version_dunder():
+    assert isinstance(compiler_gym.__version__, str)
+
+
+def test_version_dunder_format():
+    version.parse(compiler_gym.__version__)
+
+
+@install_test
+def test_setuptools_version():
+    version = pkg_resources.require("compiler_gym")[0].version
+    assert version == compiler_gym.__version__
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
* Adds `compiler_gym.__version__`.
* Adds a `GetVersion()` RPC endpoint to the service schema.
* Adds `CompilerEnv.version` which is reports the service version.
* Adds `CompilerEnv.compiler_version` which reports the compiler version, as reported by the service.