### PR TITLE
Add a script for validating LLVM results

### DIFF
--- a/compiler_gym/BUILD
+++ b/compiler_gym/BUILD
@@ -12,6 +12,7 @@ py_library(
     visibility = ["//visibility:public"],
     deps = [
         ":random_search",
+        ":validate",
         "//compiler_gym/envs",
         "//compiler_gym/util",
     ],
@@ -35,6 +36,18 @@ py_library(
     deps = [
         ":random_replay",
         "//compiler_gym/envs",
+        "//compiler_gym/util",
+    ],
+)
+
+py_library(
+    name = "validate",
+    srcs = ["validate.py"],
+    visibility = ["//compiler_gym:__subpackages__"],
+    deps = [
+        "//compiler_gym/envs:compiler_env",
+        "//compiler_gym/envs/llvm",
+        "//compiler_gym/spaces",
         "//compiler_gym/util",
     ],
 )

--- a/compiler_gym/__init__.py
+++ b/compiler_gym/__init__.py
@@ -24,8 +24,11 @@ from compiler_gym.envs import COMPILER_GYM_ENVS, CompilerEnv, observation_t, ste
 from compiler_gym.random_search import random_search
 from compiler_gym.util.download import download
 from compiler_gym.util.runfiles_path import cache_path, site_data_path
+from compiler_gym.validate import ValidationResult, validate_state, validate_states
 
+# The top-level compiler_gym API.
 __all__ = [
+    "__version__",
     "download",
     "cache_path",
     "site_data_path",
@@ -34,4 +37,7 @@ __all__ = [
     "observation_t",
     "step_t",
     "random_search",
+    "ValidationResult",
+    "validate_state",
+    "validate_states",
 ]

--- a/compiler_gym/bin/BUILD
+++ b/compiler_gym/bin/BUILD
@@ -12,6 +12,7 @@ py_library(
         ":random_replay",
         ":random_search",
         ":service",
+        ":validate",
     ],
 )
 
@@ -60,6 +61,7 @@ py_binary(
         "//compiler_gym/util/flags:benchmark_from_flags",
         "//compiler_gym/util/flags:env_from_flags",
         "//compiler_gym/util/flags:ls_benchmark",
+        "//compiler_gym/util/flags:nproc",
         "//compiler_gym/util/flags:output_dir",
     ],
 )
@@ -85,5 +87,18 @@ py_binary(
         "//compiler_gym/spaces",
         "//compiler_gym/util",
         "//compiler_gym/util/flags:env_from_flags",
+    ],
+)
+
+py_binary(
+    name = "validate",
+    srcs = ["validate.py"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//compiler_gym:validate",
+        "//compiler_gym/util",
+        "//compiler_gym/util/flags:dataset",
+        "//compiler_gym/util/flags:env_from_flags",
+        "//compiler_gym/util/flags:nproc",
     ],
 )

--- a/compiler_gym/bin/random_search.py
+++ b/compiler_gym/bin/random_search.py
@@ -119,7 +119,7 @@ def main(argv):
     finally:
         env.close()
 
