### PR TITLE
[validation] Fix assertion in validate_sha_output().

### DIFF
--- a/compiler_gym/envs/llvm/datasets.py
+++ b/compiler_gym/envs/llvm/datasets.py
@@ -501,15 +501,19 @@ def get_llvm_benchmark_validation_callback(
 # ===============================
 
 
-def validate_sha_output(result: BenchmarkExecutionResult):
+def validate_sha_output(result: BenchmarkExecutionResult) -> Optional[str]:
     """SHA benchmark prints 5 random hex strings. Normally these hex strings are
     16 characters but occasionally they are less (presumably becuase of a
     leading zero being omitted).
     """
-    assert re.match(
-        r"[0-9a-f]{0,16} [0-9a-f]{0,16} [0-9a-f]{0,16} [0-9a-f]{0,16} [0-9a-f]{0,16}",
-        result.output.decode("utf-8").rstrip(),
-    )
+    try:
+        if not re.match(
+            r"[0-9a-f]{0,16} [0-9a-f]{0,16} [0-9a-f]{0,16} [0-9a-f]{0,16} [0-9a-f]{0,16}",
+            result.output.decode("utf-8").rstrip(),
+        ):
+            return "Failed to parse hex output"
+    except UnicodeDecodeError:
+        return "Failed to parse unicode output"
 
 
 def setup_ghostscript_library_files(cwd: Path):

--- a/tests/llvm/BUILD
+++ b/tests/llvm/BUILD
@@ -84,6 +84,16 @@ py_test(
 )
 
 py_test(
+    name = "datasets_test",
+    timeout = "short",
+    srcs = ["datasets_test.py"],
+    deps = [
+        "//compiler_gym/envs/llvm:datasets",
+        "//tests:test_main",
+    ],
+)
+
+py_test(
     name = "fork_env_test",
     timeout = "short",
     srcs = ["fork_env_test.py"],

--- a/tests/llvm/datasets_test.py
+++ b/tests/llvm/datasets_test.py
@@ -1,0 +1,29 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Tests for //compiler_gym/envs/llvm:datasets."""
+
+from compiler_gym.envs.llvm import datasets
+from tests.test_main import main
+
+
+def test_validate_sha_output_okay():
+    output = datasets.BenchmarkExecutionResult(
+        walltime_seconds=0,
+        output="1234567890abcdef 1234567890abcd 1234567890abc 1234567890 12345".encode(
+            "utf-8"
+        ),
+    )
+    assert datasets.validate_sha_output(output) is None
+
+
+def test_validate_sha_output_invalid():
+    output = datasets.BenchmarkExecutionResult(
+        walltime_seconds=0, output="abcd".encode("utf-8")
+    )
+    assert datasets.validate_sha_output(output)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This method should return a string error message on failure, not
assert.

Fixes #109.
