### PR TITLE
Bug 32.

### DIFF
--- a/compiler_gym/bin/manual_env.py
+++ b/compiler_gym/bin/manual_env.py
@@ -43,10 +43,16 @@ def run_manual_env(env: CompilerEnv):
         # Allow the user to choose a benchmark, with the first choice being
         # to select randomly.
         benchmarks = sorted(env.benchmarks)
+        if not benchmarks:
+            print("No benchmarks available see https://facebookresearch.github.io/CompilerGym/getting_started.html#installing-benchmarks")
+            print("Exiting...")
+            env.close()
+            return
+
         # Strip default benchmark:// protocol.
         for i, benchmark in enumerate(benchmarks):
             if benchmark.startswith("benchmark://"):
-                benchmarks[i] = benchmark[len("benchmark://") :]
+                benchmarks[i] = benchmark[len("benchmark://"):]
 
         benchmark_index = user_input.read_list_index(
             "Benchmark", ["random"] + benchmarks


### PR DESCRIPTION
Manual env fails without helpful error when no benchmarks are loaded.

Added a check to see if no benchmarks are loaded.

Fixes #32 
