### PR TITLE
Add an LlvmEnv.fork() method

### DIFF
--- a/compiler_gym/envs/compiler_env.py
+++ b/compiler_gym/envs/compiler_env.py
@@ -356,6 +356,7 @@ class CompilerEnv(gym.Env):
 
     @action_space.setter
     def action_space(self, action_space: Optional[str]):
+        self.action_space_name = action_space
         index = (
             [a.name for a in self.action_spaces].index(action_space)
             if self.action_space_name

--- a/compiler_gym/envs/compiler_env.py
+++ b/compiler_gym/envs/compiler_env.py
@@ -113,12 +113,19 @@ class CompilerEnvState(NamedTuple):
         if not isinstance(rhs, CompilerEnvState):
             return False
         epsilon = 1e-5
+        # If only one benchmark has a reward the states cannot be equal.
+        if self.reward is None != rhs.reward is None:
+            return False
+        if self.reward is None and rhs.reward is None:
+            reward_equal = True
+        else:
+            reward_equal = abs(self.reward - rhs.reward) < epsilon
         # Note that walltime is excluded from equivalence checks as two states
         # are equivalent if they define the same point in the optimization space
         # irrespective of how long it took to get there.
         return (
             self.benchmark == rhs.benchmark
-            and abs(self.reward - rhs.reward) < epsilon
+            and reward_equal
             and self.commandline == rhs.commandline
         )
 

--- a/tests/envs/llvm/BUILD
+++ b/tests/envs/llvm/BUILD
@@ -98,6 +98,20 @@ py_library(
 )
 
 py_test(
+    name = "fork_env_test",
+    timeout = "short",
+    srcs = ["fork_env_test.py"],
+    data = [
+        "//compiler_gym/third_party/cBench:crc32",
+    ],
+    deps = [
+        ":fixtures",
+        "//compiler_gym/envs",
+        "//tests:test_main",
+    ],
+)
+
+py_test(
     name = "fresh_environment_observation_reward_test",
     srcs = ["fresh_environment_observation_reward_test.py"],
     shard_count = 8,

--- a/tests/envs/llvm/fork_env_test.py
+++ b/tests/envs/llvm/fork_env_test.py
@@ -1,0 +1,106 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Tests for LlvmEnv.fork()."""
+from time import time
+
+from compiler_gym.envs import LlvmEnv
+from compiler_gym.util.runfiles_path import runfiles_path
+from tests.test_main import main
+
+pytest_plugins = ["tests.envs.llvm.fixtures"]
+
+EXAMPLE_BITCODE_FILE = runfiles_path(
+    "CompilerGym/compiler_gym/third_party/cBench/cBench-v0/crc32.bc"
+)
+EXAMPLE_BITCODE_IR_INSTRUCTION_COUNT = 196
+
+
+def test_fork_state(env: LlvmEnv):
+    env.reset("cBench-v0/crc32")
+    env.step(0)
+    assert env.actions == [0]
+
+    new_env = env.fork()
+    try:
+        assert new_env.benchmark == new_env.benchmark
+        assert new_env.actions == env.actions
+    finally:
+        new_env.close()
+
+
+def test_fork_reset(env: LlvmEnv):
+    env.reset("cBench-v0/crc32")
+    env.step(0)
+    env.step(1)
+    env.step(2)
+
+    new_env = env.fork()
+    try:
+        new_env.step(3)
+
+        assert env.actions == [0, 1, 2]
+        assert new_env.actions == [0, 1, 2, 3]
+
+        new_env.reset()
+        assert env.actions == [0, 1, 2]
+        assert new_env.actions == []
+    finally:
+        new_env.close()
+
+
+def test_fork_custom_benchmark(env: LlvmEnv):
+    benchmark = env.make_benchmark(EXAMPLE_BITCODE_FILE)
+    env.reset(benchmark=benchmark)
+
+    def ir(env):
+        """Strip the ModuleID line from IR."""
+        return "\n".join(env.ir.split("\n")[1:])
+
+    try:
+        new_env = env.fork()
+        assert ir(env) == ir(new_env)
+
+        new_env.reset()
+        assert ir(env) == ir(new_env)
+    finally:
+        new_env.close()
+
+
+FUZZ_TIME_SECONDS = 5
+A_FEW_RANDOM_ACTIONS = 10
+
+
+def test_fork_state_fuzz_test(env: LlvmEnv):
+    """Run random episodes and check that fork() produces equivalent state."""
+    end_time = time() + FUZZ_TIME_SECONDS
+    while time() < end_time:
+        env.reset()
+
+        # Take a few warmup steps to get an environment in a random state.
+        for _ in range(A_FEW_RANDOM_ACTIONS):
+            _, _, done, _ = env.step(env.action_space.sample())
+            if done:  # Broken episode, restart.
+                break
+        else:
+            # Fork the environment and check that the states are equivalent.
+            new_env = env.fork()
+            try:
+                assert env.state == new_env.state
+                # Check that environment states remain equal if identical
+                # subsequent steps are taken.
+                for _ in range(A_FEW_RANDOM_ACTIONS):
+                    action = env.action_space.sample()
+                    _, _, done_a, _ = env.step(action)
+                    _, _, done_b, _ = new_env.step(action)
+                    assert done_a == done_b
+                    if done_a:  # Broken episode, restart.
+                        break
+                    assert env.state == new_env.state
+            finally:
+                new_env.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/envs/llvm/llvm_env_test.py
+++ b/tests/envs/llvm/llvm_env_test.py
@@ -12,6 +12,7 @@ import compiler_gym
 from compiler_gym.envs import CompilerEnv, CompilerEnvState, llvm
 from compiler_gym.envs.llvm.llvm_env import LlvmEnv
 from compiler_gym.service.connection import CompilerGymServiceConnection
+from compiler_gym.views import ObservationSpaceSpec, RewardSpaceSpec
 from tests.test_main import main
 
 pytest_plugins = ["tests.envs.llvm.fixtures"]
@@ -194,6 +195,22 @@ def test_state_to_csv_from_csv(env: LlvmEnv):
     state_from_csv = CompilerEnvState.from_csv(env.state.to_csv())
     assert state_from_csv.reward == 10
     assert state == state_from_csv
+
+
+def test_set_observation_space_from_spec(env: LlvmEnv):
+    env.observation_space = env.observation.spaces["Autophase"]
+    obs = env.observation_space
+
+    env.observation_space = "Autophase"
+    assert env.observation_space == obs
+
+
+def test_set_reward_space_from_spec(env: LlvmEnv):
+    env.reward_space = env.reward.spaces["IrInstructionCount"]
+    reward = env.reward_space
+
+    env.reward_space = "IrInstructionCount"
+    assert env.reward_space == reward
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Calling `env.fork()` creates a duplicate environment with the current                                                                                                                                                                     
state. For long episodes, this may be more efficient than resetting a                                                                                                                                                                   
fresh state and replaying the episode.       

Example usage:

```py
>>> env = gym.make("llvm-v0")
# ... use env
>>> new_env = env.fork()
>>> new_env.actions == env.actions
True
```                                                                                                                                                                                           
                                                                                                                                                                                                                                        
This implementation is totally ad-hoc for LLVM. It creates a new                                                                                                                                                                        
compiler service and makes a temporary benchmark out of the current                                                                                                                                                                     
environment state by serializing to and reading from a bitcode file. A                                                                                                                                                                  
lower overhead `fork()` could be implemented on the C++ service side by                                                                                                                                                                   
creating a new `LlvmEnvironment` for the existing service, but that                                                                                                                                                                       
would require the addition of a new API call. Let's see if `fork()`                                                                                                                                                                       
performance becomes a key factor before pursuing that. 