### PR TITLE
[readme] Add a note on changing directory to import compiler_gym.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ To build and install the python package, run:
 
     $ make install
 
+**NOTE:** To use the python code that is installed by `make install` you must
+leave the root directory of this repository. Attempting to import `compiler_gym`
+while in the root of this repository will cause import errors.
+
 When you are finished, you can deactivate and delete the conda
 environment using:
 

--- a/compiler_gym/__init__.py
+++ b/compiler_gym/__init__.py
@@ -18,7 +18,16 @@ is available through :code:`compiler_gym.COMPILER_GYM_ENVS`:
     >>> compiler_gym.COMPILER_GYM_ENVS
     ['llvm-v0', 'llvm-ic-v0', 'llvm-autophase-ic-v0', 'llvm-ir-ic-v0']
 """
-from compiler_gym.util.version import __version__  # isort:skip
+try:
+    from compiler_gym.util.version import __version__  # isort:skip
+except ModuleNotFoundError as e:
+    # NOTE(https://github.com/facebookresearch/CompilerGym/issues/76): Handler
+    # for a particularly unhelpful error message.
+    raise ModuleNotFoundError(
+        f"{e}.\nAre you running in the root of the CompilerGym repository?\n"
+        "If so, please change to a different directory so that `import "
+        "compiler_gym` will work."
+    ) from e
 
 from compiler_gym.envs import COMPILER_GYM_ENVS, CompilerEnv, observation_t, step_t
 from compiler_gym.random_search import random_search


### PR DESCRIPTION
If you try to import `compiler_gym` from the root of this repository
you will receive an import error because python tries to use the
local directory rather than the installed package.

This problem is a pure "gotcha", and error message produced is
confusing and unfriendly. See #76.
