### PR TITLE
Remove LLVM binaries from wheel.

### DIFF
--- a/compiler_gym/envs/llvm/BUILD
+++ b/compiler_gym/envs/llvm/BUILD
@@ -22,13 +22,10 @@ py_library(
 py_library(
     name = "benchmarks",
     srcs = ["benchmarks.py"],
-    data = [
-        "//compiler_gym/third_party/llvm:clang",
-        "//compiler_gym/third_party/llvm:llvm-link",
-    ],
     visibility = ["//compiler_gym:__subpackages__"],
     deps = [
         "//compiler_gym/service/proto",
+        "//compiler_gym/third_party/llvm",
         "//compiler_gym/util",
     ],
 )
@@ -36,13 +33,10 @@ py_library(
 py_library(
     name = "legacy_datasets",
     srcs = ["legacy_datasets.py"],
-    data = [
-        "//compiler_gym/third_party/llvm:clang",
-        "//compiler_gym/third_party/llvm:lli",
-    ],
     visibility = ["//tests:__subpackages__"],
     deps = [
         "//compiler_gym/datasets:dataset",
+        "//compiler_gym/third_party/llvm",
         "//compiler_gym/util",
     ],
 )

--- a/compiler_gym/envs/llvm/benchmarks.py
+++ b/compiler_gym/envs/llvm/benchmarks.py
@@ -15,10 +15,8 @@ from pathlib import Path
 from typing import Iterable, List, Optional, Union
 
 from compiler_gym.service.proto import Benchmark, File
-from compiler_gym.util.runfiles_path import cache_path, runfiles_path
-
-CLANG = runfiles_path("compiler_gym/third_party/llvm/bin/clang")
-LLVM_LINK = runfiles_path("compiler_gym/third_party/llvm/bin/llvm-link")
+from compiler_gym.third_party import llvm
+from compiler_gym.util.runfiles_path import cache_path
 
 
 def _communicate(process, input=None, timeout=None):
@@ -128,7 +126,7 @@ class ClangInvocation(object):
         self.timeout = timeout
 
     def command(self, outpath: Path) -> List[str]:
-        cmd = [str(CLANG)]
+        cmd = [str(llvm.clang_path())]
         if self.system_includes:
             for directory in get_system_includes():
                 cmd += ["-isystem", str(directory)]
@@ -319,7 +317,7 @@ def make_benchmark(
 
         if len(bitcodes + clang_outs) > 1:
             # Link all of the bitcodes into a single module.
-            llvm_link_cmd = [str(LLVM_LINK), "-o", "-"] + [
+            llvm_link_cmd = [str(llvm.llvm_link_path()), "-o", "-"] + [
                 str(path) for path in bitcodes + clang_outs
             ]
             llvm_link = subprocess.Popen(

--- a/compiler_gym/envs/llvm/legacy_datasets.py
+++ b/compiler_gym/envs/llvm/legacy_datasets.py
@@ -29,7 +29,6 @@ from compiler_gym.util.runfiles_path import cache_path, site_data_path
 from compiler_gym.util.timer import Timer
 from compiler_gym.validation_result import ValidationError
 
-_CBENCH_DATA = site_data_path("llvm/cBench-v1-runtime-data/runtime_data")
 _CBENCH_DATA_URL = (
     "https://dl.fbaipublicfiles.com/compiler_gym/cBench-v0-runtime-data.tar.bz2"
 )
@@ -369,26 +368,26 @@ def _compile_and_run_bitcode_file(
     return BenchmarkExecutionResult(walltime_seconds=timer.time, output=output)
 
 
-@fasteners.interprocess_locked(cache_path("cBench-v1-runtime-data.LOCK"))
 def download_cBench_runtime_data() -> bool:
     """Download and unpack the cBench runtime dataset."""
-    if (_CBENCH_DATA / "unpacked").is_file():
+    cbench_data = site_data_path("llvm/cBench-v1-runtime-data/runtime_data")
+    if (cbench_data / "unpacked").is_file():
         return False
     else:
         # Clean up any partially-extracted data directory.
-        if _CBENCH_DATA.is_dir():
-            shutil.rmtree(_CBENCH_DATA)
+        if cbench_data.is_dir():
+            shutil.rmtree(cbench_data)
 
         tar_contents = io.BytesIO(
             download(_CBENCH_DATA_URL, sha256=_CBENCH_DATA_SHA256)
         )
         with tarfile.open(fileobj=tar_contents, mode="r:bz2") as tar:
-            _CBENCH_DATA.parent.mkdir(parents=True, exist_ok=True)
-            tar.extractall(_CBENCH_DATA.parent)
-        assert _CBENCH_DATA.is_dir()
+            cbench_data.parent.mkdir(parents=True, exist_ok=True)
+            tar.extractall(cbench_data.parent)
+        assert cbench_data.is_dir()
         # Create the marker file to indicate that the directory is unpacked
         # and ready to go.
-        (_CBENCH_DATA / "unpacked").touch()
+        (cbench_data / "unpacked").touch()
         return True
 
 
@@ -420,9 +419,12 @@ def _make_cBench_validator(
     def validator_cb(env: "LlvmEnv") -> Optional[ValidationError]:  # noqa: F821
         """The validation callback."""
         with _CBENCH_DOWNLOAD_THREAD_LOCK:
-            download_cBench_runtime_data()
+            with fasteners.InterProcessLock(cache_path("cBench-v1-runtime-data.LOCK")):
+                download_cBench_runtime_data()
 
-        for path in input_files:
+        cbench_data = site_data_path("llvm/cBench-v1-runtime-data/runtime_data")
+        for input_file_name in input_files:
+            path = cbench_data / input_file_name
             if not path.is_file():
                 raise FileNotFoundError(f"Required benchmark input not found: {path}")
 
@@ -431,7 +433,7 @@ def _make_cBench_validator(
             cwd = Path(d)
 
             # Expand shell variable substitutions in the benchmark command.
-            expanded_command = cmd.replace("$D", str(_CBENCH_DATA))
+            expanded_command = cmd.replace("$D", str(cbench_data))
 
             # Translate the output file names into paths inside the working
             # directory.
@@ -594,7 +596,7 @@ def validator(
     platforms = platforms or ["linux", "macos"]
     if {"darwin": "macos"}.get(sys.platform, sys.platform) not in platforms:
         return False
-    infiles = [_CBENCH_DATA / p for p in data or []]
+    infiles = data or []
     outfiles = [Path(p) for p in outs or []]
     linkopts = linkopts or []
     env = env or {}
@@ -691,14 +693,15 @@ def setup_ghostscript_library_files(dataset_id: int) -> Callable[[Path], None]:
     """Make a pre-execution setup hook for ghostscript."""
 
     def setup(cwd: Path):
+        cbench_data = site_data_path("llvm/cBench-v1-runtime-data/runtime_data")
         # Copy the input data file into the current directory since ghostscript
         # doesn't like long input paths.
         shutil.copyfile(
-            _CBENCH_DATA / "office_data" / f"{dataset_id}.ps", cwd / "input.ps"
+            cbench_data / "office_data" / f"{dataset_id}.ps", cwd / "input.ps"
         )
         # Ghostscript doesn't like the library files being symlinks so copy them
         # into the working directory as regular files.
-        for path in (_CBENCH_DATA / "ghostscript").iterdir():
+        for path in (cbench_data / "ghostscript").iterdir():
             if path.name.endswith(".ps"):
                 shutil.copyfile(path, cwd / path.name)
 

--- a/compiler_gym/envs/llvm/llvm_env.py
+++ b/compiler_gym/envs/llvm/llvm_env.py
@@ -26,6 +26,7 @@ from compiler_gym.envs.llvm.llvm_rewards import (
 from compiler_gym.spaces import Commandline, CommandlineFlag, Scalar, Sequence
 from compiler_gym.third_party.autophase import AUTOPHASE_FEATURE_NAMES
 from compiler_gym.third_party.inst2vec import Inst2vecEncoder
+from compiler_gym.third_party.llvm import download_llvm_files
 from compiler_gym.util.runfiles_path import runfiles_path, site_data_path
 from compiler_gym.validation_result import ValidationError
 
@@ -78,6 +79,9 @@ class LlvmEnv(CompilerEnv):
     """
 
     def __init__(self, *args, **kwargs):
+        # First perform a one-time download of LLVM binaries that are needed by
+        # the LLVM service and are not included by the pip-installed package.
+        download_llvm_files()
         super().__init__(
             *args,
             **kwargs,

--- a/compiler_gym/envs/llvm/service/BUILD
+++ b/compiler_gym/envs/llvm/service/BUILD
@@ -7,9 +7,6 @@ filegroup(
     name = "service",
     srcs = [
         ":compiler_gym-llvm-service",
-        "//compiler_gym/third_party/llvm:clang",
-        "//compiler_gym/third_party/llvm:llvm-size",
-        "//compiler_gym/third_party/llvm:opt",
     ] + select({
         "@llvm//:darwin": [],
         "//conditions:default": [

--- a/compiler_gym/envs/llvm/service/Cost.cc
+++ b/compiler_gym/envs/llvm/service/Cost.cc
@@ -70,8 +70,8 @@ Status getTextSizeInBytes(llvm::Module& module, int64_t* value,
 #else
 Status getTextSizeInBytes(llvm::Module& module, int64_t* value, const fs::path& workingDirectory) {
 #endif
-  const auto clangPath = util::getRunfilesPath("compiler_gym/third_party/llvm/bin/clang");
-  const auto llvmSizePath = util::getRunfilesPath("compiler_gym/third_party/llvm/bin/llvm-size");
+  const auto clangPath = util::getSiteDataPath("llvm/10.0.0/bin/clang");
+  const auto llvmSizePath = util::getSiteDataPath("llvm/10.0.0/bin/llvm-size");
   DCHECK(fs::exists(clangPath)) << "File not found: " << clangPath.string();
   DCHECK(fs::exists(llvmSizePath)) << "File not found: " << llvmSizePath.string();
 

--- a/compiler_gym/envs/llvm/service/LlvmSession.cc
+++ b/compiler_gym/envs/llvm/service/LlvmSession.cc
@@ -217,7 +217,7 @@ Status LlvmSession::runOptWithArgs(const std::vector<std::string>& optArgs) {
   RETURN_IF_ERROR(writeBitcodeToFile(benchmark().module(), before_path));
 
   // Build a command line invocation: `opt input.bc -o output.bc <optArgs...>`.
-  const auto optPath = util::getRunfilesPath("compiler_gym/third_party/llvm/bin/opt");
+  const auto optPath = util::getSiteDataPath("llvm/10.0.0/bin/opt");
   std::vector<std::string> optCmd{optPath.string(), before_path.string(), "-o",
                                   after_path.string()};
   optCmd.insert(optCmd.end(), optArgs.begin(), optArgs.end());

--- a/compiler_gym/service/connection.py
+++ b/compiler_gym/service/connection.py
@@ -24,7 +24,11 @@ from compiler_gym.service.proto import (
     ObservationSpace,
 )
 from compiler_gym.util.debug_util import get_debug_level
-from compiler_gym.util.runfiles_path import runfiles_path, transient_cache_path
+from compiler_gym.util.runfiles_path import (
+    runfiles_path,
+    site_data_path,
+    transient_cache_path,
+)
 from compiler_gym.util.shell_format import plural
 from compiler_gym.util.truncate import truncate_lines
 
@@ -277,6 +281,7 @@ class ManagedConnection(Connection):
         # Set the root of the runfiles directory.
         env = os.environ.copy()
         env["COMPILER_GYM_RUNFILES"] = str(runfiles_path("."))
+        env["COMPILER_GYM_SITE_DATA"] = str(site_data_path("."))
 
         # Set the verbosity of the service. The logging level of the service
         # is the debug level - 1, so that COMPILER_GYM_DEUG=3 will cause VLOG(2)

--- a/compiler_gym/third_party/llvm/BUILD
+++ b/compiler_gym/third_party/llvm/BUILD
@@ -3,192 +3,190 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-filegroup(
-    name = "clang",
-    srcs = [
-        "bin/clang",
-    ] + select({
-        "@llvm//:darwin": [],
-        "//conditions:default": [
-            "lib/clang/10.0.0/lib/linux/libclang_rt.asan-x86_64.a",
-            "lib/clang/10.0.0/lib/linux/libclang_rt.tsan-x86_64.a",
-            "lib/clang/10.0.0/lib/linux/libclang_rt.msan-x86_64.a",
-            "lib/clang/10.0.0/lib/linux/libclang_rt.ubsan_standalone-x86_64.a",
-        ],
-    }),
+py_library(
+    name = "llvm",
+    srcs = ["__init__.py"],
     visibility = ["//visibility:public"],
-)
-
-filegroup(
-    name = "lli",
-    srcs = ["bin/lli"],
-    visibility = ["//visibility:public"],
-)
-
-filegroup(
-    name = "llvm-diff",
-    srcs = ["bin/llvm-diff"],
-    visibility = ["//visibility:public"],
-)
-
-filegroup(
-    name = "llvm-link",
-    srcs = ["bin/llvm-link"],
-    visibility = ["//visibility:public"],
-)
-
-filegroup(
-    name = "llvm-size",
-    srcs = ["bin/llvm-size"],
-    visibility = ["//visibility:public"],
-)
-
-filegroup(
-    name = "opt",
-    srcs = ["bin/opt"],
-    visibility = ["//visibility:public"],
-)
-
-filegroup(
-    name = "llvm-stress",
-    srcs = ["bin/llvm-stress"],
-    visibility = ["//visibility:public"],
-)
-
-genrule(
-    name = "make_clang",
-    srcs = select({
-        "@llvm//:darwin": [
-            "@clang-llvm-10.0.0-x86_64-apple-darwin//:clang",
-        ],
-        "//conditions:default": [
-            "@clang-llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04//:clang",
-        ],
-    }),
-    outs = ["bin/clang"],
-    cmd = "mkdir -p $$(dirname $@) && cp $< $@",
-)
-
-genrule(
-    name = "make_lli",
-    srcs = select({
-        "@llvm//:darwin": [
-            "@clang-llvm-10.0.0-x86_64-apple-darwin//:lli",
-        ],
-        "//conditions:default": [
-            "@clang-llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04//:lli",
-        ],
-    }),
-    outs = ["bin/lli"],
-    cmd = "mkdir -p $$(dirname $@) && cp $< $@",
-)
-
-genrule(
-    name = "make_llvm-diff",
-    srcs = select({
-        "@llvm//:darwin": [
-            "@clang-llvm-10.0.0-x86_64-apple-darwin//:llvm-diff",
-        ],
-        "//conditions:default": [
-            "@clang-llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04//:llvm-diff",
-        ],
-    }),
-    outs = ["bin/llvm-diff"],
-    cmd = "mkdir -p $$(dirname $@) && cp $< $@",
-)
-
-genrule(
-    name = "make_llvm-link",
-    srcs = select({
-        "@llvm//:darwin": [
-            "@clang-llvm-10.0.0-x86_64-apple-darwin//:llvm-link",
-        ],
-        "//conditions:default": [
-            "@clang-llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04//:llvm-link",
-        ],
-    }),
-    outs = ["bin/llvm-link"],
-    cmd = "mkdir -p $$(dirname $@) && cp $< $@",
-)
-
-genrule(
-    name = "make_llvm-size",
-    srcs = select({
-        "@llvm//:darwin": [
-            "@clang-llvm-10.0.0-x86_64-apple-darwin//:llvm-size",
-        ],
-        "//conditions:default": [
-            "@clang-llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04//:llvm-size",
-        ],
-    }),
-    outs = ["bin/llvm-size"],
-    cmd = "mkdir -p $$(dirname $@) && cp $< $@",
-)
-
-genrule(
-    name = "make_opt",
-    srcs = select({
-        "@llvm//:darwin": [
-            "@clang-llvm-10.0.0-x86_64-apple-darwin//:opt",
-        ],
-        "//conditions:default": [
-            "@clang-llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04//:opt",
-        ],
-    }),
-    outs = ["bin/opt"],
-    cmd = "mkdir -p $$(dirname $@) && cp $< $@",
-)
-
-genrule(
-    name = "make_llvm-stress",
-    srcs = select({
-        "@llvm//:darwin": [
-            "@clang-llvm-10.0.0-x86_64-apple-darwin//:llvm-stress",
-        ],
-        "//conditions:default": [
-            "@clang-llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04//:llvm-stress",
-        ],
-    }),
-    outs = ["bin/llvm-stress"],
-    cmd = "mkdir -p $$(dirname $@) && cp $< $@",
-)
-
-genrule(
-    name = "make_libclang_rt.asan-x86_64.a",
-    srcs = [
-        "@clang-llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04//:all_files",
-        "@clang-llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04//:clang",
+    deps = [
+        "//compiler_gym/util",
     ],
-    outs = ["lib/clang/10.0.0/lib/linux/libclang_rt.asan-x86_64.a"],
-    cmd = "mkdir -p $$(dirname $@) && cp $$(dirname $(location @clang-llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04//:clang))/../lib/clang/10.0.0/lib/linux/libclang_rt.asan-x86_64.a $@",
 )
 
-genrule(
-    name = "make_libclang_rt.tsan-x86_64.a",
-    srcs = [
-        "@clang-llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04//:all_files",
-        "@clang-llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04//:clang",
-    ],
-    outs = ["lib/clang/10.0.0/lib/linux/libclang_rt.tsan-x86_64.a"],
-    cmd = "mkdir -p $$(dirname $@) && cp $$(dirname $(location @clang-llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04//:clang))/../lib/clang/10.0.0/lib/linux/libclang_rt.tsan-x86_64.a $@",
-)
-
-genrule(
-    name = "make_libclang_rt.msan-x86_64.a",
-    srcs = [
-        "@clang-llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04//:all_files",
-        "@clang-llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04//:clang",
-    ],
-    outs = ["lib/clang/10.0.0/lib/linux/libclang_rt.msan-x86_64.a"],
-    cmd = "mkdir -p $$(dirname $@) && cp $$(dirname $(location @clang-llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04//:clang))/../lib/clang/10.0.0/lib/linux/libclang_rt.msan-x86_64.a $@",
-)
-
-genrule(
-    name = "make_libclang_rt.ubsan_standalone-x86_64.a",
-    srcs = [
-        "@clang-llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04//:all_files",
-        "@clang-llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04//:clang",
-    ],
-    outs = ["lib/clang/10.0.0/lib/linux/libclang_rt.ubsan_standalone-x86_64.a"],
-    cmd = "mkdir -p $$(dirname $@) && cp $$(dirname $(location @clang-llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04//:clang))/../lib/clang/10.0.0/lib/linux/libclang_rt.ubsan_standalone-x86_64.a $@",
-)
+# The following targets define the rules for how to assemble and compress the
+# tarball of LLVM data that is downloaded at runtime by the ":llvm" library.
+# It is commented out to prevent globs like "bazel test //..." from running
+# them, as they are only needed for updating the distributed LLVM archives.
+#
+# genrule(
+#     name = "llvm_data_tar",
+#     srcs = [":llvm_data"],
+#     outs = ["llvm.tar.bz2"],
+#     cmd = "mkdir -p $(@D)/lib && tar cjfh $@ -C $(@D) LICENSE bin lib",
+# )
+#
+# filegroup(
+#     name = "llvm_data",
+#     srcs = [
+#         "LICENSE",
+#         "bin/clang",
+#         "bin/lli",
+#         "bin/llvm-diff",
+#         "bin/llvm-link",
+#         "bin/llvm-size",
+#         "bin/llvm-stress",
+#         "bin/opt",
+#     ] + select({
+#         "@llvm//:darwin": [],
+#         "//conditions:default": [
+#             "lib/clang/10.0.0/lib/linux/libclang_rt.asan-x86_64.a",
+#             "lib/clang/10.0.0/lib/linux/libclang_rt.tsan-x86_64.a",
+#             "lib/clang/10.0.0/lib/linux/libclang_rt.msan-x86_64.a",
+#             "lib/clang/10.0.0/lib/linux/libclang_rt.ubsan_standalone-x86_64.a",
+#         ],
+#     }),
+# )
+#
+# genrule(
+#     name = "make_license",
+#     srcs = ["LICENSE.txt"],
+#     outs = ["LICENSE"],
+#     cmd = "cat $< > $@",
+# )
+#
+# genrule(
+#     name = "make_clang",
+#     srcs = select({
+#         "@llvm//:darwin": [
+#             "@clang-llvm-10.0.0-x86_64-apple-darwin//:clang",
+#         ],
+#         "//conditions:default": [
+#             "@clang-llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04//:clang",
+#         ],
+#     }),
+#     outs = ["bin/clang"],
+#     cmd = "mkdir -p $$(dirname $@) && cp $< $@",
+# )
+#
+# genrule(
+#     name = "make_lli",
+#     srcs = select({
+#         "@llvm//:darwin": [
+#             "@clang-llvm-10.0.0-x86_64-apple-darwin//:lli",
+#         ],
+#         "//conditions:default": [
+#             "@clang-llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04//:lli",
+#         ],
+#     }),
+#     outs = ["bin/lli"],
+#     cmd = "mkdir -p $$(dirname $@) && cp $< $@",
+# )
+#
+# genrule(
+#     name = "make_llvm-diff",
+#     srcs = select({
+#         "@llvm//:darwin": [
+#             "@clang-llvm-10.0.0-x86_64-apple-darwin//:llvm-diff",
+#         ],
+#         "//conditions:default": [
+#             "@clang-llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04//:llvm-diff",
+#         ],
+#     }),
+#     outs = ["bin/llvm-diff"],
+#     cmd = "mkdir -p $$(dirname $@) && cp $< $@",
+# )
+#
+# genrule(
+#     name = "make_llvm-link",
+#     srcs = select({
+#         "@llvm//:darwin": [
+#             "@clang-llvm-10.0.0-x86_64-apple-darwin//:llvm-link",
+#         ],
+#         "//conditions:default": [
+#             "@clang-llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04//:llvm-link",
+#         ],
+#     }),
+#     outs = ["bin/llvm-link"],
+#     cmd = "mkdir -p $$(dirname $@) && cp $< $@",
+# )
+#
+# genrule(
+#     name = "make_llvm-size",
+#     srcs = select({
+#         "@llvm//:darwin": [
+#             "@clang-llvm-10.0.0-x86_64-apple-darwin//:llvm-size",
+#         ],
+#         "//conditions:default": [
+#             "@clang-llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04//:llvm-size",
+#         ],
+#     }),
+#     outs = ["bin/llvm-size"],
+#     cmd = "mkdir -p $$(dirname $@) && cp $< $@",
+# )
+#
+# genrule(
+#     name = "make_opt",
+#     srcs = select({
+#         "@llvm//:darwin": [
+#             "@clang-llvm-10.0.0-x86_64-apple-darwin//:opt",
+#         ],
+#         "//conditions:default": [
+#             "@clang-llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04//:opt",
+#         ],
+#     }),
+#     outs = ["bin/opt"],
+#     cmd = "mkdir -p $$(dirname $@) && cp $< $@",
+# )
+#
+# genrule(
+#     name = "make_llvm-stress",
+#     srcs = select({
+#         "@llvm//:darwin": [
+#             "@clang-llvm-10.0.0-x86_64-apple-darwin//:llvm-stress",
+#         ],
+#         "//conditions:default": [
+#             "@clang-llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04//:llvm-stress",
+#         ],
+#     }),
+#     outs = ["bin/llvm-stress"],
+#     cmd = "mkdir -p $$(dirname $@) && cp $< $@",
+# )
+#
+# genrule(
+#     name = "make_libclang_rt.asan-x86_64.a",
+#     srcs = [
+#         "@clang-llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04//:all_files",
+#         "@clang-llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04//:clang",
+#     ],
+#     outs = ["lib/clang/10.0.0/lib/linux/libclang_rt.asan-x86_64.a"],
+#     cmd = "mkdir -p $$(dirname $@) && cp $$(dirname $(location @clang-llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04//:clang))/../lib/clang/10.0.0/lib/linux/libclang_rt.asan-x86_64.a $@",
+# )
+#
+# genrule(
+#     name = "make_libclang_rt.tsan-x86_64.a",
+#     srcs = [
+#         "@clang-llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04//:all_files",
+#         "@clang-llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04//:clang",
+#     ],
+#     outs = ["lib/clang/10.0.0/lib/linux/libclang_rt.tsan-x86_64.a"],
+#     cmd = "mkdir -p $$(dirname $@) && cp $$(dirname $(location @clang-llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04//:clang))/../lib/clang/10.0.0/lib/linux/libclang_rt.tsan-x86_64.a $@",
+# )
+#
+# genrule(
+#     name = "make_libclang_rt.msan-x86_64.a",
+#     srcs = [
+#         "@clang-llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04//:all_files",
+#         "@clang-llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04//:clang",
+#     ],
+#     outs = ["lib/clang/10.0.0/lib/linux/libclang_rt.msan-x86_64.a"],
+#     cmd = "mkdir -p $$(dirname $@) && cp $$(dirname $(location @clang-llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04//:clang))/../lib/clang/10.0.0/lib/linux/libclang_rt.msan-x86_64.a $@",
+# )
+#
+# genrule(
+#     name = "make_libclang_rt.ubsan_standalone-x86_64.a",
+#     srcs = [
+#         "@clang-llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04//:all_files",
+#         "@clang-llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04//:clang",
+#     ],
+#     outs = ["lib/clang/10.0.0/lib/linux/libclang_rt.ubsan_standalone-x86_64.a"],
+#     cmd = "mkdir -p $$(dirname $@) && cp $$(dirname $(location @clang-llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04//:clang))/../lib/clang/10.0.0/lib/linux/libclang_rt.ubsan_standalone-x86_64.a $@",
+# )

--- a/compiler_gym/third_party/llvm/LICENSE.txt
+++ b/compiler_gym/third_party/llvm/LICENSE.txt
@@ -1,0 +1,278 @@
+==============================================================================
+The LLVM Project is under the Apache License v2.0 with LLVM Exceptions:
+==============================================================================
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+    1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+    2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+    3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+    4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+    5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+    6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+    7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+    8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+    9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+    END OF TERMS AND CONDITIONS
+
+    APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+    Copyright [yyyy] [name of copyright owner]
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+
+---- LLVM Exceptions to the Apache 2.0 License ----
+
+As an exception, if, as a result of your compiling your source code, portions
+of this Software are embedded into an Object form of such source code, you
+may redistribute such embedded portions in such Object form without complying
+with the conditions of Sections 4(a), 4(b) and 4(d) of the License.
+
+In addition, if you combine or link compiled forms of this Software with
+software that is licensed under the GPLv2 ("Combined Software") and if a
+court of competent jurisdiction determines that the patent provision (Section
+3), the indemnity provision (Section 9) or other Section of the License
+conflicts with the conditions of the GPLv2, you may retroactively and
+prospectively choose to deem waived or otherwise exclude such Section(s) of
+the License, but only in their entirety and only with respect to the Combined
+Software.
+
+==============================================================================
+Software from third parties included in the LLVM Project:
+==============================================================================
+The LLVM Project contains third party software which is under different license
+terms. All such code will be identified clearly using at least one of two
+mechanisms:
+1) It will be in a separate directory tree with its own `LICENSE.txt` or
+   `LICENSE` file at the top containing the specific license and restrictions
+   which apply to that software, or
+2) It will contain specific license and restriction terms at the top of every
+   file.
+
+==============================================================================
+Legacy LLVM License (https://llvm.org/docs/DeveloperPolicy.html#legacy):
+==============================================================================
+University of Illinois/NCSA
+Open Source License
+
+Copyright (c) 2003-2019 University of Illinois at Urbana-Champaign.
+All rights reserved.
+
+Developed by:
+
+    LLVM Team
+
+    University of Illinois at Urbana-Champaign
+
+    http://llvm.org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal with
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimers.
+
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimers in the
+      documentation and/or other materials provided with the distribution.
+
+    * Neither the names of the LLVM Team, University of Illinois at
+      Urbana-Champaign, nor the names of its contributors may be used to
+      endorse or promote products derived from this Software without specific
+      prior written permission.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE
+SOFTWARE.

--- a/compiler_gym/third_party/llvm/__init__.py
+++ b/compiler_gym/third_party/llvm/__init__.py
@@ -1,0 +1,84 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Module for resolving paths to LLVM binaries and libraries."""
+import io
+import sys
+import tarfile
+from pathlib import Path
+from threading import Lock
+
+import fasteners
+
+from compiler_gym.util.download import download
+from compiler_gym.util.runfiles_path import cache_path, site_data_path
+
+# (url, sha256) tuples for the LLVM download data packs.
+_LLVM_URLS = {
+    "darwin": (
+        "https://dl.fbaipublicfiles.com/compiler_gym/llvm-10.0.0-macos.tar.bz2",
+        "ff74da7a5423528de0e25d1c79926f2ddd95e02b5c25d1b501637af63b29dba6",
+    ),
+    "linux": (
+        "https://dl.fbaipublicfiles.com/compiler_gym/llvm-10.0.0-linux.tar.bz2",
+        "c9bf5bfda3c2fa1d1a9e7ebc93da4398a6f6841c28b5d368e0eb29a153856a93",
+    ),
+}
+
+
+# Thread lock to prevent race on download_llvm_files() from multi-threading.
+# This works in tandem with the inter-process file lock - both are required.
+_LLVM_DOWNLOAD_LOCK = Lock()
+_LLVM_DOWNLOADED = False
+
+
+def _download_llvm_files(unpacked_location: Path) -> Path:
+    """Download and unpack the LLVM data pack."""
+    global _LLVM_DOWNLOADED
+    _LLVM_DOWNLOADED = True
+    if not (unpacked_location / ".unpacked").is_file():
+        url, sha256 = _LLVM_URLS[sys.platform]
+        tar_contents = io.BytesIO(download(url, sha256=sha256))
+        unpacked_location.parent.mkdir(parents=True, exist_ok=True)
+        with tarfile.open(fileobj=tar_contents, mode="r:bz2") as tar:
+            tar.extractall(unpacked_location)
+        assert unpacked_location.is_dir()
+        assert (unpacked_location / "LICENSE").is_file()
+        # Create the marker file to indicate that the directory is unpacked
+        # and ready to go.
+        (unpacked_location / ".unpacked").touch()
+
+    return unpacked_location
+
+
+def download_llvm_files() -> Path:
+    """Download and unpack the LLVM data pack."""
+    unpacked_location = site_data_path("llvm/10.0.0")
+    # Fast path for repeated calls.
+    if _LLVM_DOWNLOADED:
+        return unpacked_location
+
+    with _LLVM_DOWNLOAD_LOCK:
+        with fasteners.InterProcessLock(cache_path("llvm-download.LOCK")):
+            return _download_llvm_files(unpacked_location)
+
+
+def clang_path() -> Path:
+    """Return the path of clang."""
+    return download_llvm_files() / "bin/clang"
+
+
+def llvm_link_path() -> Path:
+    """Return the path of llvm-link."""
+    return download_llvm_files() / "bin/llvm-link"
+
+
+def lli_path() -> Path:
+    """Return the path of lli."""
+    return download_llvm_files() / "bin/lli"
+
+
+def opt_path() -> Path:
+    """Return the path of opt."""
+    return download_llvm_files() / "bin/opt"

--- a/compiler_gym/util/runfiles_path.py
+++ b/compiler_gym/util/runfiles_path.py
@@ -15,8 +15,14 @@ _PACKAGE_ROOT = Path(os.path.join(os.path.dirname(__file__), "../../")).resolve(
 def runfiles_path(relpath: str) -> Path:
     """Resolve the path to a runfiles data path.
 
+    No checks are to made to ensure that the path, or the containing directory,
+    exist.
+
     Use environment variable COMPILER_GYM_RUNFILES=/path/to/runfiles if running
     outside of bazel.
+
+    :param relpath: The relative path within the runfiles tres.
+    :return: An absolute path.
     """
     # There are three ways of determining a runfiles path:
     #   1. Set the COMPILER_GYM_RUNFILES environment variable.
@@ -47,6 +53,12 @@ def site_data_path(relpath: str) -> Path:
     CompilerGym uses a directory to store persistent site data files in, such as benchmark datasets.
     The default location is :code:`~/.local/share/compiler_gym`. Set the environment variable
     :code:`$COMPILER_GYM_SITE_DATA` to override this default location.
+
+    No checks are to made to ensure that the path, or the containing directory,
+    exist.
+
+    :param relpath: The relative path within the site data tree.
+    :return: An absolute path.
     """
     # NOTE(cummins): This function has a matching implementation in the C++
     # sources, compiler_gym::service::getSiteDataPath(). Any change to behavior
@@ -63,12 +75,16 @@ def site_data_path(relpath: str) -> Path:
 def cache_path(relpath: str) -> Path:
     """Return a path within the cache directory.
 
-    CompilerGym uses a directory to cache files in, such as downloaded content. The default location
-    for this cache is :code:`~/.cache/compiler_gym`. Set the environment variable
-    :code:`$COMPILER_GYM_CACHE` to override this default location.
+    CompilerGym uses a directory to cache files in, such as downloaded content.
+    The default location for this cache is :code:`~/.cache/compiler_gym`. Set
+    the environment variable :code:`$COMPILER_GYM_CACHE` to override this
+    default location.
 
-    :param relpath: The relative path within the cache.
-    :return: The absolute path of the cache.
+    No checks are to made to ensure that the path, or the containing directory,
+    exist.
+
+    :param relpath: The relative path within the cache tree. :return: An
+    absolute path.
     """
     forced = os.environ.get("COMPILER_GYM_CACHE")
     if forced:
@@ -82,13 +98,18 @@ def cache_path(relpath: str) -> Path:
 def transient_cache_path(relpath: str) -> Path:
     """Return a path within the transient cache directory.
 
-    The transient cache is a directory used to store files that do not need to persist beyond the
-    lifetime of the current process. When available, the temporary filesystem :code:`/dev/shm` will
-    be used. Else, :meth:`cache_path() <compiler_gym.cache_path>` is used as a fallback. Set the
-    environment variable :code:`$COMPILER_GYM_TRANSIENT_CACHE` to override the default location.
+    The transient cache is a directory used to store files that do not need to
+    persist beyond the lifetime of the current process. When available, the
+    temporary filesystem :code:`/dev/shm` will be used. Else,
+    :meth:`cache_path() <compiler_gym.cache_path>` is used as a fallback. Set
+    the environment variable :code:`$COMPILER_GYM_TRANSIENT_CACHE` to override
+    the default location.
 
-    :param relpath: The relative path within the cache.
-    :return: The absolute path of the cache.
+    No checks are to made to ensure that the path, or the containing directory,
+    exist.
+
+    :param relpath: The relative path within the cache tree. :return: An
+    absolute path.
     """
     forced = os.environ.get("COMPILER_GYM_TRANSIENT_CACHE")
     if forced:

--- a/setup.py
+++ b/setup.py
@@ -78,8 +78,6 @@ setuptools.setup(
             "third_party/cBench/benchmarks.txt",
             "third_party/cBench/cBench-v*/*",
             "third_party/cBench/runtime_data/**/*",
-            "third_party/llvm/bin/*",
-            "third_party/llvm/lib/clang/10.0.0/lib/linux/*.a",
         ]
     },
     install_requires=requirements,

--- a/tests/fuzzing/BUILD
+++ b/tests/fuzzing/BUILD
@@ -68,7 +68,6 @@ py_test(
     name = "llvm_stress_fuzz_test",
     timeout = "long",
     srcs = ["llvm_stress_fuzz_test.py"],
-    data = ["//compiler_gym/third_party/llvm:llvm-stress"],
     shard_count = 20,
     tags = ["manual"],
     deps = [

--- a/tests/fuzzing/llvm_stress_fuzz_test.py
+++ b/tests/fuzzing/llvm_stress_fuzz_test.py
@@ -8,13 +8,11 @@ import subprocess
 
 from compiler_gym.envs import LlvmEnv
 from compiler_gym.service.proto import Benchmark, File
-from compiler_gym.util.runfiles_path import runfiles_path
+from compiler_gym.third_party import llvm
 from tests.pytest_plugins.random_util import apply_random_trajectory
 from tests.test_main import main
 
 pytest_plugins = ["tests.pytest_plugins.llvm"]
-
-LLVM_STRESS = runfiles_path("compiler_gym/third_party/llvm/bin/llvm-stress")
 
 # The uniform range for trajectory lengths.
 RANDOM_TRAJECTORY_LENGTH_RANGE = (1, 10)
@@ -25,7 +23,7 @@ def test_fuzz(env: LlvmEnv, observation_space: str, reward_space: str):
     llvm-stress.
     """
     seed = random.randint(0, 2 << 31)
-    llvm_ir = subprocess.check_output([str(LLVM_STRESS), f"--seed={seed}"])
+    llvm_ir = subprocess.check_output([str(llvm.llvm_stress_path()), f"--seed={seed}"])
     print(f"llvm-stress --seed={seed}")  # For debugging in case of failure.
     env.benchamrk = Benchmark(uri="stress", program=File(contents=llvm_ir))
 

--- a/tests/llvm/datasets_test.py
+++ b/tests/llvm/datasets_test.py
@@ -3,9 +3,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 """Tests for //compiler_gym/envs/llvm:legacy_datasets."""
-import os
-
-import gym
 import pytest
 
 from compiler_gym.envs.llvm import LlvmEnv, legacy_datasets
@@ -25,57 +22,6 @@ def test_validate_sha_output_okay():
 def test_validate_sha_output_invalid():
     output = legacy_datasets.BenchmarkExecutionResult(walltime_seconds=0, output="abcd")
     assert legacy_datasets.validate_sha_output(output)
-
-
-def test_default_cBench_dataset_require(tmpwd, temporary_environ):
-    """Test that cBench is downloaded."""
-    del temporary_environ
-
-    os.environ["COMPILER_GYM_SITE_DATA"] = str(tmpwd / "site_data")
-    env = gym.make("llvm-v0")
-    try:
-        assert not env.benchmarks, "Sanity check"
-
-        # Datasaet is downloaded.
-        assert env.require_dataset("cBench-v1")
-        assert env.benchmarks
-
-        # Dataset is already downloaded.
-        assert not env.require_dataset("cBench-v1")
-    finally:
-        env.close()
-
-
-def test_default_cBench_on_reset(tmpwd, temporary_environ):
-    """Test that cBench is downloaded by default when no benchmarks are available."""
-    del temporary_environ
-
-    os.environ["COMPILER_GYM_SITE_DATA"] = str(tmpwd / "site_data")
-    env = gym.make("llvm-v0")
-    try:
-        assert not env.benchmarks, "Sanity check"
-
-        env.reset()
-        assert env.benchmarks
-        assert env.benchmark.startswith("benchmark://cBench-v1/")
-    finally:
-        env.close()
-
-
-@pytest.mark.parametrize("benchmark_name", ["benchmark://npb-v0/1", "npb-v0/1"])
-def test_dataset_required(tmpwd, temporary_environ, benchmark_name):
-    """Test that the required dataset is downlaoded when a benchmark is specified."""
-    del temporary_environ
-
-    os.environ["COMPILER_GYM_SITE_DATA"] = str(tmpwd / "site_data")
-    env = gym.make("llvm-v0")
-    try:
-        env.reset(benchmark=benchmark_name)
-
-        assert env.benchmarks
-        assert env.benchmark.startswith("benchmark://npb-v0/")
-    finally:
-        env.close()
 
 
 def test_cBench_v0_deprecation(env: LlvmEnv):

--- a/tests/pytest_plugins/BUILD
+++ b/tests/pytest_plugins/BUILD
@@ -15,12 +15,10 @@ py_library(
     data = [
         "//compiler_gym/envs/llvm/service/passes:actions_genfiles",
         "//compiler_gym/third_party/cBench:benchmarks_list",
-        "//compiler_gym/third_party/llvm:clang",
-        "//compiler_gym/third_party/llvm:llvm-diff",
-        "//compiler_gym/third_party/llvm:opt",
     ],
     deps = [
         "//compiler_gym",
+        "//compiler_gym/third_party/llvm",
     ],
 )
 

--- a/tests/pytest_plugins/llvm.py
+++ b/tests/pytest_plugins/llvm.py
@@ -12,6 +12,7 @@ import pytest
 
 from compiler_gym.envs import CompilerEnv
 from compiler_gym.envs.llvm.legacy_datasets import VALIDATORS
+from compiler_gym.third_party import llvm
 from compiler_gym.util.runfiles_path import runfiles_path
 
 ACTIONS_LIST = Path(
@@ -117,16 +118,16 @@ def cBench_dataset():
 @pytest.fixture(scope="module")
 def llvm_opt() -> Path:
     """Test fixture that yields the path of opt."""
-    return runfiles_path("compiler_gym/third_party/llvm/bin/opt")
+    return llvm.opt_path()
 
 
 @pytest.fixture(scope="module")
 def llvm_diff() -> Path:
     """Test fixture that yields the path of llvm-diff."""
-    return runfiles_path("compiler_gym/third_party/llvm/bin/llvm-diff")
+    return llvm.llvm_diff_path()
 
 
 @pytest.fixture(scope="module")
 def clang() -> Path:
     """Test fixture that yields the path of clang."""
-    return runfiles_path("compiler_gym/third_party/llvm/bin/clang")
+    return llvm.clang_path()


### PR DESCRIPTION
This patch removes the LLVM binaries from the shipped wheel. This is                                                                                                                                                     
to reduce the package size to be under the 100MB default maximum                                                                                                                                                         
imposed by PyPi.                                                                                                                                                                                                         
                                                                                                                                                                                                                         
Instead of shipping the files in the wheel, the LLVM binaries are                                                                                                                                                        
downloaded from an archive hosted by Facebook when needed. The                                                                                                                                                           
circumstances for needing them are: (1) starting an LLVM service, (2)                                                                                                                                                    
attempting to resolve the path to an LLVM binary.    