### PR TITLE
Generate enum declarations for LLVM capabilities.

### DIFF
--- a/compiler_gym/envs/llvm/BUILD
+++ b/compiler_gym/envs/llvm/BUILD
@@ -5,7 +5,10 @@
 
 py_library(
     name = "llvm",
-    srcs = ["__init__.py"],
+    srcs = [
+        "__init__.py",
+        ":specs.py",
+    ],
     data = [
         "//compiler_gym/envs/llvm/service:compiler_gym-llvm-service",
     ],
@@ -69,4 +72,18 @@ py_library(
         "//compiler_gym/spaces",
         "//compiler_gym/views",
     ],
+)
+
+genrule(
+    name = "specs",
+    srcs = ["//compiler_gym/envs/llvm/service:compiler_gym-llvm-service"],
+    outs = ["specs.py"],
+    cmd = "$(location :make_specs) $(location //compiler_gym/envs/llvm/service:compiler_gym-llvm-service) $@",
+    tools = [":make_specs"],
+)
+
+py_binary(
+    name = "make_specs",
+    srcs = ["make_specs.py"],
+    deps = [":llvm_env"],
 )

--- a/compiler_gym/envs/llvm/__init__.py
+++ b/compiler_gym/envs/llvm/__init__.py
@@ -11,6 +11,7 @@ from compiler_gym.envs.llvm.benchmarks import (
     make_benchmark,
 )
 from compiler_gym.envs.llvm.llvm_env import LlvmEnv
+from compiler_gym.envs.llvm.specs import observation_spaces, reward_spaces
 from compiler_gym.util.registration import register
 from compiler_gym.util.runfiles_path import runfiles_path
 
@@ -20,6 +21,8 @@ __all__ = [
     "ClangInvocation",
     "get_system_includes",
     "LLVM_SERVICE_BINARY",
+    "observation_spaces",
+    "reward_spaces",
 ]
 
 LLVM_SERVICE_BINARY = runfiles_path(

--- a/compiler_gym/envs/llvm/make_specs.py
+++ b/compiler_gym/envs/llvm/make_specs.py
@@ -1,0 +1,34 @@
+"""Generate enum declarations for LLVM service capabilities.
+
+Usage: make_specs.py <service_binary> <output_path>.
+"""
+# TODO: As we add support for more compilers we could generalize this script
+# to work with other compiler services rather than hardcoding to LLVM.
+import sys
+from pathlib import Path
+
+from compiler_gym.envs.llvm.llvm_env import LlvmEnv
+
+
+def main(argv):
+    assert len(argv) == 3, "Usage: make_specs.py <service_binary> <output_path>"
+    service_path, output_path = argv[1:]
+
+    env = LlvmEnv(Path(service_path))
+    try:
+        with open(output_path, "w") as f:
+            print("from enum import Enum", file=f)
+            print(file=f)
+            print("class observation_spaces(Enum):", file=f)
+            for name in env.observation.spaces:
+                print(f'    {name} = "{name}"', file=f)
+            print(file=f)
+            print("class reward_spaces(Enum):", file=f)
+            for name in env.reward.spaces:
+                print(f'    {name} = "{name}"', file=f)
+    finally:
+        env.close()
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/compiler_gym/views/observation.py
+++ b/compiler_gym/views/observation.py
@@ -2,7 +2,7 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-from typing import Callable, List
+from typing import Callable, Dict, List
 
 from compiler_gym.service import ServiceError, observation_t
 from compiler_gym.service.proto import ObservationSpace, StepReply, StepRequest
@@ -33,12 +33,13 @@ class ObservationView(object):
     ):
         if not spaces:
             raise ValueError("No observation spaces")
-        self.spaces = {
-            s.name: ObservationSpaceSpec.from_proto(i, s) for i, s in enumerate(spaces)
-        }
-        self.session_id = -1
+        self.spaces: Dict[str, ObservationSpaceSpec] = {}
 
         self._get_observation = get_observation
