### PR TITLE
Fix fuzz test default assertions.

### DIFF
--- a/tests/envs/llvm/benchmarks_random_actions_test.py
+++ b/tests/envs/llvm/benchmarks_random_actions_test.py
@@ -37,8 +37,9 @@ def test_benchmark_random_actions(benchmark_name: str):
         while time() < end_time:
             observation, reward, done, info = env.step(env.action_space.sample())
             if done:
-                assert observation is None
-                assert reward is None
+                # Default-value for observation is an array of zeros.
+                np.testing.assert_array_equal(observation, np.zeros((56,)))
+                assert isinstance(reward, float)
                 env = make_env(benchmark_name)
             else:
                 assert isinstance(observation, np.ndarray)

--- a/tests/envs/llvm/benchmarks_random_actions_test.py
+++ b/tests/envs/llvm/benchmarks_random_actions_test.py
@@ -9,7 +9,6 @@ from time import time
 import gym
 import numpy as np
 
-from compiler_gym.envs import CompilerEnv
 from tests.test_main import main
 
 pytest_plugins = ["tests.envs.llvm.fixtures"]
@@ -18,18 +17,15 @@ pytest_plugins = ["tests.envs.llvm.fixtures"]
 FUZZ_TIME_SECONDS = 2
 
 
-def make_env(benchmark_name: str) -> CompilerEnv:
-    """Construct an environment for testing."""
-    env = gym.make("llvm-v0")
-    env.reward_space = "IrInstructionCount"
-    env.observation_space = "Autophase"
-    env.reset(benchmark=benchmark_name)
-    return env
-
-
 def test_benchmark_random_actions(benchmark_name: str):
     """Run randomly selected actions on a benchmark until a minimum amount of time has elapsed."""
-    env = make_env(benchmark_name)
+    env = gym.make(
+        "llvm-v0",
+        reward_space="IrInstructionCount",
+        observation_space="Autophase",
+        benchmark=benchmark_name,
+    )
+    env.reset()
 
     try:
         # Take a random step until a predetermined amount of time has elapsed.
@@ -40,7 +36,13 @@ def test_benchmark_random_actions(benchmark_name: str):
                 # Default-value for observation is an array of zeros.
                 np.testing.assert_array_equal(observation, np.zeros((56,)))
                 assert isinstance(reward, float)
-                env = make_env(benchmark_name)
+                env = gym.make(
+                    "llvm-v0",
+                    reward_space="IrInstructionCount",
+                    observation_space="Autophase",
+                    benchmark=benchmark_name,
+                )
+                env.reset()
             else:
                 assert isinstance(observation, np.ndarray)
                 assert observation.shape == (56,)


### PR DESCRIPTION
The return type of env.step() was changed to return default values on
failure in https://github.com/facebookresearch/CompilerGym/pull/30.
This patch updates the test to assert for these new default values.

Fixes CI failure: https://github.com/facebookresearch/CompilerGym/runs/1716634438?check_suite_focus=true
