### PR TITLE
Add default rewards for non-LLVM backends

### DIFF
--- a/compiler_gym/random_search.py
+++ b/compiler_gym/random_search.py
@@ -96,7 +96,10 @@ class RandomAgentWorker(Thread):
                 patience = self._patience
                 self.best_returns = total_returns
                 self.best_actions = actions.copy()
-                self.best_commandline = env.commandline()
+                try:
+                    self.best_commandline = env.commandline()
+                except NotImplementedError:
+                    self.best_commandline = ""
                 self.best_found_at_time = time()
 
         return True
@@ -129,7 +132,6 @@ def random_search(
         reward_space_name = env.reward_space.id
 
         action_space_names = list(env.action_space.names)
-        num_instructions = int(env.observation["IrInstructionCount"])
 
         metadata_path = outdir / logs.METADATA_NAME
         progress_path = outdir / logs.PROGRESS_LOG_NAME
@@ -142,11 +144,10 @@ def random_search(
 
         # Write a metadata file.
         metadata = {
-            "env": env.spec.id,
+            "env": env.spec.id if env.spec else "",
             "benchmark": benchmark_name,
             "reward": reward_space_name,
             "patience": patience,
-            "num_instructions": num_instructions,
         }
         with open(str(metadata_path), "w") as f:
             json.dump(metadata, f, sort_keys=True, indent=2)
@@ -164,7 +165,6 @@ def random_search(
 
     print(
         f"Started {len(workers)} worker threads for "
-        f"{benchmark_name} ({humanize.intcomma(metadata['num_instructions'])} instructions) "
         f"using reward {reward_space_name}."
     )
     print(f"Writing logs to {outdir}")


### PR DESCRIPTION
Removes some hard coding and provides the option of default rewards when they are unspecified in the CompilerEnv