### PR TITLE
Add a parallelization load benchmark.

### DIFF
--- a/tests/benchmarks/BUILD
+++ b/tests/benchmarks/BUILD
@@ -14,3 +14,24 @@ py_test(
         "//tests/pytest_plugins:llvm",
     ],
 )
+
+py_binary(
+    name = "parallelization_load_test",
+    srcs = ["parallelization_load_test.py"],
+    deps = [
+        "//compiler_gym/util",
+        "//compiler_gym/util/flags:benchmark_from_flags",
+        "//compiler_gym/util/flags:env_from_flags",
+    ],
+)
+
+py_test(
+    name = "parallelization_load_test_test",
+    srcs = ["parallelization_load_test_test.py"],
+    deps = [
+        ":parallelization_load_test",
+        "//tests:test_main",
+        "//tests/pytest_plugins:common",
+        "//tests/pytest_plugins:llvm",
+    ],
+)

--- a/tests/benchmarks/parallelization_load_test.py
+++ b/tests/benchmarks/parallelization_load_test.py
@@ -1,0 +1,121 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""A load test for measuring parallelization scalability.
+
+This benchmark runs random episodes with varying numbers of parallel threads and
+processes and records the time taken for each. The objective is to compare
+performance of a simple random search when parallelized using thread-level
+parallelism vs process-based parallelism.
+
+This load test aims to provide a worst-case scenario for multithreading
+performance testing: there is no communication or synchronization between
+threads and the benchmark is entirely compute bound.
+"""
+from multiprocessing import Process, cpu_count
+from threading import Thread
+
+from absl import app, flags
+
+from compiler_gym.util.flags.benchmark_from_flags import benchmark_from_flags
+from compiler_gym.util.flags.env_from_flags import env_from_flags
+from compiler_gym.util.timer import Timer
+
+flags.DEFINE_integer("max_nproc", 2 * cpu_count(), "The maximum number of threads.")
+flags.DEFINE_integer(
+    "nproc_increment",
+    cpu_count() // 4,
+    "The number of workers to change at each step of the load test.",
+)
+flags.DEFINE_integer(
+    "num_episodes", 50, "The number of episodes to run in each worker."
+)
+flags.DEFINE_integer("num_steps", 50, "The number of steps in each episode.")
+flags.DEFINE_string(
+    "logfile",
+    "parallelization_load_test.csv",
+    "The path of the file to write results to.",
+)
+FLAGS = flags.FLAGS
+
+
+def run_random_search(num_episodes, num_steps) -> None:
+    """The inner loop of a load test benchmark."""
+    env = env_from_flags(benchmark=benchmark_from_flags())
+    try:
+        for _ in range(num_episodes):
+            env.reset()
+            for _ in range(num_steps):
+                _, _, done, _ = env.step(env.action_space.sample())
+                if done:
+                    break
+    finally:
+        env.close()
+
+
+def main(argv):
+    assert len(argv) == 1, f"Unknown arguments: {argv[1:]}"
+
+    with open(FLAGS.logfile, "w") as f:
+        print(
+            "nproc",
+            "episodes_per_worker",
+            "steps_per_episode",
+            "total_episodes",
+            "thread_steps_per_second",
+            "process_steps_per_second",
+            "thread_walltime",
+            "process_walltime",
+            sep=",",
+            file=f,
+        )
+
+        for nproc in [1] + list(
+            range(FLAGS.nproc_increment, FLAGS.max_nproc + 1, FLAGS.nproc_increment)
+        ):
+            # Perform the same `nproc * num_episodes` random trajectories first
+            # using threads, then using processes.
+            threads = [
+                Thread(
+                    target=run_random_search,
+                    args=(FLAGS.num_episodes, FLAGS.num_steps),
+                )
+                for _ in range(nproc)
+            ]
+            with Timer(f"Run {nproc} threaded workers") as thread_time:
+                for thread in threads:
+                    thread.start()
+                for thread in threads:
+                    thread.join()
+
+            processes = [
+                Process(
+                    target=run_random_search,
+                    args=(FLAGS.num_episodes, FLAGS.num_steps),
+                )
+                for _ in range(nproc)
+            ]
+            with Timer(f"Run {nproc} process workers") as process_time:
+                for process in processes:
+                    process.start()
+                for process in processes:
+                    process.join()
+
+            print(
+                nproc,
+                FLAGS.num_episodes,
+                FLAGS.num_steps,
+                FLAGS.num_episodes * nproc,
+                (FLAGS.num_episodes * FLAGS.num_steps * nproc) / thread_time.time,
+                (FLAGS.num_episodes * FLAGS.num_steps * nproc) / process_time.time,
+                thread_time.time,
+                process_time.time,
+                sep=",",
+                file=f,
+                flush=True,
+            )
+
+
+if __name__ == "__main__":
+    app.run(main)

--- a/tests/benchmarks/parallelization_load_test_test.py
+++ b/tests/benchmarks/parallelization_load_test_test.py
@@ -1,0 +1,50 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Smoke test for //tests/benchmarks:parallelization_load_test."""
+from pathlib import Path
+
+from absl import flags
+
+from compiler_gym.util.capture_output import capture_output
+from tests.benchmarks.parallelization_load_test import main as load_test
+from tests.pytest_plugins.common import skip_on_ci
+from tests.test_main import main
+
+FLAGS = flags.FLAGS
+
+pytest_plugins = ["tests.pytest_plugins.llvm", "tests.pytest_plugins.common"]
+
+
+@skip_on_ci
+def test_load_test(env, tmpwd):
+    del env  # Unused.
+    del tmpwd  # Unused.
+    FLAGS.unparse_flags()
+    FLAGS(
+        [
+            "arv0",
+            "--env=llvm-v0",
+            "--benchmark=cBench-v1/crc32",
+            "--max_nproc=3",
+            "--nproc_increment=1",
+            "--num_steps=2",
+            "--num_episodes=2",
+        ]
+    )
+    with capture_output() as out:
+        load_test(["argv0"])
+
+    assert "Run 1 threaded workers in " in out.stdout
+    assert "Run 1 process workers in " in out.stdout
+    assert "Run 2 threaded workers in " in out.stdout
+    assert "Run 2 process workers in " in out.stdout
+    assert "Run 3 threaded workers in " in out.stdout
+    assert "Run 3 process workers in " in out.stdout
+
+    assert Path("parallelization_load_test.csv").is_file()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This adds a load test for measuring parallelization scalability.

