### PR TITLE
Enable `make livedocs` to automatically rebuild on source change.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,10 +170,12 @@ GENERATED_DOCS := \
 	docs/source/installation.rst \
 	$(NULL)
 
-docs: $(GENERATED_DOCS) install
+gendocs: $(GENERATED_DOCS)
+
+docs: gendocs install
 	$(MAKE) -C docs html
 
-livedocs: $(GENERATED_DOCS) install
+livedocs: gendocs
 	$(MAKE) -C docs livehtml
 
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -9,7 +9,7 @@ help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 livehtml:
-	sphinx-autobuild "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	sphinx-autobuild "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) --pre-build 'make -C .. gendocs install' --watch ../compiler_gym $(O)
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).


### PR DESCRIPTION
Running `make livedocs` will now trigger a rebuild whenever the source
code is modified. Previously, one had to cancel the running server and
restart to trigger a new build.
