### PR TITLE
[llvm] Strip module and source IDs in benchmarks.

### DIFF
--- a/compiler_gym/envs/llvm/service/Benchmark.cc
+++ b/compiler_gym/envs/llvm/service/Benchmark.cc
@@ -83,7 +83,15 @@ std::unique_ptr<llvm::Module> makeModule(llvm::LLVMContext& context, const Bitco
       llvm::parseBitcodeFile(buffer, context);
   if (moduleOrError) {
     *status = Status::OK;
-    return std::move(moduleOrError.get());
+    std::unique_ptr<llvm::Module> module = std::move(moduleOrError.get());
+
+    // Strip the module identifiers and source file names from the module to
+    // anonymize them. This is to deter learning algorithms from overfitting to
+    // benchmarks by their name.
+    module->setModuleIdentifier("-");
+    module->setSourceFileName("-");
+
+    return module;
   } else {
     *status = Status(StatusCode::INVALID_ARGUMENT,
                      fmt::format("Failed to parse LLVM bitcode: \"{}\"", name));

--- a/compiler_gym/envs/llvm/service/Benchmark.h
+++ b/compiler_gym/envs/llvm/service/Benchmark.h
@@ -28,7 +28,8 @@ using Bitcode = llvm::SmallString<0>;
 
 grpc::Status readBitcodeFile(const boost::filesystem::path& path, Bitcode* bitcode);
 
-// Returns nullptr on error and sets status.
+// Parses the given bitcode into a module and strips the identifying ModuleID
+// and source_filename attributes. Returns nullptr on error and sets status.
 std::unique_ptr<llvm::Module> makeModule(llvm::LLVMContext& context, const Bitcode& bitcode,
                                          const std::string& name, grpc::Status* status);
 

--- a/tests/llvm/BUILD
+++ b/tests/llvm/BUILD
@@ -164,6 +164,18 @@ py_test(
 )
 
 py_test(
+    name = "module_id_test",
+    timeout = "short",
+    srcs = ["module_id_test.py"],
+    deps = [
+        "//compiler_gym",
+        "//tests:test_main",
+        "//tests/pytest_plugins:common",
+        "//tests/pytest_plugins:llvm",
+    ],
+)
+
+py_test(
     name = "multiprocessing_test",
     timeout = "short",
     srcs = ["multiprocessing_test.py"],

--- a/tests/llvm/module_id_test.py
+++ b/tests/llvm/module_id_test.py
@@ -1,0 +1,37 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Tests that module and source IDs are stripped in the LLVM modules."""
+from compiler_gym.envs.llvm import LlvmEnv
+from tests.test_main import main
+
+pytest_plugins = ["tests.pytest_plugins.llvm", "tests.pytest_plugins.common"]
+
+
+def test_no_module_id_builtin_benchmark(env: LlvmEnv):
+    """Test that the module and source IDs are stripped in shipped benchmark."""
+    env.reset("cBench-v1/crc32")
+    ir = env.ir
+
+    print(ir)  # For debugging in case of error.
+    assert "; ModuleID = '-'\n" in ir
+    assert '\nsource_filename = "-"\n' in ir
+
+
+def test_no_module_id_custom_benchmark(env: LlvmEnv):
+    """Test that the module and source IDs are stripped in custom benchmark."""
+
+    with open("source.c", "w") as f:
+        f.write("int A() {return 0;}")
+    benchmark = env.make_benchmark("source.c")
+    env.reset(benchmark=benchmark)
+    ir = env.ir
+
+    print(ir)  # For debugging in case of error.
+    assert "; ModuleID = '-'\n" in ir
+    assert '\nsource_filename = "-"\n' in ir
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This strips the ModuleID and source_filename values from the LLVM
module immediately after creation. Previously those values would leak
into the IR:

```py
>>> env = gym.make("llvm-v0")
>>> env.reset(benchmark="cBench-v1/crc32")
>>> print(env.ir)
; ModuleID = 'benchmark://cBench-v1/crc32'
source_filename = "llvm-link"
...
```

This provided an opportunity for a learning algorithm to overfit to
the benchmarks by their name. Now, the ModuleID and source_filename
attributes are stripped, anonymizing the IRs:

```py
>>> print(env.ir)
; ModuleID = '-'
source_filename = "-"
...
```