This benchmark runs random episodes with varying numbers of parallel threads and
processes and records the time taken for each. The objective is to compare
performance of a simple random search when parallelized using thread-level
parallelism vs process-based parallelism.

This load test aims to provide a worst-case scenario for multithreading
performance testing: there is no communication or synchronization between
threads and the benchmark is entirely compute bound.

Example usage:                                                                                                 
                                                                                                       
    $ python parallelization_load_test.py --env=llvm-ic-v0 \                                           
        --benchmark=cBench-v1/dijkstra \                                                               
        --max_nproc=16 --nproc_increment=4                                                             
    Run 1 threaded workers in 1.543s                                                                   
    Run 1 process workers in 1.503s                                                                    
    Run 4 threaded workers in 1.737s                                                                   
    Run 4 process workers in 1.580s                                                                    
    Run 8 threaded workers in 3.203s                                                                   
    Run 8 process workers in 1.669s                                                                    
    Run 12 threaded workers in 4.724s                                                                  
    Run 12 process workers in 1.803s                                                                   
    Run 16 threaded workers in 5.368s                                                                  
    Run 16 process workers in 1.752s                                                                   
                                                                                                       
Results are logged to a CSV file:                                                                      
                                                                                                       
    $ cat parallelization_load_test.csv                                                                
    nproc,episodes_per_worker,steps_per_episode,total_episodes,thread_steps_per_second,process_steps_p$
    1,50,50,50,1620.4372004398122,1663.4964430567027,1.5427935123443604,1.5028586387634277             
    4,50,50,200,5755.458232453162,6328.963335414668,1.7374811172485352,1.5800375938415527              
    8,50,50,400,6244.325393014872,11986.754938498028,3.2029080390930176,1.6685082912445068             
    12,50,50,600,6350.147876765795,16638.061905447597,4.724299430847168,1.8030946254730225             
    16,50,50,800,7451.701144128089,22829.69757469734,5.367901802062988,1.7521038055419922 

Visualizations of data collected:

![image](https://user-images.githubusercontent.com/1636663/111502205-8b9cdc80-873d-11eb-85df-a59c3b7ea98e.png)

![image](https://user-images.githubusercontent.com/1636663/111515056-43d08200-874a-11eb-93eb-9682a98cc7d4.png)
