### PR TITLE
Runs random walk in gym env and remove redundant actions

### DIFF
--- a/examples/actor_critic.py
+++ b/examples/actor_critic.py
@@ -120,7 +120,7 @@ class CustomEnv:
         self._env = gym.make("llvm-v0", reward_space=FLAGS.reward)
         try:
             self._env.require_dataset("cBench-v0")
-            self._env.reset(benchmark="benchmark://"+FLAGS.benchmark)
+            self._env.reset(benchmark=FLAGS.benchmark)
 
             # Project onto the subset of transformations that have
             # been specified to be used.

--- a/examples/actor_critic.py
+++ b/examples/actor_critic.py
@@ -120,7 +120,7 @@ class CustomEnv:
         self._env = gym.make("llvm-v0", reward_space=FLAGS.reward)
         try:
             self._env.require_dataset("cBench-v0")
-            self._env.reset(benchmark="benchmark://" + FLAGS.benchmark)
+            self._env.reset(benchmark=FLAGS.benchmark)
 
             # Project onto the subset of transformations that have
             # been specified to be used.

--- a/examples/actor_critic.py
+++ b/examples/actor_critic.py
@@ -120,7 +120,7 @@ class CustomEnv:
         self._env = gym.make("llvm-v0", reward_space=FLAGS.reward)
         try:
             self._env.require_dataset("cBench-v0")
-            self._env.reset(benchmark="benchmark://"+FLAGS.benchmark)
+            self._env.reset(benchmark="benchmark://" + FLAGS.benchmark)
 
             # Project onto the subset of transformations that have
             # been specified to be used.

--- a/examples/actor_critic.py
+++ b/examples/actor_critic.py
@@ -120,7 +120,7 @@ class CustomEnv:
         self._env = gym.make("llvm-v0", reward_space=FLAGS.reward)
         try:
             self._env.require_dataset("cBench-v0")
-            self._env.reset(benchmark=FLAGS.benchmark)
+            self._env.reset(benchmark="benchmark://"+FLAGS.benchmark)
 
             # Project onto the subset of transformations that have
             # been specified to be used.

--- a/examples/random_walk.py
+++ b/examples/random_walk.py
@@ -10,8 +10,9 @@ Example usage:
     $ python3 examples/random_walk.py --env=llvm-v0 --step_min=100 --step_max=100 \
         --benchmark=cBench-v0/dijkstra --reward=IrInstructionCount
 """
-import random
 import hashlib
+import random
+
 import humanize
 from absl import app, flags
 
@@ -42,8 +43,10 @@ def run_random_walk(env: CompilerEnv, step_count: int) -> None:
 
     "Use hashes of the environment to record its internal state"
     hashes, actions, rewards = [], [], []
+
     def encode_env_state(env):
         return hashlib.sha1(env.ir.encode("utf-8")).hexdigest()
+
     step_num = 0
     with Timer() as episode_time:
         env.reset()
@@ -87,7 +90,9 @@ def run_random_walk(env: CompilerEnv, step_count: int) -> None:
 
     def minimize_action_sequence(hashes, actions):
         """First pass removes actions that did not change the internal states"""
-        actions = [actions[i] for i in range(len(actions)) if hashes[i] != hashes[i+1]]
+        actions = [
+            actions[i] for i in range(len(actions)) if hashes[i] != hashes[i + 1]
+        ]
         """Second pass removes cancelling actions in the trajectory"""
         cancelling_dict = {"mem2reg": "reg2mem"}
         for act, counteract in cancelling_dict.items():

--- a/examples/random_walk.py
+++ b/examples/random_walk.py
@@ -4,23 +4,11 @@
 # LICENSE file in the root directory of this source tree.
 """Perform a random walk of the action space of a CompilerGym environment.
 
-This program launches a CompilerGym service and runs a random number of steps, at
-each step selecting a random action, and recording the observations and rewards
-to stdout.
-
 Example usage:
 
-    # Build the CompilerGym service binary that you want to use.
-    $ bazel build -c opt //examples/example_compiler_gym_service
-
-    # Run a random walk.
-    $ bazel run -c opt //compiler_gym/bin:random_walk -- \
-        --local_service_binary=$PWD/bazel-bin/examples/example_compiler_gym_service/service/service \
-        --program=foo \
-        --observation=features \
-        --reward=codesize \
-        --step_min=100 \
-        --step_max=100
+    # Run a random walk on cBench example program using instruction count reward.
+    $ python3 examples/random_walk.py --env=llvm-v0 --step_min=100 --step_max=100
+    --benchmark=benchmark://cBench-v0/dijkstra --reward=IrInstructionCount
 """
 import random
 from typing import List
@@ -44,16 +32,15 @@ flags.DEFINE_integer("step_max", 256, "The maximum number of steps.")
 FLAGS = flags.FLAGS
 
 
-def run_random_walk(env: CompilerEnv, step_count: int) -> List[float]:
+def run_random_walk(env: CompilerEnv, step_count: int) -> None:
     """Perform a random walk of the action space.
 
     :param env: The environment to use.
     :param step_count: The number of steps to run. This value is an upper bound -
         fewer steps will be performed if any of the actions lead the
         environment to end the episode.
