### PR TITLE
Prevent github actions running twice on PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,6 +3,9 @@ name: CI
 
 on:
     push:
+        branches:
+            - development
+            - stable
     pull_request:
     schedule:
         - cron: 0 0 * * 0 # weekly

--- a/.github/workflows/pre_commit.yaml
+++ b/.github/workflows/pre_commit.yaml
@@ -1,7 +1,12 @@
 ---
 name: Pre-commit
 
-on: [push, pull_request]
+on:
+    push:
+        branches:
+            - development
+    pull_request:
+
 
 jobs:
     all:

--- a/.github/workflows/release_test.yaml
+++ b/.github/workflows/release_test.yaml
@@ -1,0 +1,32 @@
+---
+name: Release Test
+
+on:
+    schedule:
+        - cron: 0 0 * * 0 # weekly
+
+jobs:
+    release_package_test:
+        runs-on: ${{ matrix.os }}
+
+        strategy:
+            fail-fast: false
+            matrix:
+                os: [ubuntu-latest, macos-latest]
+                python: [3.8]
+
+        steps:
+            - uses: actions/checkout@v2
+              with:
+                  ref: stable
+
+            - name: Set up Python ${{ matrix.python }}
+              uses: actions/setup-python@v2
+              with:
+                  python-version: ${{ matrix.python }}
+
+            - name: Install python wheel
+              run: python -m pip install compiler_gym
+
+            - name: Test
+              run: make pytest


### PR DESCRIPTION
At the moment, opening or updating a pull request causes the
workflow actions to be triggered twice: once because it is a push, the
second time because it is a PR.
