### PR TITLE
Refresh the example compiler service.

### DIFF
--- a/compiler_gym/service/proto/compiler_gym_service.proto
+++ b/compiler_gym/service/proto/compiler_gym_service.proto
@@ -59,9 +59,9 @@ message StartEpisodeRequest {
   // The name of the benchmark to use for this episode. If not
   // provided, a benchmark is chosen randomly by the service.
   string benchmark = 1;
-  // An index into the GetSpaces().action_space_list selecting the action space
-  // that is to be used for this episode. Once set, the action space cannot
-  // be changed for the duration of the episode.
+  // An index into the GetSpacesReply.action_space_list selecting the action
+  // space that is to be used for this episode. Once set, the action space
+  // cannot be changed for the duration of the episode.
   int32 action_space = 2;
   // Enable eager computation of observation. When set, every call to
   // takeAction() will return the observation given by this index into

--- a/examples/example_compiler_gym_service/BUILD
+++ b/examples/example_compiler_gym_service/BUILD
@@ -7,7 +7,7 @@ py_library(
     name = "example_compiler_gym_service",
     srcs = ["__init__.py"],
     data = [
-        "//examples/example_compiler_gym_service/service",
+        "//examples/example_compiler_gym_service/service:compiler_gym-example-service",
     ],
     deps = [
         "//compiler_gym/util",

--- a/examples/example_compiler_gym_service/README.md
+++ b/examples/example_compiler_gym_service/README.md
@@ -1,12 +1,21 @@
 # Example CompilerGym Service
 
-This directory contains an a simple example implementation of the
-CompilerGymService interface, useful for debugging or testing frontend logic.
+CompilerGym uses a
+[client/service architecture](https://facebookresearch.github.io/CompilerGym/compiler_gym/service.html).
+The client is the frontend python API and the service is the backend that
+handles the actual compilation. The backend exposes a
+[CompilerGymService](https://github.com/facebookresearch/CompilerGym/blob/development/compiler_gym/service/proto/compiler_gym_service.proto)
+RPC interface that the frontend interacts with.
+
+This directory contains an an example backend service. It doesn't do any actual
+compilation, but can be used as a starting point for writing new services, or
+for debugging and testing frontend code.
 
 Features:
 
 * Enforces the service contract, e.g. `Init()` must be called before
   `StartEpisode()`, list indices must be in-bounds, etc.
+* Implements all of the RPC endpoints.
 * It has two programs "foo" and "bar".
 * It has a static action space with three items: `["a", "b", "c"]`. The action
   space never changes. Actions never end the episode.
@@ -16,21 +25,27 @@ Features:
 * There is a single reward space `codesize` which returns 0.
 * Supports eager observation and reward.
 
+See [service/ExampleService.h](service/ExampleService.h) for the service
+implementation, [__init__.py](__init__.py) for a python module that
+registers this service with the gym on import, and [env_tests.py](env_tests.py)
+for tests.
+
 
 ## Usage
 
 Start an example service using:
 
 ```sh
-$ bazel run -c opt //examples/example_compiler_gym_service -- --port=8080
+$ bazel run -c opt //examples/example_compiler_gym_service/service -- \
+      --port=8080 --working_dir=/tmp
 ```
 
-The service does never terminates and does not print logging messages.
-Interact with the RPC endpoints using your frontend of choice, for example, the
-manual environment:
+The service never terminates and does not print logging messages. Interact with
+the RPC endpoints using your frontend of choice, for example, the manual
+environment:
 
 ```sh
-$ python -m compiler_gym.bin.manual_env --service=localhost:8080
+$ bazel run -c opt //compiler_gym/bin:manual_env -- --service=localhost:8080
 ```
 
 Kill the service using C-c when you are done.

--- a/examples/example_compiler_gym_service/__init__.py
+++ b/examples/example_compiler_gym_service/__init__.py
@@ -2,42 +2,18 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-from itertools import product
-
+"""This module demonstrates how to """
 from compiler_gym.util.registration import register
 from compiler_gym.util.runfiles_path import runfiles_path
 
-_EXAMPLE_SERVICE_BINARY = runfiles_path(
-    "examples/example_compiler_gym_service/service/service"
+# Register the example service on module import. After importing this module,
+# the example-v0 environment will be available to gym.make(...).
+register(
+    id="example-v0",
+    entry_point="compiler_gym.envs:CompilerEnv",
+    kwargs={
+        "service": runfiles_path(
+            "examples/example_compiler_gym_service/service/compiler_gym-example-service"
+        ),
+    },
 )
-
-
-def _register_example_gym_service():
-    """Register environments for the example service."""
-    register(
-        id="example-v0",
-        entry_point="compiler_gym.envs:CompilerEnv",
-        kwargs={
-            "service": _EXAMPLE_SERVICE_BINARY,
-        },
-    )
-
-    # Register rewards for all combinations of eager observation and
-    # reward spaces.
-    observation_spaces = ["ir", "features"]
-    reward_spaces = ["codesize"]
-    configurations = product(observation_spaces, reward_spaces)
-    for observation_space, reward_space in configurations:
-        env_id = f"example-{observation_space}-{reward_space}-v0"
-        register(
-            id=env_id,
-            entry_point="compiler_gym.envs:CompilerEnv",
-            kwargs={
-                "service": _EXAMPLE_SERVICE_BINARY,
-                "observation_space": observation_space,
-                "reward_space": reward_space,
-            },
-        )
-
-
-_register_example_gym_service()

--- a/examples/example_compiler_gym_service/env_tests.py
+++ b/examples/example_compiler_gym_service/env_tests.py
@@ -25,11 +25,13 @@ def env() -> CompilerEnv:
 
 
 def test_versions(env: CompilerEnv):
+    """Tests the GetVersion() RPC endpoint."""
     assert env.version == compiler_gym.__version__
     assert env.compiler_version == "1.0.0"
 
 
 def test_action_space(env: CompilerEnv):
+    """Test that the environment reports the service's action spaces."""
     assert env.action_spaces == [
         NamedDiscrete(
             name="default",
@@ -39,6 +41,7 @@ def test_action_space(env: CompilerEnv):
 
 
 def test_observation_spaces(env: CompilerEnv):
+    """Test that the environment reports the service's observation spaces."""
     env.reset()
     assert env.observation.spaces.keys() == {"ir", "features"}
     assert env.observation.spaces["ir"].space == Sequence(
@@ -50,53 +53,62 @@ def test_observation_spaces(env: CompilerEnv):
 
 
 def test_reward_spaces(env: CompilerEnv):
+    """Test that the environment reports the service's reward spaces."""
     env.reset()
     assert env.reward.spaces.keys() == {"codesize"}
 
 
 def test_takeAction_before_startEpisode(env: CompilerEnv):
+    """Taking a step() before reset() is illegal."""
     with pytest.raises(Exception):
         env.step(0)
 
 
 def test_observation_before_startEpisode(env: CompilerEnv):
-    with pytest.raises(TypeError) as ctx:
+    """Taking an observation before reset() is illegal."""
+    with pytest.raises(ValueError) as ctx:
         _ = env.observation["ir"]
-    assert str(ctx.value) == "No episode"
+    assert str(ctx.value) == "Session ID not found"
 
 
 def test_reward_before_reset(env: CompilerEnv):
-    with pytest.raises(TypeError) as ctx:
+    """Taking a reward before reset() is illegal."""
+    with pytest.raises(ValueError) as ctx:
         _ = env.reward["codesize"]
-    assert str(ctx.value) == "No episode"
+    assert str(ctx.value) == "Session ID not found"
 
 
 def test_reset_invalid_benchmark(env: CompilerEnv):
+    """Test requesting a specific benchmark."""
     with pytest.raises(ValueError) as ctx:
         env.reset(benchmark="foobar")
     assert str(ctx.value) == "Unknown program name"
 
 
-def test_invalid_observation_space(
-    env: CompilerEnv,
-):
+def test_invalid_observation_space(env: CompilerEnv):
+    """Test error handling with invalid observation space."""
     with pytest.raises(LookupError):
         env.observation_space = 100
 
 
-def test_invalid_reward_space(
-    env: CompilerEnv,
-):
+def test_invalid_reward_space(env: CompilerEnv):
+    """Test error handling with invalid reward space."""
     with pytest.raises(LookupError):
         env.reward_space = 100
 
 
 def test_double_reset(env: CompilerEnv):
+    """Test that reset() can be called twice."""
     env.reset()
+    assert env.in_episode
+    env.step(env.action_space.sample())
     env.reset()
+    env.step(env.action_space.sample())
+    assert env.in_episode
 
 
 def test_takeAction_out_of_range(env: CompilerEnv):
+    """Test error handling with an invalid action."""
     env.reset()
     with pytest.raises(ValueError) as ctx:
         env.step(100)
@@ -104,6 +116,7 @@ def test_takeAction_out_of_range(env: CompilerEnv):
 
 
 def test_eager_ir_observation(env: CompilerEnv):
+    """Test eager observation space."""
     env.observation_space = "ir"
     observation = env.reset()
     assert observation == "Hello, world!"
@@ -114,9 +127,8 @@ def test_eager_ir_observation(env: CompilerEnv):
     assert not done
 
 
-def test_eager_features_observation(
-    env: CompilerEnv,
-):
+def test_eager_features_observation(env: CompilerEnv):
+    """Test eager observation space."""
     env.observation_space = "features"
     observation = env.reset()
     assert isinstance(observation, np.ndarray)
@@ -126,6 +138,7 @@ def test_eager_features_observation(
 
 
 def test_eager_reward(env: CompilerEnv):
+    """Test eager reward space."""
     env.reward_space = "codesize"
     env.reset()
     observation, reward, done, info = env.step(0)
@@ -134,12 +147,15 @@ def test_eager_reward(env: CompilerEnv):
     assert not done
 
 
-def test_getObservation_ir(env: CompilerEnv):
+def test_observations(env: CompilerEnv):
+    """Test observation spaces."""
     env.reset()
     assert env.observation["ir"] == "Hello, world!"
+    np.testing.assert_array_equal(env.observation["features"], [0, 0, 0])
 
 
-def test_getReward(env: CompilerEnv):
+def test_rewards(env: CompilerEnv):
+    """Test reward spaces."""
     env.reset()
     assert env.reward["codesize"] == 0
 

--- a/examples/example_compiler_gym_service/service/BUILD
+++ b/examples/example_compiler_gym_service/service/BUILD
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 cc_binary(
-    name = "service",
+    name = "compiler_gym-example-service",
     srcs = ["RunService.cc"],
     visibility = ["//visibility:public"],
     deps = [

--- a/examples/example_compiler_gym_service/service/ExampleService.cc
+++ b/examples/example_compiler_gym_service/service/ExampleService.cc
@@ -5,8 +5,6 @@
 
 #include "examples/example_compiler_gym_service/service/ExampleService.h"
 
-#include <stdexcept>
-
 #include "compiler_gym/service/proto/compiler_gym_service.pb.h"
 #include "compiler_gym/util/GrpcStatusMacros.h"
 #include "compiler_gym/util/Version.h"
@@ -19,6 +17,8 @@ using grpc::StatusCode;
 
 namespace fs = boost::filesystem;
 
+namespace {
+
 template <typename T>
 [[nodiscard]] inline Status rangeCheck(const T& value, const T& minValue, const T& maxValue) {
   if (value < minValue || value > maxValue) {
@@ -27,19 +27,26 @@ template <typename T>
   return Status::OK;
 }
 
-ExampleService::ExampleService(const fs::path& workingDirectory)
-    : workingDirectory_(workingDirectory),
-      episodeStarted_(false),
-      programNameList_({"foo", "bar"}),
-      actionSpace_({"a", "b", "c"}),
-      eagerObservation_(false),
-      eagerReward_(false) {
+}  // namespace
+
+std::vector<std::string> getBenchmarks() { return {"foo", "bar"}; }
+
+std::vector<ActionSpace> getActionSpaces() {
+  ActionSpace space;
+  space.set_name("default");
+  space.add_action("a");
+  space.add_action("b");
+  space.add_action("c");
+
+  return {space};
+}
+
+std::vector<ObservationSpace> getObservationSpaces() {
   ObservationSpace ir;
   ir.set_name("ir");
   ScalarRange irSizeRange;
   irSizeRange.mutable_min()->set_value(0);
   *ir.mutable_string_size_range() = irSizeRange;
-  observationSpaces_.push_back(ir);
 
   ObservationSpace features;
   features.set_name("features");
@@ -48,13 +55,20 @@ ExampleService::ExampleService(const fs::path& workingDirectory)
     featureSizeRange->mutable_min()->set_value(-100);
     featureSizeRange->mutable_max()->set_value(100);
   }
-  observationSpaces_.push_back(features);
 
+  return {ir, features};
+}
+
+std::vector<RewardSpace> getRewardSpaces() {
   RewardSpace codesize;
   codesize.set_name("codesize");
   codesize.mutable_range()->mutable_max()->set_value(0);
-  rewardSpaces_.push_back(codesize);
+
+  return {codesize};
 }
+
+ExampleService::ExampleService(const fs::path& workingDirectory)
+    : workingDirectory_(workingDirectory), nextSessionId_(0) {}
 
 Status ExampleService::GetVersion(ServerContext* /* unused */,
                                   const GetVersionRequest* /* unused */, GetVersionReply* reply) {
@@ -65,108 +79,140 @@ Status ExampleService::GetVersion(ServerContext* /* unused */,
 
 Status ExampleService::GetSpaces(ServerContext* /* unused*/, const GetSpacesRequest* /* unused */,
                                  GetSpacesReply* reply) {
-  auto actionSpace = reply->add_action_space_list();
-  actionSpace->set_name("default");
-  *actionSpace->mutable_action() = {actionSpace_.begin(), actionSpace_.end()};
-  *reply->mutable_observation_space_list() = {observationSpaces_.begin(), observationSpaces_.end()};
-  *reply->mutable_reward_space_list() = {rewardSpaces_.begin(), rewardSpaces_.end()};
+  const auto actionSpaces = getActionSpaces();
+  const auto observationSpaces = getObservationSpaces();
+  const auto rewardSpaces = getRewardSpaces();
 
+  *reply->mutable_action_space_list() = {actionSpaces.begin(), actionSpaces.end()};
+  *reply->mutable_observation_space_list() = {observationSpaces.begin(), observationSpaces.end()};
+  *reply->mutable_reward_space_list() = {rewardSpaces.begin(), rewardSpaces.end()};
   return Status::OK;
 }
 
 Status ExampleService::StartEpisode(ServerContext* /* unused*/, const StartEpisodeRequest* request,
                                     StartEpisodeReply* reply) {
-  if (episodeStarted_) {
-    return Status(StatusCode::FAILED_PRECONDITION, "Already started episode");
-  }
-
-  // Program.
+  // Determine the benchmark to use.
   std::string benchmark = request->benchmark();
-  if (benchmark.size() && (benchmark != "foo" && benchmark != "bar")) {
+  const auto benchmarks = getBenchmarks();
+  if (!benchmark.empty() &&
+      std::find(benchmarks.begin(), benchmarks.end(), benchmark) == benchmarks.end()) {
     return Status(StatusCode::INVALID_ARGUMENT, "Unknown program name");
   } else {
-    benchmark = "foo";  // Choose the benchmark to use.
+    // If no benchmark was requested, choose one.
+    benchmark = "foo";
   }
-
   reply->set_benchmark(benchmark);
 
-  // Eager observation.
+  // Determine the action space.
+  const auto actionSpaces = getActionSpaces();
+  RETURN_IF_ERROR(
+      rangeCheck(request->action_space(), 0, static_cast<int32_t>(actionSpaces.size()) - 1));
+  const auto actionSpace = actionSpaces[request->action_space()];
+
+  // Range check the eager observation space.
+  std::optional<int32_t> eagerObservation = std::nullopt;
   if (request->use_eager_observation_space()) {
-    eagerObservation_ = true;
-    eagerObservationSpace_ = request->eager_observation_space();
+    eagerObservation = request->eager_observation_space();
     RETURN_IF_ERROR(
-        rangeCheck(eagerObservationSpace_, 0, static_cast<int32_t>(observationSpaces_.size()) - 1));
+        rangeCheck(*eagerObservation, 0, static_cast<int32_t>(getObservationSpaces().size()) - 1));
   }
 
-  // Eager reward.
+  // Range check the eager reward space.
+  std::optional<int32_t> eagerReward = std::nullopt;
   if (request->use_eager_reward_space()) {
-    eagerReward_ = true;
-    eagerRewardSpace_ = request->eager_reward_space();
+    eagerReward = request->eager_reward_space();
     RETURN_IF_ERROR(
-        rangeCheck(eagerRewardSpace_, 0, static_cast<int32_t>(rewardSpaces_.size()) - 1));
+        rangeCheck(*eagerReward, 0, static_cast<int32_t>(getRewardSpaces().size()) - 1));
   }
 
-  episodeStarted_ = true;
+  // Create the new compilation session given.
+  reply->set_session_id(nextSessionId_);
+  sessions_[nextSessionId_] = std::make_unique<ExampleCompilationSession>(
+      benchmark, actionSpace, eagerObservation, eagerReward);
+  ++nextSessionId_;
 
   return Status::OK;
 }
 
-Status ExampleService::EndEpisode(ServerContext* /* unused*/, const EndEpisodeRequest* /* unused */,
+Status ExampleService::EndEpisode(ServerContext* /* unused*/, const EndEpisodeRequest* request,
                                   EndEpisodeReply* /* unused */) {
-  episodeStarted_ = false;
+  auto session = sessions_.find(request->session_id());
+  // De-allocate the session.
+  if (session != sessions_.end()) {
+    sessions_.erase(session);
+  }
   return Status::OK;
 }
 
 Status ExampleService::TakeAction(ServerContext* /* unused*/, const ActionRequest* request,
                                   ActionReply* reply) {
-  if (!episodeStarted_) {
-    return Status(StatusCode::FAILED_PRECONDITION, "No episode");
-  }
-
-  for (int i = 0; i < request->action_size(); ++i) {
-    const auto& action = request->action(i);
-    RETURN_IF_ERROR(rangeCheck(action, 0, static_cast<int32_t>(actionSpace_.size()) - 1));
-  }
-
-  if (eagerObservation_) {
-    RETURN_IF_ERROR(setObservation(eagerObservationSpace_, reply->mutable_observation()));
-  }
-
-  if (eagerReward_) {
-    RETURN_IF_ERROR(setReward(eagerRewardSpace_, reply->mutable_reward()));
-  }
-
-  return Status::OK;
+  ExampleCompilationSession* sess;
+  RETURN_IF_ERROR(session(request->session_id(), &sess));
+  return sess->takeAction(request, reply);
 }
 
 Status ExampleService::GetObservation(ServerContext* /* unused*/, const ObservationRequest* request,
                                       Observation* reply) {
-  if (!episodeStarted_) {
-    return Status(StatusCode::FAILED_PRECONDITION, "No episode");
-  }
-  return setObservation(request->observation_space(), reply);
+  ExampleCompilationSession* sess;
+  RETURN_IF_ERROR(session(request->session_id(), &sess));
+  return sess->getObservation(request->observation_space(), reply);
 }
 
 Status ExampleService::GetReward(ServerContext* /* unused*/, const RewardRequest* request,
                                  Reward* reply) {
-  if (!episodeStarted_) {
-    return Status(StatusCode::FAILED_PRECONDITION, "No episode");
-  }
-  return setReward(request->reward_space(), reply);
+  ExampleCompilationSession* sess;
+  RETURN_IF_ERROR(session(request->session_id(), &sess));
+  return sess->getReward(request->reward_space(), reply);
 }
 
 Status ExampleService::GetBenchmarks(grpc::ServerContext* /*unused*/,
                                      const GetBenchmarksRequest* /*unused*/,
                                      GetBenchmarksReply* reply) {
-  reply->add_benchmark("foo");
-  reply->add_benchmark("bar");
-
+  const auto benchmarks = getBenchmarks();
+  *reply->mutable_benchmark() = {benchmarks.begin(), benchmarks.end()};
   return Status::OK;
 }
 
-Status ExampleService::setObservation(int32_t observationSpace, Observation* observation) {
+Status ExampleService::session(uint64_t id, ExampleCompilationSession** sess) {
+  auto it = sessions_.find(id);
+  if (it == sessions_.end()) {
+    return Status(StatusCode::INVALID_ARGUMENT, "Session ID not found");
+  }
+  *sess = it->second.get();
+  return Status::OK;
+}
+
+ExampleCompilationSession::ExampleCompilationSession(const std::string& benchmark,
+                                                     ActionSpace actionSpace,
+                                                     std::optional<int32_t> eagerObservation,
+                                                     std::optional<int32_t> eagerReward)
+    : benchmark_(benchmark),
+      actionSpace_(actionSpace),
+      eagerObservation_(eagerObservation),
+      eagerReward_(eagerReward) {}
+
+Status ExampleCompilationSession::takeAction(const ActionRequest* request, ActionReply* reply) {
+  for (int i = 0; i < request->action_size(); ++i) {
+    const auto action = request->action(i);
+    // Run the actual action. Here we just range check.
+    RETURN_IF_ERROR(rangeCheck(action, 0, static_cast<int32_t>(actionSpace_.action_size() - 1)));
+  }
+
+  // Compute a new observation and reward if required.
+  if (eagerObservation_.has_value()) {
+    RETURN_IF_ERROR(getObservation(*eagerObservation_, reply->mutable_observation()));
+  }
+  if (eagerReward_.has_value()) {
+    RETURN_IF_ERROR(getReward(*eagerReward_, reply->mutable_reward()));
+  }
+  return Status::OK;
+}
+
+Status ExampleCompilationSession::getObservation(int32_t observationSpace,
+                                                 Observation* observation) {
+  const auto observationSpaces = getObservationSpaces();
   RETURN_IF_ERROR(
-      rangeCheck(observationSpace, 0, static_cast<int32_t>(observationSpaces_.size()) - 1));
+      rangeCheck(observationSpace, 0, static_cast<int32_t>(observationSpaces.size()) - 1));
   switch (observationSpace) {
     case 0:
       observation->set_string_value("Hello, world!");
@@ -182,8 +228,9 @@ Status ExampleService::setObservation(int32_t observationSpace, Observation* obs
   return Status::OK;
 }
 
-Status ExampleService::setReward(int32_t rewardSpace, Reward* reward) {
-  RETURN_IF_ERROR(rangeCheck(rewardSpace, 0, static_cast<int32_t>(rewardSpaces_.size()) - 1));
+Status ExampleCompilationSession::getReward(int32_t rewardSpace, Reward* reward) {
+  const auto rewardSpaces = getRewardSpaces();
+  RETURN_IF_ERROR(rangeCheck(rewardSpace, 0, static_cast<int32_t>(rewardSpaces.size()) - 1));
   reward->set_reward(0);
   return Status::OK;
 }

--- a/examples/example_compiler_gym_service/service/RunService.cc
+++ b/examples/example_compiler_gym_service/service/RunService.cc
@@ -13,4 +13,8 @@ const char* usage = R"(LLVM CompilerGym service)";
 using namespace compiler_gym::util;
 using namespace compiler_gym::example_service;
 
-int main(int argc, char** argv) { return runService<ExampleService>(&argc, &argv, usage); }
+int main(int argc, char** argv) {
+  // Call the utility runService() function to launch the service. This function
+  // never returns.
+  return runService<ExampleService>(&argc, &argv, usage);
+}


### PR DESCRIPTION
This refreshes the example CompilerGym service implementation to make it (hopefully) more accessible. It could be useful as a barebones skeleton for implementing support for new compilers.

The `examples/example_compiler_gym_service/service/ExampleService.h` file contains the service implementation, `examples/example_compiler_gym_service/__init__.py` contains a python module that registers this service with the gym on import, and `examples/example_compiler_gym_service/env_tests.py` has unit tests.