### PR TITLE
Persist the bazel cache on CI test runs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,6 +49,24 @@ jobs:
                   python -m pip install -r compiler_gym/requirements.txt -r examples/requirements.txt -r tests/requirements.txt
               if: matrix.os == 'macos-latest'
 
+            - name: Persist bazel cache (linux)
+              uses: actions/cache@v2
+              with:
+                  path: ~/.cache/bazel/_bazel_runner
+                  key: ${{ runner.os }}-test-${{ matrix.python }}-${{ hashFiles('**/BUILD') }}
+                  restore-keys: |
+                      ${{ runner.os }}-test-${{ matrix.python }}-
+              if: matrix.os == 'ubuntu-latest'
+
+            - name: Persist bazel cache (macOS)
+              uses: actions/cache@v2
+              with:
+                  path: /private/var/tmp/_bazel_runner
+                  key: ${{ runner.os }}-test-${{ matrix.python }}-${{ hashFiles('**/BUILD') }}
+                  restore-keys: |
+                      ${{ runner.os }}-test-${{ matrix.python }}-
+              if: matrix.os == 'macos-latest'
+
             - name: Test
               run: make test
               env:
@@ -88,6 +106,24 @@ jobs:
                   brew install bazelisk
                   python -m pip install -r examples/requirements.txt
                   python -m pip install -r tests/requirements.txt
+              if: matrix.os == 'macos-latest'
+
+            - name: Persist bazel cache (linux)
+              uses: actions/cache@v2
+              with:
+                  path: ~/.cache/bazel/_bazel_runner
+                  key: ${{ runner.os }}-install-${{ matrix.python }}-${{ hashFiles('**/BUILD') }}
+                  restore-keys: |
+                      ${{ runner.os }}-install-${{ matrix.python }}-
+              if: matrix.os == 'ubuntu-latest'
+
+            - name: Persist bazel cache (macOS)
+              uses: actions/cache@v2
+              with:
+                  path: /private/var/tmp/_bazel_runner
+                  key: ${{ runner.os }}-install-${{ matrix.python }}-${{ hashFiles('**/BUILD') }}
+                  restore-keys: |
+                      ${{ runner.os }}-install-${{ matrix.python }}-
               if: matrix.os == 'macos-latest'
 
             - name: Test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -127,7 +127,9 @@ jobs:
               if: matrix.os == 'macos-latest'
 
             - name: Test
-              run: make install-test
+              run: |
+                  bazel clean --expunge
+                  make install-test
               env:
                   CC: clang
                   CXX: clang++


### PR DESCRIPTION
Starting a fresh bazel build in every build environment is wasteful and leads to a lot of redundant work. Persisting the bazel build cache will amortize these costs, and also help mitigate flakiness, e.g. #22.