### PR TITLE
Prune some irrelevant passes from the LLVM action space.

### DIFF
--- a/compiler_gym/envs/llvm/service/passes/config.py
+++ b/compiler_gym/envs/llvm/service/passes/config.py
@@ -157,9 +157,15 @@ CREATE_PASS_NAME_MAP = {
 
 # A list of pass names that should be excluded from the action space.
 _EXCLUDED_PASSES = {
-    # Garbage collection.
+    # Irrelevant garbage collection passes.
     "StripGCRelocates",
     "PlaceBackedgeSafepointsImpl",
+    "PlaceSafepointsPass",
+    # Irrelevant Objective-C Automatic Reference Counting passes.
+    "ObjCarcapelimPass",
+    "ObjCarccontractPass",
+    "ObjCarcexpandPass",
+    "ObjCarcoptPass",
     # Doesn't use legacy pass constructor API, or requires additional
     # constructor arguments that are not available.
     "WholeProgramDevirt",
@@ -173,6 +179,9 @@ _EXCLUDED_PASSES = {
     "DAH",  # Bugpoint only.
     "MetaRenamerPass",
     "PAEvalPass",
+    "BarrierNoop",  # Used for debugging pass manager.
+    "StripNonLineTableDebugInfoPass",  # Debug stripping.
+    "StripDeadDebugInfoPass",  # Debug stripping.
     # Unwanted instrumentation passes.
     "BoundsCheckingLegacy",
     "ASanGlobalsMetadataWrapperPass",
@@ -185,14 +194,17 @@ _EXCLUDED_PASSES = {
     "FunctionImportPass",
     "DataFlowSanitizerPass",
     "InstrOrderFilePass",
-    # Profile-guided optimization instrumentation.
+    "PostInlineEntryExitInstrumenter",
+    # Profile-guided optimization or profiling.
     "PGOIndirectCallPromotionLegacyPass",
     "PGOInstrumentationUseLegacyPass",
     "PGOInstrumentationGenCreateVarLegacyPass",
     "PGOInstrumentationGenLegacyPass",
     "PGOInstrumentationUseLegacyPass",
     "PGOMemOpsizeOptLegacyPass",
+    "PgomemOpsizeOptLegacyPass",
     "InstrProfilingLegacyPass",
+    "ControlHeightReductionLegacyPass",
     # Microsoft's Control Flow Guard checks on Windows targets.
     # https://llvm.org/doxygen/CFGuard_8cpp.html
     "CFGuardCheckPass",


### PR DESCRIPTION
Deselect some passes that are obviously irrelevant (e.g. Objective-C
refcounting passes), used for debugging (e.g. BarrierNoop), or passes
that require profiling data as
input (e.g. PostInlineEntryexitinstrumenter).
