### PR TITLE
[bin] Increase contrast for shell prompt.

### DIFF
--- a/compiler_gym/bin/manual_env.py
+++ b/compiler_gym/bin/manual_env.py
@@ -172,6 +172,7 @@ from compiler_gym.datasets.dataset import require
 from compiler_gym.envs import CompilerEnv
 from compiler_gym.util.flags.benchmark_from_flags import benchmark_from_flags
 from compiler_gym.util.flags.env_from_flags import env_from_flags
+from compiler_gym.util.shell_format import emph
 from compiler_gym.util.tabulate import tabulate
 from compiler_gym.util.timer import Timer
 
@@ -213,8 +214,7 @@ class CompilerGymShell(cmd.Cmd):
     intro = """Welcome to the CompilerGym Shell!
 ---------------------------------
 Type help or ? for more information.
-The 'tutorial' command will give a step by step guide.
-"""
+The 'tutorial' command will give a step by step guide."""
 
     def __init__(self, env: CompilerEnv):
         """Initialise with an environment.
@@ -275,7 +275,8 @@ The 'tutorial' command will give a step by step guide.
                 bname = bname[len("benchmark://") :]
         else:
             bname = "NO-BENCHMARK"
-        self.prompt = f"compilergym:{bname}> "
+        prompt = f"compilergym:{bname}>"
+        self.prompt = f"\n{emph(prompt)} "
 
     def simple_complete(self, text, options):
         """Return a list of options that match the text prefix"""


### PR DESCRIPTION
This is total bikeshedding, but I find it easier to scan through shell output when the prompt is a different color and when there is a linebreak between commands:

```
$ python -m compiler_gym.bin.manual_env --env=llvm-ic-v0 --benchmark=cBench-v0/dijkstra
Initialized environment in 111.6ms
Welcome to the CompilerGym Shell!
---------------------------------
Type help or ? for more information.
The 'tutorial' command will give a step by step guide.

compilergym:cBench-v0/dijkstra> reset
Reset in 85.2ms

compilergym:cBench-v0/dijkstra> action -mem2reg
Action -mem2reg
Reward: 0.625806
Actions -mem2reg in 1.1ms with reward 0.6258064516129033.

compilergym:cBench-v0/dijkstra> action -reg2mem
Action -reg2mem
Reward: -0.703226
Actions -reg2mem in 909.6us with reward -0.7032258064516129.

compilergym:cBench-v0/dijkstra> stack
   Depth | Action   | Effect   | Done   |    Reward |   Cumulative Reward
---------+----------+----------+--------+-----------+---------------------
       4 | -reg2mem | True     | False  | -0.664516 |           -0.116129
       3 | -mem2reg | True     | False  |  0.625806 |            0.548387
       2 | -reg2mem | True     | False  | -0.703226 |           -0.077419
       1 | -mem2reg | True     | False  |  0.625806 |            0.625806
       0 | <init>   | False    | False  |  0        |            0
```