### PR TITLE
Fix error when running tutorial

### DIFF
--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -161,9 +161,9 @@ The observation space is described by
 The :ref:`Autophase <llvm/index:Autophase>` observation space is a 56-dimension
 vector of integers:
 
-    >>> env.observation_space.shape
+    >>> env.observation_space.space.shape
     (56,)
-    >>> env.observation_space.dtype
+    >>> env.observation_space.space.dtype
     dtype('int64')
 
 The upper and lower bounds of the reward signal are described by


### PR DESCRIPTION
When running the tutorial in CoLab I got 2 errors:
AttributeError: 'ObservationSpaceSpec' object has no attribute 'shape'
AttributeError: 'ObservationSpaceSpec' object has no attribute 'dtype'

so this commit does the fix

Fixes #{issue number}