-    best_reward = random_search(
+    best_reward, _ = random_search(
         make_env=make_env,
         outdir=Path(FLAGS.output_dir) if FLAGS.output_dir else None,
         patience=FLAGS.patience,

--- a/compiler_gym/bin/random_search.py
+++ b/compiler_gym/bin/random_search.py
@@ -54,12 +54,12 @@ to the number of processors on the host machine. Set a different value using
 :code:`--nproc`.
 """
 import sys
-from multiprocessing import cpu_count
 from pathlib import Path
 
 from absl import app, flags
 
 import compiler_gym.util.flags.ls_benchmark  # Flag definition.
+import compiler_gym.util.flags.nproc  # Flag definition.
 import compiler_gym.util.flags.output_dir  # Flag definition.
 from compiler_gym.random_search import random_search
 from compiler_gym.util.flags.benchmark_from_flags import benchmark_from_flags
@@ -73,9 +73,6 @@ flags.DEFINE_integer(
     "If 0, use the size of the action space for the patience value.",
 )
 flags.DEFINE_float("runtime", None, "If set, limit the search to this many seconds.")
-flags.DEFINE_integer(
-    "nproc", cpu_count(), "The number of parallel search processes to run."
-)
 flags.DEFINE_boolean(
     "skip_done",
     False,

--- a/compiler_gym/bin/validate.py
+++ b/compiler_gym/bin/validate.py
@@ -1,0 +1,101 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Validate environment states.
+
+Example usage:
+
+.. code-block::
+
+    $ cat << EOF |
+    benchmark,reward,walltime,commandline
+    cBench-v0/crc32,0,1.2,opt  input.bc -o output.bc
+    EOF
+    python -m compiler_gym.bin.validate < results.csv --env=llvm-v0 --reward=IrInstructionCount
+
+Use this script to validate environment states. Environment states are read from
+stdin as a comma-separated list of benchmark names, walltimes, episode rewards,
+and commandlines. Each state is validated by replaying the commandline and
+validating that the reward matches the expected value. Further, some benchmarks
+allow for validation of program semantics. When available, those additional
+checks will be automatically run.
+
+Input Format
+------------
+
+The correct format for generating input states can be generated using
+:func:`env.state.to_csv() <compiler_gym.envs.CompilerEnvState.to_csv>`. The
+input CSV must start with a header row. A valid header row can be generated
+using
+:func:`env.state.csv_header() <compiler_gym.envs.CompilerEnvState.csv_header>`.
+
+Full example:
+
+>>> env = gym.make("llvm-v0")
+>>> env.reset()
+>>> env.step(0)
+>>> print(env.state.csv_header())
+benchmark,reward,walltime,commandline
+>>> print(env.state.to_csv())
+benchmark://cBench-v0/rijndael,,20.53565216064453,opt -add-discriminators input.bc -o output.bc
+%
+
+Output Format
+-------------
+
+This script prints one line per input state. The order of input states is not
+preserved. A successfully validated state has the format:
+
+.. code-block::
+
+    ✅  <benchmark_name>  <reproduced_reward>
+
+Else if validation fails, the output is:
+
+.. code-block::
+
+    ❌  <benchmark_name>  <error_details>
+"""
+import csv
+import sys
+
+from absl import app, flags
+
+import compiler_gym.util.flags.dataset  # Flag definition.
+import compiler_gym.util.flags.nproc  # Flag definition.
+from compiler_gym.envs.compiler_env import CompilerEnvState
+from compiler_gym.util.flags.env_from_flags import env_from_flags
+from compiler_gym.validate import validate_states
+
+FLAGS = flags.FLAGS
+
+
+def main(argv):
+    """Main entry point."""
+    assert len(argv) == 1, f"Unrecognized flags: {argv[1:]}"
+
+    data = sys.stdin.readlines()
+    states = []
+    for line in csv.DictReader(data):
+        try:
+            line["reward"] = float(line["reward"])
+            states.append(CompilerEnvState(**line))
+        except (TypeError, KeyError) as e:
+            print(f"Failed to parse input: `{e}`", file=sys.stderr)
+            sys.exit(1)
+
+    error_count = 0
+    for result in validate_states(
+        env_from_flags, states, datasets=FLAGS.dataset, nproc=FLAGS.nproc
+    ):
+        print(result)
+        if result.failed:
+            error_count += 1
+
+    if error_count:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    app.run(main)

--- a/compiler_gym/envs/BUILD
+++ b/compiler_gym/envs/BUILD
@@ -16,9 +16,9 @@ py_library(
 py_library(
     name = "compiler_env",
     srcs = ["compiler_env.py"],
-    visibility = ["//compiler_gym/envs:__subpackages__"],
+    visibility = ["//compiler_gym:__subpackages__"],
     deps = [
-        "//compiler_gym/datasets",
+        "//compiler_gym/datasets:dataset",
         "//compiler_gym/service",
         "//compiler_gym/service/proto",
         "//compiler_gym/spaces",

--- a/compiler_gym/envs/__init__.py
+++ b/compiler_gym/envs/__init__.py
@@ -2,12 +2,19 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-from compiler_gym.envs.compiler_env import CompilerEnv, info_t, observation_t, step_t
+from compiler_gym.envs.compiler_env import (
+    CompilerEnv,
+    CompilerEnvState,
+    info_t,
+    observation_t,
+    step_t,
+)
 from compiler_gym.envs.llvm.llvm_env import LlvmEnv
 from compiler_gym.util.registration import COMPILER_GYM_ENVS
 
 __all__ = [
     "CompilerEnv",
+    "CompilerEnvState",
     "LlvmEnv",
     "observation_t",
     "info_t",

--- a/compiler_gym/envs/compiler_env.py
+++ b/compiler_gym/envs/compiler_env.py
@@ -16,7 +16,7 @@ import gym
 import numpy as np
 from gym.spaces import Space
 
-from compiler_gym.datasets import Dataset, require
+from compiler_gym.datasets.dataset import Dataset, require
 from compiler_gym.service import (
     CompilerGymServiceConnection,
     ConnectionOpts,

--- a/compiler_gym/envs/compiler_env.py
+++ b/compiler_gym/envs/compiler_env.py
@@ -3,10 +3,13 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 """This module defines the OpenAI gym interface for compilers."""
+import csv
 import os
 import warnings
+from io import StringIO
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Union
+from time import time
+from typing import Any, Dict, Iterable, List, NamedTuple, Optional, Tuple, Union
 
 import fasteners
 import gym
@@ -42,6 +45,81 @@ from compiler_gym.views import (
 # Type hints.
 info_t = Dict[str, Any]
 step_t = Tuple[Optional[observation_t], Optional[float], bool, info_t]
+
+
+def _to_csv(*columns) -> str:
+    buf = StringIO()
+    writer = csv.writer(buf)
+    writer.writerow(columns)
+    return buf.getvalue().rstrip()
+
+
+class CompilerEnvState(NamedTuple):
+    """The representation of a compiler environment state.
+
+    The state of an environment is defined as a benchmark and a sequence of
+    actions that has been applied to it. For a given environment, the state
+    contains the information required to reproduce the result.
+    """
+
+    benchmark: str
+    """The name of the benchmark used for this episode."""
+
+    commandline: str
+    """The list of actions that produced this state, as a commandline."""
+
+    walltime: float
+    """The walltime of the episode."""
+
+    reward: Optional[float] = None
+    """The cumulative reward for this episode."""
+
+    @staticmethod
+    def csv_header() -> str:
+        """Return the header string for the CSV-format.
+
+        :return: A comma-separated string.
+        """
+        return _to_csv("benchmark", "reward", "walltime", "commandline")
+
+    def to_csv(self) -> str:
+        """Serialize a state to a comma separated list of values.
+
+        :return: A comma-separated string.
+        """
+        return _to_csv(self.benchmark, self.reward, self.walltime, self.commandline)
+
+    @classmethod
+    def from_csv(cls, csv_string: str) -> "CompilerEnvState":
+        """Construct a state from a comma separated list of values."""
+        reader = csv.reader(StringIO(csv_string))
+        for line in reader:
+            try:
+                benchmark, reward, walltime, commandline = line
+                break
+            except ValueError as e:
+                raise ValueError(f"Failed to parse input: `{csv_string}`: {e}") from e
+        else:
+            raise ValueError(f"Failed to parse input: `{csv_string}`")
+        return cls(
+            benchmark=benchmark,
+            reward=None if reward == "" else float(reward),
+            walltime=float(walltime),
+            commandline=commandline,
+        )
+
+    def __eq__(self, rhs) -> bool:
+        if not isinstance(rhs, CompilerEnvState):
+            return False
+        epsilon = 1e-5
+        # Note that walltime is excluded from equivalence checks as two states
+        # are equivalent if they define the same point in the optimization space
+        # irrespective of how long it took to get there.
+        return (
+            self.benchmark == rhs.benchmark
+            and abs(self.reward - rhs.reward) < epsilon
+            and self.commandline == rhs.commandline
+        )
 
 
 class CompilerEnv(gym.Env):
@@ -194,6 +272,7 @@ class CompilerEnv(gym.Env):
         self.observation_space: Optional[Space] = None
         self.reward_range: Tuple[float, float] = (-np.inf, np.inf)
         self.episode_reward: Optional[float] = None
+        self.episode_start_time: float = time()
 
         # Initialize eager observation/reward and benchmark.
         self.observation_space = observation_space
@@ -225,6 +304,20 @@ class CompilerEnv(gym.Env):
         :return: A string commandline invocation.
         """
         return ""
+
+    @property
+    def episode_walltime(self) -> float:
+        return time() - self.episode_start_time
+
+    @property
+    def state(self) -> CompilerEnvState:
+        """The tuple representation of the current environment state."""
+        return CompilerEnvState(
+            benchmark=self.benchmark,
+            reward=self.episode_reward,
+            walltime=self.episode_walltime,
+            commandline=self.commandline(),
+        )
 
     @property
     def inactive_datasets_site_path(self) -> Optional[Path]:
@@ -503,6 +596,7 @@ class CompilerEnv(gym.Env):
         self._session_id = reply.session_id
         self.observation.session_id = reply.session_id
         self.reward.session_id = reply.session_id
+        self.episode_start_time = time()
 
         # If the action space has changed, update it.
         if reply.HasField("new_action_space"):

--- a/compiler_gym/envs/compiler_env.py
+++ b/compiler_gym/envs/compiler_env.py
@@ -436,6 +436,7 @@ class CompilerEnv(gym.Env):
             it overrides any value that set during :func:`__init__`, and
             subsequent calls to :code:`reset()` will use this action space.
             If no aciton space is provided, the default action space is used.
+        :return: The initial observation.
         """
         if retry_count > self.connection_settings.init_max_attempts:
             raise OSError(f"Failed to reset environment after {retry_count} attempts")

--- a/compiler_gym/envs/llvm/BUILD
+++ b/compiler_gym/envs/llvm/BUILD
@@ -9,7 +9,7 @@ py_library(
     data = [
         "//compiler_gym/envs/llvm/service",
     ],
-    visibility = ["//compiler_gym/envs:__pkg__"],
+    visibility = ["//compiler_gym:__subpackages__"],
     deps = [
         ":benchmarks",
         ":llvm_env",
@@ -34,7 +34,7 @@ py_library(
     name = "datasets",
     srcs = ["datasets.py"],
     deps = [
-        "//compiler_gym/datasets",
+        "//compiler_gym/datasets:dataset",
     ],
 )
 

--- a/compiler_gym/envs/llvm/datasets.py
+++ b/compiler_gym/envs/llvm/datasets.py
@@ -3,7 +3,9 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 """This module defines the available LLVM datasets."""
-from compiler_gym.datasets import Dataset
+from typing import Callable, Dict, Optional
+
+from compiler_gym.datasets.dataset import Dataset
 
 LLVM_DATASETS = [
     Dataset(
@@ -107,3 +109,13 @@ LLVM_DATASETS = [
         sha256="f77dd1988c772e8359e1303cc9aba0d73d5eb27e0c98415ac3348076ab94efd1",
     ),
 ]
+
+# A map from benchmark name to a callback which takes as input an LlvmEnv
+# instance and returns None if the environment is valid, else a string error
+# message.
+#
+# TODO(cummins): Populate this map for cBench using the CK meta properties.
+# See: https://github.com/ctuning/ai/blob/main/program/cbench-bzip2/.cm/meta.json
+LLVM_BENCHMARK_VALIDATION_CALLBACKS: Dict[
+    str, Callable[["LlvmEnv"], Optional[str]]
+] = {}

--- a/compiler_gym/random_search.py
+++ b/compiler_gym/random_search.py
@@ -8,7 +8,7 @@ from multiprocessing import cpu_count
 from pathlib import Path
 from threading import Thread
 from time import sleep, time
-from typing import Callable, List, Optional, Union
+from typing import Callable, List, Optional, Tuple, Union
 
 import humanize
 
@@ -103,7 +103,7 @@ def random_search(
     patience: int = 0,
     nproc: int = cpu_count(),
     skip_done: bool = False,
-) -> float:
+) -> Tuple[float, List[int]]:
     env = make_env()
     env.reset()
     if not isinstance(env, CompilerEnv):
@@ -250,4 +250,4 @@ def random_search(
     replay_actions(env, best_action_names, outdir)
     env.close()
 
-    return best_returns
+    return best_returns, best_actions

--- a/compiler_gym/spaces/commandline.py
+++ b/compiler_gym/spaces/commandline.py
@@ -2,7 +2,7 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-from typing import Iterable, NamedTuple, Optional, Union
+from typing import Iterable, List, NamedTuple, Optional, Union
 
 from compiler_gym.spaces.named_discrete import NamedDiscrete
 
@@ -73,3 +73,21 @@ class Commandline(NamedDiscrete):
             return self.flags[values]
         else:
             return " ".join([self.flags[v] for v in values])
+
+    def from_commandline(self, commandline: str) -> List[int]:
+        """Produce a sequence of actions from a commandline.
+
+        :param commandline: A string commandline invocation, as produced by
+            :func:`commandline() <compiler_gym.spaces.commandline.Commandline.commandline>`.
+        :return: A list of action values.
+        :raises LookupError: If any of the flags in the commandline are not
+            recognized.
+        """
+        flags = commandline.split()
+        values = []
+        for flag in flags:
+            try:
+                values.append(self.flags.index(flag))
+            except IndexError:
+                raise LookupError(f"Unknown flag: `{flag}`")
+        return values

--- a/compiler_gym/util/flags/BUILD
+++ b/compiler_gym/util/flags/BUILD
@@ -13,6 +13,12 @@ py_library(
 )
 
 py_library(
+    name = "dataset",
+    srcs = ["dataset.py"],
+    visibility = ["//visibility:public"],
+)
+
+py_library(
     name = "env_from_flags",
     srcs = ["env_from_flags.py"],
     visibility = ["//visibility:public"],
@@ -26,6 +32,12 @@ py_library(
 py_library(
     name = "ls_benchmark",
     srcs = ["ls_benchmark.py"],
+    visibility = ["//visibility:public"],
+)
+
+py_library(
+    name = "nproc",
+    srcs = ["nproc.py"],
     visibility = ["//visibility:public"],
 )
 

--- a/compiler_gym/util/flags/README.md
+++ b/compiler_gym/util/flags/README.md
@@ -1,5 +1,9 @@
 # Common flag definitions for command line usage
 
-This directory contains modules that define command line flags for use in
-scripts. These modules should not be used by the core library as they may
-interfere with user code.
+This directory contains modules that define command line flags for use by
+`compiler_gym.bin` and other scripts. The reason for defining flags here is to
+allow flag names to be re-used across scripts without causing
+multiple-definition errors when the scripts are imported.
+
+Using these flags requires that the absl flags library is initialized. As such
+they should not be used in the core library.

--- a/compiler_gym/util/flags/dataset.py
+++ b/compiler_gym/util/flags/dataset.py
@@ -1,0 +1,11 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+from absl import flags
+
+flags.DEFINE_list(
+    "dataset",
+    [],
+    "A list of datasets that are required.",
+)

--- a/compiler_gym/util/flags/nproc.py
+++ b/compiler_gym/util/flags/nproc.py
@@ -1,0 +1,9 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+from multiprocessing import cpu_count
+
+from absl import flags
+
+flags.DEFINE_integer("nproc", cpu_count(), "The number of parallel processes to run.")

--- a/compiler_gym/validate.py
+++ b/compiler_gym/validate.py
@@ -1,0 +1,191 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Validate environment states."""
+import math
+import multiprocessing
+import multiprocessing.pool
+from typing import Callable, Iterable, List, NamedTuple, Optional, cast
+
+import gym
+
+from compiler_gym.envs.compiler_env import CompilerEnv, CompilerEnvState
+from compiler_gym.envs.llvm import LlvmEnv
+from compiler_gym.envs.llvm.datasets import LLVM_BENCHMARK_VALIDATION_CALLBACKS
+from compiler_gym.spaces import Commandline
+from compiler_gym.util.timer import Timer
+
+
+class ValidationResult(NamedTuple):
+    """The result of validating a compiler state."""
+
+    state: CompilerEnvState
+    """The compiler environment state that was validated."""
+
+    reward_validated: bool
+    """Whether the reward that was recorded in the original state was validated."""
+
+    actions_replay_failed: bool
+    """Whether the commandline was unable to be reproduced."""
+
+    reward_validation_failed: bool
+    """Whether the validated reward differed from the original state."""
+
+    benchmark_semantics_validated: bool
+    """Whether the semantics of the benchmark were validated."""
+
+    benchmark_semantics_validation_failed: bool
+    """Whether the semantics of the benchmark were found to have changed."""
+
+    walltime: float
+    """The wall time in seconds that the validation took."""
+
+    error_details: str = ""
+    """A description of any validation errors."""
+
+    @property
+    def success(self) -> bool:
+        """Whether validation succeeded."""
+        return not self.failed
+
+    @property
+    def failed(self) -> bool:
+        """Whether validation failed."""
+        return (
+            self.actions_replay_failed
+            or self.reward_validation_failed
+            or self.benchmark_semantics_validation_failed
+        )
+
+    def __repr__(self):
+        if self.failed:
+            return f"❌  {self.state.benchmark}  {self.error_details}"
+        elif self.state.reward is None:
+            return f"✅  {self.state.benchmark}"
+        else:
+            return f"✅  {self.state.benchmark}  {self.state.reward:.4f}"
+
+
+def _llvm_replay_commandline(env: LlvmEnv, commandline: str) -> Optional[float]:
+    """Replay the sequence of actions given by a commandline."""
+
+    # Strip the decorative elements that LlvmEnv.commandline() adds.
+    if not commandline.startswith("opt ") or not commandline.endswith(
+        " input.bc -o output.bc"
+    ):
+        raise ValueError(f"Invalid commandline: `{commandline}`")
+    commandline = commandline[len("opt ") : -len(" input.bc -o output.bc")]
+
+    actions = cast(Commandline, env.action_space).from_commandline(commandline)
+    for action in actions:
+        _, _, done, info = env.step(action)
+        if done:
+            raise OSError(
+                f"Environment terminated with error: `{info.get('error_details')}`"
+            )
+    return env.episode_reward
+
+
+def validate_state(env: CompilerEnv, state: CompilerEnvState) -> ValidationResult:
+    """Validate a :class:`CompilerEnvState <compiler_gym.envs.CompilerEnvState>`.
+
+    :param env: A compiler environment.
+    :param state: The environment state to validate.
+    :return: A :class:`ValidationResult <compiler_gym.ValidationResult>` instance.
+    """
+    error_messages = []
+    validation = {
+        "state": state,
+        "actions_replay_failed": False,
+        "reward_validated": False,
+        "reward_validation_failed": False,
+        "benchmark_semantics_validated": False,
+        "benchmark_semantics_validation_failed": False,
+    }
+
+    if state.reward is not None and env.reward_space is None:
+        raise ValueError("Reward space not specified")
+
+    with Timer() as walltime:
+        env.reset(benchmark=state.benchmark)
+        # Use a while loop here so that we can `break` early out of the
+        # validation process in case a step fails.
+        while True:
+            try:
+                reward = _llvm_replay_commandline(env, state.commandline)
+            except (ValueError, OSError) as e:
+                validation["actions_replay_failed"] = True
+                error_messages.append(str(e))
+                break
+
+            if state.reward is not None and env.reward_space.deterministic:
+                validation["reward_validated"] = True
+                # If reward deviates from the expected amount record the
+                # error but continue with the remainder of the validation.
+                if not math.isclose(reward, state.reward, rel_tol=1e-5, abs_tol=1e-10):
+                    validation["reward_validation_failed"] = True
+                    error_messages.append(
+                        f"Expected reward {state.reward:.4f} but received reward {reward:.4f}"
+                    )
+
+            validate_semantics = LLVM_BENCHMARK_VALIDATION_CALLBACKS.get(
+                state.benchmark
+            )
+            if validate_semantics:
+                validation["benchmark_semantics_validated"] = True
+                semantics_error = validate_semantics(env)
+                if semantics_error:
+                    validation["benchmark_semantics_validation_failed"] = True
+                    error_messages.append(semantics_error)
+
+            # Finished all checks, break the loop.
+            break
+
+    return ValidationResult(
+        walltime=walltime.time, error_details="\n".join(error_messages), **validation
+    )
+
+
+def _validate_states_worker(args) -> ValidationResult:
+    reward_space, state = args
+    env = gym.make("llvm-v0", reward_space=reward_space)
+    try:
+        result = validate_state(env, state)
+    finally:
+        env.close()
+    return result
+
+
+def validate_states(
+    make_env: Callable[[], CompilerEnv],
+    states: Iterable[CompilerEnvState],
+    datasets: Optional[List[str]] = None,
+    nproc: Optional[int] = None,
+) -> Iterable[ValidationResult]:
+    """A parallelized implementation of
+    :func:`validate_state() <compiler_gym.validate_state>` for batched
+    validation.
+
+    :param make_env: A callback which instantiates a compiler environment.
+    :param states: A sequence of compiler environment states to validate.
+    :param datasets: An optional list of datasets that are required.
+    :param nproc: The number of parallel worker processes to run.
+    :return: An iterator over validation results. The order of results may
+        differ from the input states.
+    """
+    env = make_env()
+    try:
+        if not isinstance(env, LlvmEnv):
+            raise ValueError("Only LLVM environment is supported for validation.")
+
+        # Ensure that the required datasets are available.
+        env.require_datasets(datasets)
+        reward_space_name: str = env.reward_space.id if env.reward_space else None
+    finally:
+        env.close()
+
+    with multiprocessing.Pool(processes=nproc) as pool:
+        yield from pool.imap_unordered(
+            _validate_states_worker, [(reward_space_name, r) for r in states]
+        )

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -32,3 +32,8 @@ compiler_gym.bin.random_replay
 ------------------------------
 
 .. automodule:: compiler_gym.bin.random_replay
+
+compiler_gym.bin.validate
+-------------------------
+
+.. automodule:: compiler_gym.bin.validate

--- a/docs/source/compiler_gym/compiler_gym.rst
+++ b/docs/source/compiler_gym/compiler_gym.rst
@@ -3,5 +3,4 @@ compiler_gym
 
 .. automodule:: compiler_gym
    :members:
-   :special-members:
    :exclude-members: CompilerEnv

--- a/docs/source/compiler_gym/envs.rst
+++ b/docs/source/compiler_gym/envs.rst
@@ -22,6 +22,13 @@ CompilerEnv
    .. automethod:: __init__
 
 
+CompilerEnvState
+----------------
+
+.. autoclass:: CompilerEnvState
+   :members:
+
+
 LlvmEnv
 -------
 

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -52,7 +52,18 @@ cc_library(
 )
 
 py_test(
+    name = "validate_test",
+    timeout = "short",
+    srcs = ["validate_test.py"],
+    deps = [
+        ":test_main",
+        "//compiler_gym",
+    ],
+)
+
+py_test(
     name = "version_test",
+    timeout = "short",
     srcs = ["version_test.py"],
     deps = [
         ":test_main",

--- a/tests/benchmarks/BUILD
+++ b/tests/benchmarks/BUILD
@@ -9,6 +9,7 @@ py_test(
     data = [
         "//compiler_gym/envs/llvm/service",
     ],
+    shard_count = 8,
     deps = [
         "//compiler_gym",
         "//compiler_gym/envs",

--- a/tests/bin/BUILD
+++ b/tests/bin/BUILD
@@ -32,3 +32,13 @@ py_test(
         "//tests:test_main",
     ],
 )
+
+py_test(
+    name = "validate_test",
+    srcs = ["validate_test.py"],
+    deps = [
+        "//compiler_gym",
+        "//compiler_gym/bin:validate",
+        "//tests:test_main",
+    ],
+)

--- a/tests/bin/validate_test.py
+++ b/tests/bin/validate_test.py
@@ -1,0 +1,64 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Unit tests for //compiler_gym/bin:validate."""
+from io import StringIO
+
+import pytest
+from absl import flags
+
+from compiler_gym.bin.validate import main
+from compiler_gym.util.capture_output import capture_output
+from tests.test_main import main as _test_main
+
+
+def test_okay_llvm_result(monkeypatch):
+    input = """
+benchmark,reward,commandline,walltime
+benchmark://cBench-v0/dijkstra,0,opt  input.bc -o output.bc,0.3
+""".strip()
+    flags.FLAGS.unparse_flags()
+    flags.FLAGS(["argv0", "--env=llvm-ic-v0", "--dataset=cBench-v0"])
+    monkeypatch.setattr("sys.stdin", StringIO(input))
+
+    with capture_output() as out:
+        main(["argv0"])
+
+    assert out.stdout == ("✅  benchmark://cBench-v0/dijkstra  0.0000\n")
+    assert not out.stderr
+
+
+def test_invalid_reward_llvm_result(monkeypatch):
+    input = """
+benchmark,reward,commandline,walltime
+benchmark://cBench-v0/dijkstra,0.5,opt  input.bc -o output.bc,0.3
+""".strip()
+    flags.FLAGS.unparse_flags()
+    flags.FLAGS(["argv0", "--env=llvm-ic-v0", "--dataset=cBench-v0"])
+    monkeypatch.setattr("sys.stdin", StringIO(input))
+    with capture_output() as out:
+        with pytest.raises(SystemExit):
+            main(["argv0"])
+
+    assert out.stdout == (
+        "❌  benchmark://cBench-v0/dijkstra  Expected reward 0.5000 but received reward 0.0000\n"
+    )
+    assert not out.stderr
+
+
+def test_invalid_csv_format(monkeypatch):
+    input = "invalid\ncsv\nformat"
+    flags.FLAGS.unparse_flags()
+    flags.FLAGS(["argv0", "--env=llvm-ic-v0", "--dataset=cBench-v0"])
+    monkeypatch.setattr("sys.stdin", StringIO(input))
+
+    with capture_output() as out:
+        with pytest.raises(SystemExit):
+            main(["argv0"])
+
+    assert "Failed to parse input:" in out.stderr
+
+
+if __name__ == "__main__":
+    _test_main()

--- a/tests/envs/BUILD
+++ b/tests/envs/BUILD
@@ -1,0 +1,13 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+py_test(
+    name = "compiler_env_test",
+    srcs = ["compiler_env_test.py"],
+    deps = [
+        "//compiler_gym/envs",
+        "//tests:test_main",
+    ],
+)

--- a/tests/envs/compiler_env_test.py
+++ b/tests/envs/compiler_env_test.py
@@ -1,0 +1,51 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Unit tests for //compiler_gym/envs."""
+import pytest
+
+from compiler_gym.envs import CompilerEnvState
+from tests.test_main import main
+
+
+def test_state_to_csv_from_csv():
+    original_state = CompilerEnvState(
+        benchmark="foo", walltime=100, reward=1.5, commandline="-a -b -c"
+    )
+    state_from_csv = CompilerEnvState.from_csv(original_state.to_csv())
+
+    assert state_from_csv.benchmark == "foo"
+    assert state_from_csv.walltime == 100
+    assert state_from_csv.reward == 1.5
+    assert state_from_csv.commandline == "-a -b -c"
+
+
+def test_state_to_csv_from_csv_no_reward():
+    original_state = CompilerEnvState(
+        benchmark="foo", walltime=100, commandline="-a -b -c"
+    )
+    state_from_csv = CompilerEnvState.from_csv(original_state.to_csv())
+
+    assert state_from_csv.benchmark == "foo"
+    assert state_from_csv.walltime == 100
+    assert state_from_csv.reward is None
+    assert state_from_csv.commandline == "-a -b -c"
+
+
+def test_state_from_csv_empty():
+    with pytest.raises(ValueError) as ctx:
+        CompilerEnvState.from_csv("")
+
+    assert str(ctx.value) == "Failed to parse input: ``"
+
+
+def test_state_from_csv_invalid_format():
+    with pytest.raises(ValueError) as ctx:
+        CompilerEnvState.from_csv("abcdef")
+
+    assert str(ctx.value).startswith("Failed to parse input: `abcdef`: ")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/envs/llvm/BUILD
+++ b/tests/envs/llvm/BUILD
@@ -108,6 +108,7 @@ py_test(
 py_test(
     name = "llvm_env_test",
     srcs = ["llvm_env_test.py"],
+    shard_count = 4,
     deps = [
         ":fixtures",
         "//compiler_gym",

--- a/tests/envs/llvm/BUILD
+++ b/tests/envs/llvm/BUILD
@@ -19,7 +19,7 @@ py_test(
     name = "all_benchmarks_init_close_test",
     timeout = "long",
     srcs = ["all_benchmarks_init_close_test.py"],
-    shard_count = 4,
+    shard_count = 6,
     deps = [
         ":fixtures",
         "//compiler_gym/envs",

--- a/tests/envs/llvm/all_benchmarks_init_close_test.py
+++ b/tests/envs/llvm/all_benchmarks_init_close_test.py
@@ -13,6 +13,8 @@ pytest_plugins = ["tests.envs.llvm.fixtures"]
 def test_init_benchmark(env: CompilerEnv, benchmark_name: str):
     """Create an environment for each benchmark and close it."""
     env.reset(benchmark=benchmark_name)
+    assert env.benchmark == benchmark_name
+    env.close()
 
 
 if __name__ == "__main__":

--- a/tests/envs/llvm/llvm_env_test.py
+++ b/tests/envs/llvm/llvm_env_test.py
@@ -9,7 +9,7 @@ import gym
 import pytest
 
 import compiler_gym
-from compiler_gym.envs import CompilerEnv, llvm
+from compiler_gym.envs import CompilerEnv, CompilerEnvState, llvm
 from compiler_gym.envs.llvm.llvm_env import LlvmEnv
 from compiler_gym.service.connection import CompilerGymServiceConnection
 from tests.test_main import main
@@ -69,7 +69,7 @@ def test_double_reset(env: CompilerEnv):
 
 
 def test_commandline(env: CompilerEnv):
-    env.reset("cBench-v0/crc32")
+    env.reset(benchmark="cBench-v0/crc32")
     assert env.commandline() == "opt  input.bc -o output.bc"
 
 
@@ -157,7 +157,7 @@ def test_gym_make_kwargs():
 
 def test_connection_dies_default_reward(env: LlvmEnv):
     env.reward_space = "IrInstructionCount"
-    env.reset("cBench-v0/crc32")
+    env.reset(benchmark="cBench-v0/crc32")
 
     env.reward_space.default_negates_returns = False
     env.reward_space.default_value = 2.5
@@ -172,7 +172,7 @@ def test_connection_dies_default_reward(env: LlvmEnv):
 
 def test_connection_dies_default_reward_negated(env: LlvmEnv):
     env.reward_space = "IrInstructionCount"
-    env.reset("cBench-v0/crc32")
+    env.reset(benchmark="cBench-v0/crc32")
 
     env.reward_space.default_negates_returns = True
     env.reward_space.default_value = 2.5
@@ -183,6 +183,17 @@ def test_connection_dies_default_reward_negated(env: LlvmEnv):
     assert done
 
     assert reward == -7.5  # negates reward.
+
+
+def test_state_to_csv_from_csv(env: LlvmEnv):
+    env.reset(benchmark="cBench-v0/crc32")
+    env.episode_reward = 10
+
+    state = env.state
+    assert state.reward == 10
+    state_from_csv = CompilerEnvState.from_csv(env.state.to_csv())
+    assert state_from_csv.reward == 10
+    assert state == state_from_csv
 
 
 if __name__ == "__main__":

--- a/tests/spaces/BUILD
+++ b/tests/spaces/BUILD
@@ -4,6 +4,16 @@
 # LICENSE file in the root directory of this source tree.
 
 py_test(
+    name = "commandline_test",
+    timeout = "short",
+    srcs = ["commandline_test.py"],
+    deps = [
+        "//compiler_gym/spaces",
+        "//tests:test_main",
+    ],
+)
+
+py_test(
     name = "named_discrete_test",
     timeout = "short",
     srcs = ["named_discrete_test.py"],

--- a/tests/spaces/commandline_test.py
+++ b/tests/spaces/commandline_test.py
@@ -1,0 +1,51 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Unit tests for //compiler_gym/spaces:scalar."""
+from compiler_gym.spaces import Commandline, CommandlineFlag
+from tests.test_main import main
+
+
+def test_sample():
+    space = Commandline(
+        [
+            CommandlineFlag(name="a", flag="-a", description=""),
+            CommandlineFlag(name="b", flag="-b", description=""),
+            CommandlineFlag(name="c", flag="-c", description=""),
+        ]
+    )
+    assert space.sample() in {0, 1, 2}
+
+
+def test_contains():
+    space = Commandline(
+        [
+            CommandlineFlag(name="a", flag="-a", description=""),
+            CommandlineFlag(name="b", flag="-b", description=""),
+            CommandlineFlag(name="c", flag="-c", description=""),
+        ]
+    )
+    assert space.contains(0)
+    assert space.contains(1)
+    assert space.contains(2)
+    assert not space.contains(-11)
+    assert not space.contains(1.5)
+    assert not space.contains(4)
+
+
+def test_commandline():
+    space = Commandline(
+        [
+            CommandlineFlag(name="a", flag="-a", description=""),
+            CommandlineFlag(name="b", flag="-b", description=""),
+            CommandlineFlag(name="c", flag="-c", description=""),
+        ]
+    )
+
+    assert space.commandline([0, 1, 2]) == "-a -b -c"
+    assert space.from_commandline(space.commandline([0, 1, 2])) == [0, 1, 2]
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/validate_test.py
+++ b/tests/validate_test.py
@@ -1,0 +1,90 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Unit tests for //compiler_gym:validate."""
+import gym
+
+from compiler_gym import validate_state, validate_states
+from compiler_gym.envs import CompilerEnvState
+from tests.test_main import main
+
+
+def test_validate_state_no_reward():
+    state = CompilerEnvState(
+        benchmark="cBench-v0/dijkstra",
+        walltime=1,
+        commandline="opt  input.bc -o output.bc",
+    )
+    env = gym.make("llvm-v0")
+    try:
+        result = validate_state(env, state)
+    finally:
+        env.close()
+
+    assert result.success
+    assert not result.failed
+    assert not result.reward_validated
+    assert str(result) == "✅  cBench-v0/dijkstra"
+
+
+def test_validate_state_with_reward():
+    state = CompilerEnvState(
+        benchmark="cBench-v0/dijkstra",
+        walltime=1,
+        reward=0,
+        commandline="opt  input.bc -o output.bc",
+    )
+    env = gym.make("llvm-v0", reward_space="IrInstructionCount")
+    try:
+        result = validate_state(env, state)
+    finally:
+        env.close()
+
+    assert result.success
+    assert not result.failed
+    assert result.reward_validated
+    assert not result.reward_validation_failed
+    assert str(result) == "✅  cBench-v0/dijkstra  0.0000"
+
+
+def test_validate_state_invalid_reward():
+    state = CompilerEnvState(
+        benchmark="cBench-v0/dijkstra",
+        walltime=1,
+        reward=1,
+        commandline="opt  input.bc -o output.bc",
+    )
+    env = gym.make("llvm-v0", reward_space="IrInstructionCount")
+    try:
+        result = validate_state(env, state)
+    finally:
+        env.close()
+
+    assert not result.success
+    assert result.failed
+    assert result.reward_validated
+    assert result.reward_validation_failed
+    assert (
+        str(result)
+        == "❌  cBench-v0/dijkstra  Expected reward 1.0000 but received reward 0.0000"
+    )
+
+
+def test_validate_states_lambda_callback():
+    state = CompilerEnvState(
+        benchmark="cBench-v0/dijkstra",
+        walltime=1,
+        commandline="opt  input.bc -o output.bc",
+    )
+    results = list(
+        validate_states(
+            make_env=lambda: gym.make("llvm-v0"), states=[state], datasets=["cBench-v0"]
+        )
+    )
+    assert len(results) == 1
+    assert results[0].success
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This is part one of a two-stage implementation of leaderboard results validation. This first part adds a script to validate agent results, and a new `CompilerEnvState` tuple to produce the necessary info for this validation. A subsequent PR will add semantics validation for the cBench LLVM dataset.

## CompilerEnvState

This adds a `CompilerEnvState` tuple which describes, for a given
environment state, the sequence of steps that must be applied to a
fresh environment to reproduce this state. It is accessed through a
`CompilerEnv.state` property and provides a simple comma-separated
text format:

```py
>>> env = gym.make("llvm-v0", benchmark="cBench-v0/crc32")
>>> env.reset()
>>> env.step(0)
>>> print(env.state.csv_header())
benchmark,reward,runtime,commandline
>>> print(env.state.to_csv())
benchmark://cBench-v0/crc32,,11.316940307617188,opt -add-discriminators input.bc -o output.bc
```

## compiler_gym.bin.validate

This adds a script to validate agent results. The validation script
consumes a list of episodes and replays them, validating that the
correct reward is produced. There is also the option to validate that
a benchmark's semantics remains unchanged using a set of ad-hoc
validation callbacks, though these callbacks will be provided in a
later patch.

To validate agent results, produce a CSV in the format:

    benchmark,reward,commandline,walltime
    benchmark://cBench-v0/dijkstra,0.5,opt  input.bc -o output.bc,0.3
    benchmark://cBench-v0/crc32,0.5,opt  input.bc -o output.bc,0.3

where each row contains the outcome of an episode: the name of the
benchmark, the total reward for the episode, the sequence of actions
as a commandline, and the walltime. The `CompilerEnv.state.to_csv()`
method produces output in the required format. Then pass the CSV to
stdin of the validation script:

    $ python -m compiler_gym.bin.validate < results.csv \
        --env=llvm-v0 --reward=IrInstructionCount
