### PR TITLE
Fix runfiles_path() when called from non-{bazel,setuptools} context.

### DIFF
--- a/compiler_gym/util/runfiles_path.py
+++ b/compiler_gym/util/runfiles_path.py
@@ -6,6 +6,7 @@
 import os
 from pathlib import Path
 
+# NOTE(cummins): Moving this file may require updating this relative path.
 _PACKAGE_ROOT = Path(os.path.join(os.path.dirname(__file__), "../../")).resolve(
     strict=True
 )
@@ -19,11 +20,11 @@ def runfiles_path(relpath: str) -> Path:
     """
     # There are three ways of determining a runfiles path:
     #   1. Set the COMPILER_GYM_RUNFILES environment variable.
-    #   2. Using pkg_resources to find package data.
-    #   3. Using bazel's runfiles library to find data.
-    #
-    # The last two options depend on the calling context - whether the code
-    # was built by bazel or installed using setuptools.
+    #   2. Using the rules_python library that is provided by bazel. This will
+    #      fail if not being executed within a bazel sandbox.
+    #   3. Computing the path relative to the location of this file. This is the
+    #      fallback approach that is used for when the code has been installed
+    #      by setuptools.
     runfiles_path = os.environ.get("COMPILER_GYM_RUNFILES")
     if runfiles_path:
         return Path(runfiles_path) / relpath
@@ -36,7 +37,7 @@ def runfiles_path(relpath: str) -> Path:
                     "CompilerGym" if relpath == "." else f"CompilerGym/{relpath}"
                 )
             )
-        except ModuleNotFoundError:
+        except (ModuleNotFoundError, TypeError):
             return _PACKAGE_ROOT / relpath
 
 


### PR DESCRIPTION
The current runfiles_path() implementation covers the cases where the
calling context is from within a bazel sandbox, or after running `make
install`, but not the case for the "loose binary" case that results
from running a binary in bazel-bin.
