### PR TITLE
Datasets API tweak

### DIFF
--- a/compiler_gym/datasets/__init__.py
+++ b/compiler_gym/datasets/__init__.py
@@ -3,6 +3,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 """Manage datasets of benchmarks."""
-from compiler_gym.datasets.dataset import Dataset, require
+from compiler_gym.datasets.dataset import Dataset, activate, deactivate, delete, require
 
-__all__ = ["Dataset", "require"]
+__all__ = ["Dataset", "require", "activate", "deactivate", "delete"]

--- a/tests/bin/datasets_test.py
+++ b/tests/bin/datasets_test.py
@@ -50,9 +50,7 @@ def test_llvm_activate_non_existent_dataset(site_data):
 def test_llvm_deactivate_non_existent_dataset(site_data):
     del site_data
     invalid = "nonexistent"
-    with pytest.raises(ValueError) as ctx:
-        run_main("--env=llvm-v0", "--deactivate", invalid)
-    assert f"Active dataset not found: {invalid}" == str(ctx.value)
+    run_main("--env=llvm-v0", "--deactivate", invalid)
 
 
 def test_llvm_activate_invalid_metadata_file(site_data):


### PR DESCRIPTION
This exposes APIs for additional dataset-wrangling operations (activate, deactivate, and delete) that were previously only available through the command-line interface. This also makes the dataset APIs more lenient and less likely to throw errors. They instead simply return a bool value indicating whether work was done.