-    :return: The list of observed rewards.
     """
-    rewards = []
+    rewards, actions = [],[]
 
     step_num = 0
     with Timer() as episode_time:
@@ -68,6 +55,7 @@ def run_random_walk(env: CompilerEnv, step_count: int) -> List[float]:
                 f"(changed={not info.get('action_had_no_effect')})"
             )
             rewards.append(reward)
+            actions.append(env.action_space.names[action_index])
             print(f"Reward:       {reward}")
             if env._eager_observation:
                 print(f"Observation:\n{observation}")
@@ -77,22 +65,25 @@ def run_random_walk(env: CompilerEnv, step_count: int) -> List[float]:
                 break
         env.close()
 
-    def reward_delta(reward):
-        delta = rewards[0] / max(reward, 1e-9) - 1
-        return emph(f"{'+' if delta >= 0 else ''}{delta:.2%}")
+    def reward_percentage(reward, rewards):
+        if sum(rewards) == 0:
+            return 0
+        percentage = reward / sum(rewards)
+        return emph(f"{'+' if percentage >= 0 else ''}{percentage:.2%}")
 
     print(
         f"\nCompleted {emph(humanize.intcomma(step_num))} steps in {episode_time} "
         f"({step_num / episode_time.time:.1f} steps / sec)."
     )
-    print(f"Init reward:  {rewards[0]}")
-    print(f"Final reward: {rewards[-1]} ({reward_delta(rewards[-1])})")
+    print(f"Total reward: {sum(rewards)}")
     print(
-        f"Max reward:   {max(rewards)} ({reward_delta(max(rewards))} "
+        f"Max reward:   {max(rewards)} ({reward_percentage(max(rewards), rewards)} "
         f"at step {humanize.intcomma(rewards.index(max(rewards)) + 1)})"
     )
-    return rewards
-
+    def remove_no_change(rewards, actions):
+        return [a for (r, a) in zip(rewards, actions) if r != 0]
+    actions = remove_no_change(rewards, actions)
+    print("Effective actions from trajectory: " + ", ".join(actions))
 
 def main(argv):
     """Main entry point."""

--- a/examples/random_walk.py
+++ b/examples/random_walk.py
@@ -11,7 +11,6 @@ Example usage:
     --benchmark=benchmark://cBench-v0/dijkstra --reward=IrInstructionCount
 """
 import random
-from typing import List
 
 import humanize
 from absl import app, flags
@@ -40,7 +39,7 @@ def run_random_walk(env: CompilerEnv, step_count: int) -> None:
         fewer steps will be performed if any of the actions lead the
         environment to end the episode.
     """
-    rewards, actions = [],[]
+    rewards, actions = [], []
 
     step_num = 0
     with Timer() as episode_time:
@@ -80,10 +79,13 @@ def run_random_walk(env: CompilerEnv, step_count: int) -> None:
         f"Max reward:   {max(rewards)} ({reward_percentage(max(rewards), rewards)} "
         f"at step {humanize.intcomma(rewards.index(max(rewards)) + 1)})"
     )
+
     def remove_no_change(rewards, actions):
         return [a for (r, a) in zip(rewards, actions) if r != 0]
+
     actions = remove_no_change(rewards, actions)
     print("Effective actions from trajectory: " + ", ".join(actions))
+
 
 def main(argv):
     """Main entry point."""

--- a/examples/random_walk.py
+++ b/examples/random_walk.py
@@ -7,12 +7,11 @@
 Example usage:
 
     # Run a random walk on cBench example program using instruction count reward.
-    $ python3 examples/random_walk.py --env=llvm-v0 --step_min=100 --step_max=100
-    --benchmark=benchmark://cBench-v0/dijkstra --reward=IrInstructionCount
+    $ python3 examples/random_walk.py --env=llvm-v0 --step_min=100 --step_max=100 \
+        --benchmark=cBench-v0/dijkstra --reward=IrInstructionCount
 """
 import random
-from typing import List
-
+import hashlib
 import humanize
 from absl import app, flags
 
