### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Now proceed to [All platforms](#all-platforms) below.
 On debian-based linux systems, install the required toolchain using:
 
 ```sh
-sudo apt install clang clang-9 libtinfo5 libjpeg-dev patchelf
+sudo apt install clang-9 libtinfo5 libjpeg-dev patchelf
 wget https://github.com/bazelbuild/bazelisk/releases/download/v1.7.5/bazelisk-linux-amd64 -O bazel
 chmod +x bazel && mkdir -p ~/.local/bin && mv -v bazel ~/.local/bin
 export PATH="$HOME/.local/bin:$PATH"

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Now proceed to [All platforms](#all-platforms) below.
 On debian-based linux systems, install the required toolchain using:
 
 ```sh
-sudo apt install clang libtinfo5 libjpeg-dev patchelf
+sudo apt install clang clang-9 libtinfo5 libjpeg-dev patchelf
 wget https://github.com/bazelbuild/bazelisk/releases/download/v1.7.5/bazelisk-linux-amd64 -O bazel
 chmod +x bazel && mkdir -p ~/.local/bin && mv -v bazel ~/.local/bin
 export PATH="$HOME/.local/bin:$PATH"


### PR DESCRIPTION
Clang 9 was needed on Ubuntu.

Fixes #182.
