### PR TITLE
Temporarily disable flaky cBench benchmarks

### DIFF
--- a/compiler_gym/envs/llvm/datasets.py
+++ b/compiler_gym/envs/llvm/datasets.py
@@ -548,11 +548,12 @@ for i in range(1, 21):
         outs=["output.txt"],
     )
 
-    validator(
-        benchmark="benchmark://cBench-v0/bzip2",
-        cmd=f"$BIN -d -k -f -c $D/bzip2_data/{i}.bz2",
-        data=[f"bzip2_data/{i}.bz2"],
-    )
+    # TODO(cummins): Investigate.
+    # validator(
+    #     benchmark="benchmark://cBench-v0/bzip2",
+    #     cmd=f"$BIN -d -k -f -c $D/bzip2_data/{i}.bz2",
+    #     data=[f"bzip2_data/{i}.bz2"],
+    # )
 
     validator(
         benchmark="benchmark://cBench-v0/crc32",
@@ -566,11 +567,12 @@ for i in range(1, 21):
         data=[f"network_dijkstra_data/{i}.dat"],
     )
 
-    validator(
-        benchmark="benchmark://cBench-v0/gsm",
-        cmd=f"$BIN -fps -c $D/telecom_gsm_data/{i}.au",
-        data=[f"telecom_gsm_data/{i}.au"],
-    )
+    # TODO(cummins): Investigate.
+    # validator(
+    #     benchmark="benchmark://cBench-v0/gsm",
+    #     cmd=f"$BIN -fps -c $D/telecom_gsm_data/{i}.au",
+    #     data=[f"telecom_gsm_data/{i}.au"],
+    # )
 
     # TODO(cummins): ispell executable appears broken. Investigation needed.
     # validator(
@@ -579,19 +581,21 @@ for i in range(1, 21):
     #     data = [f"office_data/{i}.txt"],
     # )
 
-    validator(
-        benchmark="benchmark://cBench-v0/jpeg-c",
-        cmd=f"$BIN -dct int -progressive -outfile output.jpeg $D/consumer_jpeg_data/{i}.ppm",
-        data=[f"consumer_jpeg_data/{i}.ppm"],
-        outs=["output.jpeg"],
-    )
+    # TODO(cummins): Investigate.
+    # validator(
+    #     benchmark="benchmark://cBench-v0/jpeg-c",
+    #     cmd=f"$BIN -dct int -progressive -outfile output.jpeg $D/consumer_jpeg_data/{i}.ppm",
+    #     data=[f"consumer_jpeg_data/{i}.ppm"],
+    #     outs=["output.jpeg"],
+    # )
 
-    validator(
-        benchmark="benchmark://cBench-v0/jpeg-d",
-        cmd=f"$BIN -dct int -outfile output.ppm $D/consumer_jpeg_data/{i}.jpg",
-        data=[f"consumer_jpeg_data/{i}.jpg"],
-        outs=["output.ppm"],
-    )
+    # TODO(cummins): Investigate.
+    # validator(
+    #     benchmark="benchmark://cBench-v0/jpeg-d",
+    #     cmd=f"$BIN -dct int -outfile output.ppm $D/consumer_jpeg_data/{i}.jpg",
+    #     data=[f"consumer_jpeg_data/{i}.jpg"],
+    #     outs=["output.ppm"],
+    # )
 
     validator(
         benchmark="benchmark://cBench-v0/patricia",
@@ -646,49 +650,54 @@ for i in range(1, 21):
         linkopts=["-lm"],
     )
 
-    validator(
-        benchmark="benchmark://cBench-v0/tiff2bw",
-        cmd=f"$BIN $D/consumer_tiff_data/{i}.tif output.tif",
-        data=[f"consumer_tiff_data/{i}.tif"],
-        outs=["output.tif"],
-        linkopts=["-lm"],
-    )
+    # TODO(cummins): Investigate.
+    # validator(
+    #     benchmark="benchmark://cBench-v0/tiff2bw",
+    #     cmd=f"$BIN $D/consumer_tiff_data/{i}.tif output.tif",
+    #     data=[f"consumer_tiff_data/{i}.tif"],
+    #     outs=["output.tif"],
+    #     linkopts=["-lm"],
+    # )
 