+        self.session_id = -1
+
+        for i, s in enumerate(spaces):
+            self._add_space(ObservationSpaceSpec.from_proto(i, s))
 
     def __getitem__(self, observation_space: str) -> observation_t:
         """Request an observation from the given space.
@@ -58,6 +59,15 @@ class ObservationView(object):
                 f"Requested 1 observation but received {len(reply.observation)}"
             )
         return space.translate(reply.observation[0])
+
+    def _add_space(self, space: ObservationSpaceSpec):
+        """Register a new space."""
+        self.spaces[space.id] = space
+        # Bind a new method to this class that is a callback to compute the
+        # given observation space. E.g. if a new space is added with ID
+        # `FooBar`, this observation can be computed using
+        # env.observation.FooBar().
+        setattr(self, space.id, lambda: self[space.id])
 
     def add_derived_space(
         self,
@@ -87,7 +97,7 @@ class ObservationView(object):
             :func:`ObservationSpaceSpec.make_derived_space <compiler_gym.views.ObservationSpaceSpec.make_derived_space>`.
         """
         base_space = self.spaces[base_id]
-        self.spaces[id] = base_space.make_derived_space(id=id, **kwargs)
+        self._add_space(base_space.make_derived_space(id=id, **kwargs))
 
     def __repr__(self):
         return f"ObservationView[{', '.join(sorted(self.spaces.keys()))}]"

--- a/compiler_gym/views/reward.py
+++ b/compiler_gym/views/reward.py
@@ -30,9 +30,12 @@ class RewardView(object):
         spaces: List[Reward],
         observation_view: ObservationView,
     ):
-        self.spaces: Dict[str, Reward] = {s.id: s for s in spaces}
+        self.spaces: Dict[str, Reward] = {}
         self.previous_action = None
         self._observation_view = observation_view
+
+        for space in spaces:
+            self._add_space(space)
 
     def __getitem__(self, reward_space: str) -> float:
         """Request an observation from the given space.
@@ -68,4 +71,12 @@ class RewardView(object):
         """
         if space.id in self.spaces:
             warnings.warn(f"Replacing existing reward space '{space.id}'")
+        self._add_space(space)
+
+    def _add_space(self, space: Reward):
+        """Register a new space."""
         self.spaces[space.id] = space
+        # Bind a new method to this class that is a callback to compute the
+        # given reward space. E.g. if a new space is added with ID `FooBar`,
+        # this reward can be computed using env.reward.FooBar().
+        setattr(self, space.id, lambda: self[space.id])