@@ -40,11 +39,15 @@ def run_random_walk(env: CompilerEnv, step_count: int) -> None:
         fewer steps will be performed if any of the actions lead the
         environment to end the episode.
     """
-    rewards, actions = [],[]
 
+    "Use hashes of the environment to record its internal state"
+    hashes, actions, rewards = [], [], []
+    def encode_env_state(env):
+        return hashlib.sha1(env.ir.encode("utf-8")).hexdigest()
     step_num = 0
     with Timer() as episode_time:
         env.reset()
+        hashes.append(encode_env_state(env))
         for step_num in range(1, step_count + 1):
             action_index = env.action_space.sample()
             with Timer() as step_time:
@@ -54,8 +57,9 @@ def run_random_walk(env: CompilerEnv, step_count: int) -> None:
                 f"Action:       {env.action_space.names[action_index]} "
                 f"(changed={not info.get('action_had_no_effect')})"
             )
-            rewards.append(reward)
+            hashes.append(encode_env_state(env))
             actions.append(env.action_space.names[action_index])
+            rewards.append(reward)
             print(f"Reward:       {reward}")
             if env._eager_observation:
                 print(f"Observation:\n{observation}")
@@ -80,10 +84,38 @@ def run_random_walk(env: CompilerEnv, step_count: int) -> None:
         f"Max reward:   {max(rewards)} ({reward_percentage(max(rewards), rewards)} "
         f"at step {humanize.intcomma(rewards.index(max(rewards)) + 1)})"
     )
-    def remove_no_change(rewards, actions):
-        return [a for (r, a) in zip(rewards, actions) if r != 0]
-    actions = remove_no_change(rewards, actions)
+
+    def minimize_action_sequence(hashes, actions):
+        """First pass removes actions that did not change the internal states"""
+        actions = [actions[i] for i in range(len(actions)) if hashes[i] != hashes[i+1]]
+        """Second pass removes cancelling actions in the trajectory"""
+        cancelling_dict = {"mem2reg": "reg2mem"}
+        for act, counteract in cancelling_dict.items():
+            """For each pair, runs through actions once and find pairs to be removed"""
+            cancelling_state = 0
+            last_act_ind = -1
+            remove_ind = []
+            for i, a in enumerate(actions):
+                "Cancel actions if the opposite was found last. After cancelling, reset to neutral."
+                if a == act:
+                    if cancelling_state < 0:
+                        remove_ind += [last_act_ind, i]
+                        cancelling_state = 0
+                    else:
+                        cancelling_state = 1
+                        last_act_ind = i
+                elif a == counteract:
+                    if cancelling_state > 0:
+                        remove_ind += [last_act_ind, i]
+                        cancelling_state = 0
+                    else:
+                        cancelling_state = -1
+                        last_act_ind = i
+        return [a for i, a in enumerate(actions) if i not in set(remove_ind)]
+
+    actions = minimize_action_sequence(hashes, actions)
     print("Effective actions from trajectory: " + ", ".join(actions))
+
 
 def main(argv):
     """Main entry point."""

--- a/examples/random_walk.py
+++ b/examples/random_walk.py
@@ -10,9 +10,8 @@ Example usage:
     $ python3 examples/random_walk.py --env=llvm-v0 --step_min=100 --step_max=100 \
         --benchmark=cBench-v0/dijkstra --reward=IrInstructionCount
 """
-import hashlib
 import random
-
+import hashlib
 import humanize
 from absl import app, flags
 
@@ -43,10 +42,8 @@ def run_random_walk(env: CompilerEnv, step_count: int) -> None:
 
     "Use hashes of the environment to record its internal state"
     hashes, actions, rewards = [], [], []
-
     def encode_env_state(env):
         return hashlib.sha1(env.ir.encode("utf-8")).hexdigest()
-
     step_num = 0
     with Timer() as episode_time:
         env.reset()
@@ -90,9 +87,7 @@ def run_random_walk(env: CompilerEnv, step_count: int) -> None:
 
     def minimize_action_sequence(hashes, actions):
         """First pass removes actions that did not change the internal states"""
-        actions = [
-            actions[i] for i in range(len(actions)) if hashes[i] != hashes[i + 1]
-        ]
+        actions = [actions[i] for i in range(len(actions)) if hashes[i] != hashes[i+1]]
         """Second pass removes cancelling actions in the trajectory"""
         cancelling_dict = {"mem2reg": "reg2mem"}
         for act, counteract in cancelling_dict.items():

--- a/examples/random_walk.py
+++ b/examples/random_walk.py
@@ -7,8 +7,8 @@
 Example usage:
 
     # Run a random walk on cBench example program using instruction count reward.
-    $ python3 examples/random_walk.py --env=llvm-v0 --step_min=100 --step_max=100
-    --benchmark=benchmark://cBench-v0/dijkstra --reward=IrInstructionCount
+    $ python3 examples/random_walk.py --env=llvm-v0 --step_min=100 --step_max=100 \
+      --benchmark=cBench-v0/dijkstra --reward=IrInstructionCount
 """
 import random
 


### PR DESCRIPTION
Fixes #{issue number}
Use reward and environment identical to actor critic example without having to locally compile the environment. Adapted rewards as well. 
Example output: 
```

=== Step 100 ===
Action:       -consthoist (changed=False)
Reward:       0.0
Step time:    763.2us

Completed 100 steps in 2.098s (47.7 steps / sec).
Total reward: -14.0
Max reward:   75.0 (-535.71% at step 47)
Effective actions from trajectory: -loop-extract-single, -gvn-hoist, -lcssa, -gvn, -lcssa, -loop-extract-single, -dce, -loop-extract, -structurizecfg
```

Random walk typically increase lr count rather then reducing them it seems. 