-    validator(
-        benchmark="benchmark://cBench-v0/tiff2rgba",
-        cmd=f"$BIN $D/consumer_tiff_data/{i}.tif output.tif",
-        data=[f"consumer_tiff_data/{i}.tif"],
-        outs=["output.tif"],
-        linkopts=["-lm"],
-    )
+    # TODO(cummins): Investigate.
+    # validator(
+    #     benchmark="benchmark://cBench-v0/tiff2rgba",
+    #     cmd=f"$BIN $D/consumer_tiff_data/{i}.tif output.tif",
+    #     data=[f"consumer_tiff_data/{i}.tif"],
+    #     outs=["output.tif"],
+    #     linkopts=["-lm"],
+    # )
 
-    validator(
-        benchmark="benchmark://cBench-v0/tiffdither",
-        cmd=f"$BIN $D/consumer_tiff_data/{i}.bw.tif out.tif",
-        data=[f"consumer_tiff_data/{i}.bw.tif"],
-        outs=["out.tif"],
-        linkopts=["-lm"],
-    )
+    # TODO(cummins): Investigate.
+    # validator(
+    #     benchmark="benchmark://cBench-v0/tiffdither",
+    #     cmd=f"$BIN $D/consumer_tiff_data/{i}.bw.tif out.tif",
+    #     data=[f"consumer_tiff_data/{i}.bw.tif"],
+    #     outs=["out.tif"],
+    #     linkopts=["-lm"],
+    # )
 
-    validator(
-        benchmark="benchmark://cBench-v0/tiffmedian",
-        cmd=f"$BIN $D/consumer_tiff_data/{i}.nocomp.tif output.tif",
-        data=[f"consumer_tiff_data/{i}.nocomp.tif"],
-        outs=["output.tif"],
-        linkopts=["-lm"],
-    )
+    # TODO(cummins): Investigate.
+    # validator(
+    #     benchmark="benchmark://cBench-v0/tiffmedian",
+    #     cmd=f"$BIN $D/consumer_tiff_data/{i}.nocomp.tif output.tif",
+    #     data=[f"consumer_tiff_data/{i}.nocomp.tif"],
+    #     outs=["output.tif"],
+    #     linkopts=["-lm"],
+    # )
 
     # NOTE(cummins): On macOS the following benchmarks abort with an illegal
     # hardware instruction error.
     if sys.platform != "darwin":
-        validator(
-            benchmark="benchmark://cBench-v0/lame",
-            cmd=f"$BIN $D/consumer_data/{i}.wav output.mp3",
-            data=[f"consumer_data/{i}.wav"],
-            outs=["output.mp3"],
-            compare_output=False,
-            linkopts=["-lm"],
-        )
+        # TODO(cummins): Investigate.
+        # validator(
+        #     benchmark="benchmark://cBench-v0/lame",
+        #     cmd=f"$BIN $D/consumer_data/{i}.wav output.mp3",
+        #     data=[f"consumer_data/{i}.wav"],
+        #     outs=["output.mp3"],
+        #     compare_output=False,
+        #     linkopts=["-lm"],
+        # )
 
         validator(
             benchmark="benchmark://cBench-v0/ghostscript",

--- a/tests/envs/llvm/benchmark_semantics_validation_test.py
+++ b/tests/envs/llvm/benchmark_semantics_validation_test.py
@@ -18,11 +18,19 @@ pytest_plugins = ["tests.envs.llvm.fixtures"]
 # The set of cBench benchmarks which do not have support for semantics
 # validation.
 CBENCH_VALIDATION_EXCLUDE_LIST: Set[str] = {
+    "benchmark://cBench-v0/bzip2",
+    "benchmark://cBench-v0/gsm",
     "benchmark://cBench-v0/ispell",
+    "benchmark://cBench-v0/jpeg-c",
+    "benchmark://cBench-v0/jpeg-d",
+    "benchmark://cBench-v0/lame",
     "benchmark://cBench-v0/stringsearch2",
+    "benchmark://cBench-v0/tiff2bw",
+    "benchmark://cBench-v0/tiff2rgba",
+    "benchmark://cBench-v0/tiffdither",
+    "benchmark://cBench-v0/tiffmedian",
 }
 if sys.platform == "darwin":
-    CBENCH_VALIDATION_EXCLUDE_LIST.add("benchmark://cBench-v0/lame")
     CBENCH_VALIDATION_EXCLUDE_LIST.add("benchmark://cBench-v0/ghostscript")
 
 


### PR DESCRIPTION
Each of these benchmarks has been found to have issues when used for
difftesting, possibly due to user error, possibly due to misconfigured
code. Further investigation is needed. This reduces the number of
cBench benchmarks whose semantics can be validated to 11.