--- a/tests/fuzzing/BUILD
+++ b/tests/fuzzing/BUILD
@@ -8,7 +8,7 @@
 py_test(
     name = "llvm_commandline_opt_equivalence_fuzz_test",
     srcs = ["llvm_commandline_opt_equivalence_fuzz_test.py"],
-    flaky = 1,
+    tags = ["manual"],
     deps = [
         "//compiler_gym",
         "//tests:test_main",
@@ -21,7 +21,7 @@ py_test(
 py_test(
     name = "llvm_deterministic_action_fuzz_test",
     srcs = ["llvm_deterministic_action_fuzz_test.py"],
-    flaky = 1,
+    tags = ["manual"],
     deps = [
         "//compiler_gym",
         "//tests:test_main",
@@ -32,7 +32,7 @@ py_test(
 py_test(
     name = "llvm_fork_env_fuzz_test",
     srcs = ["llvm_fork_env_fuzz_test.py"],
-    flaky = 1,
+    tags = ["manual"],
     deps = [
         "//compiler_gym",
         "//tests:test_main",
@@ -43,7 +43,7 @@ py_test(
 py_test(
     name = "llvm_trajectory_replay_fuzz_test",
     srcs = ["llvm_trajectory_replay_fuzz_test.py"],
-    flaky = 1,
+    tags = ["manual"],
     deps = [
         "//compiler_gym",
         "//tests:test_main",
@@ -55,7 +55,7 @@ py_test(
 py_test(
     name = "llvm_validate_fuzz_test",
     srcs = ["llvm_validate_fuzz_test.py"],
-    flaky = 1,
+    tags = ["manual"],
     deps = [
         "//compiler_gym",
         "//tests:test_main",
@@ -68,8 +68,8 @@ py_test(
     timeout = "long",
     srcs = ["llvm_stress_fuzz_test.py"],
     data = ["//compiler_gym/third_party/llvm:llvm-stress"],
-    flaky = 1,
     shard_count = 20,
+    tags = ["manual"],
     deps = [
         "//compiler_gym",
         "//tests:test_main",

--- a/tests/llvm/llvm_env_test.py
+++ b/tests/llvm/llvm_env_test.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 """Integrations tests for the LLVM CompilerGym environments."""
 from pathlib import Path
+from enum import Enum
 from typing import List
 
 import gym
@@ -267,6 +268,11 @@ def test_ir_sha1(env: LlvmEnv, tmpwd: Path):
 
     after = env.ir_sha1
     assert before != after
+
+
+def test_generate_enum_declarations(env: LlvmEnv):
+    assert issubclass(llvm.observation_spaces, Enum)
+    assert issubclass(llvm.reward_spaces, Enum)
 
 
 if __name__ == "__main__":

--- a/tests/views/observation_test.py
+++ b/tests/views/observation_test.py
@@ -112,6 +112,10 @@ def test_observed_value_types():
             Observation(double_list=DoubleList(value=[1.0, 2.0])),
             Observation(int64_list=Int64List(value=[-5, 15])),
             Observation(binary_value=b"Hello, bytes\0"),
+            Observation(string_value="Hello, IR"),
+            Observation(double_list=DoubleList(value=[1.0, 2.0])),
+            Observation(int64_list=Int64List(value=[-5, 15])),
+            Observation(binary_value=b"Hello, bytes\0"),
         ]
     )
     observation = ObservationView(mock, spaces)
@@ -133,6 +137,26 @@ def test_observed_value_types():
 
     # Check that the correct observation_space_list indices were used.
     assert mock.called_observation_spaces == [0, 2, 1, 3]
+    mock.called_observation_spaces = []
+
+    # Repeat the above tests using the generated bound methods.
+    value = observation.ir()
+    assert isinstance(value, str)
+    assert value == "Hello, IR"
+
+    value = observation.dfeat()
+    np.testing.assert_array_almost_equal(value, [1.0, 2.0])
+    assert value.dtype == np.float64
+
+    value = observation.features()
+    np.testing.assert_array_equal(value, [-5, 15])
+    assert value.dtype == np.int64
+
+    value = observation.binary()
+    assert value == b"Hello, bytes\0"
+
+    # Check that the correct observation_space_list indices were used.
+    assert mock.called_observation_spaces == [0, 2, 1, 3]
 
 
 def test_add_derived_space():
@@ -143,7 +167,10 @@ def test_add_derived_space():
         ),
     ]
     mock = MockGetObservation(
-        ret=[Observation(string_value="Hello, world!")],
+        ret=[
+            Observation(string_value="Hello, world!"),
+            Observation(string_value="Hello, world!"),
+        ],
     )
     observation = ObservationView(mock, spaces)
     observation.add_derived_space(
@@ -156,6 +183,13 @@ def test_add_derived_space():
     )
 
     value = observation["ir_len"]
+    assert isinstance(value, list)
+    assert value == [
+        len("Hello, world!"),
+    ]
+
+    # Repeat the above test using the generated bound method.
+    value = observation.ir_len()
     assert isinstance(value, list)
     assert value == [
         len("Hello, world!"),

--- a/tests/views/reward_test.py
+++ b/tests/views/reward_test.py
@@ -52,5 +52,19 @@ def test_reward_values():
     assert value == 10
 
 
+def test_reward_values_bound_methods():
+    spaces = [
+        MockReward(id="codesize", ret=[-5]),
+        MockReward(id="runtime", ret=[10]),
+    ]
+    reward = RewardView(spaces, MockObservationView())
+
+    value = reward.codesize()
+    assert value == -5
+
+    value = reward.runtime()
+    assert value == 10
+
+
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This adds new enums `compiler_gym.envs.llvm.observation_spaces` and
`compiler_gym.envs.llvm.reward_spaces` that define the string names of
the available LLVM observation and reward spaces.

In https://github.com/facebookresearch/CompilerGym/issues/72#issuecomment-778216106 I suggested adding this feature to `compiler_gym.bin.service`. This turned out to be a bit tricky without introducing a circular dependency. Instead, I made a small ad-hoc script to generate the enums.

Fixes #72.
