### PR TITLE
[tests] Fix pytest module rewrite failures in test_main.

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,11 +3,11 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 import os
+import subprocess
 import sys
 from typing import List, Optional
 
 import gym
-import pytest
 
 import compiler_gym  # noqa Register environments.
 from compiler_gym.util import debug_util as dbg
@@ -62,4 +62,9 @@ def main(extra_pytest_args: Optional[List[str]] = None, debug_level: int = 1):
 
     pytest_args += extra_pytest_args or []
 
-    sys.exit(pytest.main(pytest_args))
+    # Run the tests in a subprocess rather than directly invoking pytest.main()
+    # as pytest uses import-time hooks that fail if the module has already been
+    # imported.
+    process = subprocess.Popen(["pytest"] + pytest_args)
+    process.communicate()
+    sys.exit(process.returncode)


### PR DESCRIPTION
pytest.main() uses import-time hooks that fail if a module has already
been imported. This patch fixes this problem by instead invoking
pytest as a subprocess.

See: https://stackoverflow.com/a/54666289
