### PR TITLE
Save benchmark output by default

### DIFF
--- a/compiler_gym/util/statistics.py
+++ b/compiler_gym/util/statistics.py
@@ -9,7 +9,7 @@ def geometric_mean(iterable):
     vals = np.array(iterable)
     # Shortcut to return 0 when any element of the input is zero without
     # performaning (and printing a warning about) a division by zero below.
-    if not np.all(all):
+    if not np.all(vals):
         return 0
     a = np.log(vals)
     return np.exp(a.sum() / len(a))

--- a/tests/benchmarks/BUILD
+++ b/tests/benchmarks/BUILD
@@ -9,8 +9,6 @@ py_test(
     shard_count = 8,
     deps = [
         "//compiler_gym",
-        "//compiler_gym/envs",
-        "//compiler_gym/util",
         "//tests:test_main",
         "//tests/pytest_plugins:llvm",
     ],

--- a/tests/benchmarks/bench_test.py
+++ b/tests/benchmarks/bench_test.py
@@ -2,7 +2,20 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-"""Microbenchmarks for CompilerGym environments."""
+"""Microbenchmarks for CompilerGym environments.
+
+To run these benchmarks within bazel, compile with optimiztions and stream the
+test output:
+
+    $ bazel test -c opt --test_output=streamed //tests/benchmarks:bench_test
+
+A record of the benchmark results is stored in
+/tmp/compiler_gym/benchmarks/<device>/<run>_bench_test.json
+Compare multiple runs using:
+
+    $ pytest-benchmark compare --group-by=name --sort=fullname \
+        /tests/benchmarks/*_bench_test.json
+"""
 import gym
 import pytest
 
@@ -19,14 +32,21 @@ pytest_plugins = ["tests.pytest_plugins.llvm"]
 #
 # adpcm is small and jpeg-d is large. ghostscript is the largest but that
 # one takes too long.
-@pytest.fixture(params=["cBench-v0/adpcm", "cBench-v0/jpeg-d"])
+@pytest.fixture(
+    params=["cBench-v0/crc32", "cBench-v0/jpeg-d"],
+    ids=["fast_benchmark", "slow_benchmark"],
+)
 def benchmark_name(request) -> str:
     yield request.param
 
 
-# The observation benchmark is too slow for a large input.
-@pytest.fixture(params=["cBench-v0/adpcm"])
+@pytest.fixture(params=["cBench-v0/crc32"], ids=["fast_benchmark"])
 def fast_benchmark_name(request) -> str:
+    yield request.param
+
+
+@pytest.fixture(params=["-globaldce", "-gvn"], ids=["fast_action", "slow_action"])
+def action_name(request) -> str:
     yield request.param
 
 
@@ -46,9 +66,10 @@ def test_reset(benchmark, env: CompilerEnv, benchmark_name):
     benchmark(env.reset, benchmark_name)
 
 
-def test_step(benchmark, env: CompilerEnv, benchmark_name):
+def test_step(benchmark, env: CompilerEnv, benchmark_name, action_name):
     env.reset(benchmark_name)
-    benchmark(env.step, 0)
+    action = env.action_space.flags.index(action_name)
+    benchmark(env.step, action)
 
 
 def test_observation(
@@ -64,4 +85,11 @@ def test_reward(benchmark, env: CompilerEnv, benchmark_name, reward_space):
 
 
 if __name__ == "__main__":
-    main()
+    main(
+        extra_pytest_args=[
+            "--benchmark-storage=/tmp/compiler_gym/benchmarks",
+            "--benchmark-save=bench_test",
+            "-x",
+        ],
+        verbose_service_logging=False,
+    )

--- a/tests/benchmarks/bench_test.py
+++ b/tests/benchmarks/bench_test.py
@@ -84,6 +84,11 @@ def test_reward(benchmark, env: CompilerEnv, benchmark_name, reward_space):
     benchmark(lambda: env.reward[reward_space])
 
 
+def test_fork(benchmark, env: CompilerEnv, benchmark_name):
+    env.reset(benchmark_name)
+    benchmark(lambda: env.fork().close())
+
+
 if __name__ == "__main__":
     main(
         extra_pytest_args=[

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -12,7 +12,9 @@ import pytest
 import compiler_gym  # noqa Register environments.
 
 
-def main(extra_pytest_args: Optional[List[str]] = None):
+def main(
+    extra_pytest_args: Optional[List[str]] = None, verbose_service_logging: bool = True
+):
     """The main entry point for the pytest runner.
 
     An example file which uses this:
@@ -29,6 +31,8 @@ def main(extra_pytest_args: Optional[List[str]] = None):
 
     :param extra_pytest_args: A list of additional command line options to pass
         to pytest.
+    :param verbose_service_logging: Whether to enable verbose CompilerGym
+        service logging, useful for debugging failing tests.
     """
     # Use isolated data directories for running tests.
     os.environ["COMPILER_GYM_SITE_DATA"] = "/tmp/compiler_gym/tests/site_data"
@@ -44,7 +48,8 @@ def main(extra_pytest_args: Optional[List[str]] = None):
 
     # Use verbose backend debugging when running tests. If a test fails, the debugging
     # output will be included in the captured stderr.
-    os.environ["COMPILER_GYM_SERVICE_DEBUG"] = "1"
+    if verbose_service_logging:
+        os.environ["COMPILER_GYM_SERVICE_DEBUG"] = "1"
 
     pytest_args = sys.argv + ["-vv"]
     # Support for sharding. If a py_test target has the shard_count attribute


### PR DESCRIPTION
Record benchmark output as JSON for comparison against previous
runs. Also name the fast/slow benchmarks and run the benchmarks for
slightly longer.

## Usage

```sh
# on development
$ bazel test -c opt --test_output=streamed //tests/benchmarks:bench_test
# git checkout some other branch and re-run
$ bazel test -c opt --test_output=streamed //tests/benchmarks:bench_test
# compare the two runs
$ pytest-benchmark compare --group-by=name /tmp/compiler_gym/benchmarks/*/*.json --sort=fullname
```

