### PR TITLE
[util] Make download() accept a list of redundant URLS.

### DIFF
--- a/compiler_gym/util/download.py
+++ b/compiler_gym/util/download.py
@@ -76,7 +76,6 @@ def _download(urls: List[str], sha256: Optional[str], max_retries: int = 3) -> b
     raise last_exception
 
 
-@fasteners.interprocess_locked(cache_path("downloads/LOCK"))
 def download(
     urls: Union[str, List[str]], sha256: Optional[str] = None, max_retries: int = 3
 ) -> bytes:

--- a/compiler_gym/util/download.py
+++ b/compiler_gym/util/download.py
@@ -5,6 +5,7 @@
 import hashlib
 import logging
 import os
+import random
 from typing import List, Optional, Union
 
 import fasteners
@@ -47,10 +48,11 @@ def _do_download_attempt(url: str, sha256: Optional[str]) -> bytes:
         # Cache the downloaded file.
         cache_path("downloads").mkdir(parents=True, exist_ok=True)
         # Atomic write by writing to a temporary file and renaming.
-        manifest_path = cache_path(f"downloads/{sha256}")
-        with open(f"{manifest_path}.tmp", "wb") as f:
+        path = cache_path(f"downloads/{sha256}")
+        tmp_path = f"{path}-{random.getrandbits(16):04x}"
+        with open(tmp_path, "wb") as f:
             f.write(content)
-        os.rename(f"{manifest_path}.tmp", str(manifest_path))
+        os.rename(tmp_path, str(path))
 
     logging.debug(f"Downloaded {url}")
     return content

--- a/compiler_gym/util/download.py
+++ b/compiler_gym/util/download.py
@@ -106,7 +106,7 @@ def download(
     # and download the same resource. If we don't have an ID for the resource
     # then we just lock globally to reduce NIC thrashing.
     if sha256:
-        with fasteners.InterProcessLock(cache_path("downloads/{sha256}.lock")):
+        with fasteners.InterProcessLock(cache_path(f"downloads/{sha256}.lock")):
             return _download(urls, sha256, max_retries)
     else:
         with fasteners.InterProcessLock(cache_path("downloads/LOCK")):

--- a/compiler_gym/util/download.py
+++ b/compiler_gym/util/download.py
@@ -5,7 +5,7 @@
 import hashlib
 import logging
 import os
-from typing import Optional
+from typing import List, Optional, Union
 
 import fasteners
 import requests
@@ -13,32 +13,31 @@ import requests
 from compiler_gym.util.runfiles_path import cache_path
 
 
-def __download(url: str) -> bytes:
+class DownloadFailed(OSError):
+    """Error thrown if a download fails."""
+
+
+def _get_url_data(url: str) -> bytes:
     req = requests.get(url)
     try:
         if req.status_code != 200:
-            raise OSError(f"GET returned status code {req.status_code}: {url}")
+            raise DownloadFailed(f"GET returned status code {req.status_code}: {url}")
 
         return req.content
     finally:
         req.close()
 
 
-def _download(url: str, sha256: Optional[str]) -> bytes:
-    # Cache hit.
-    if sha256 and cache_path(f"downloads/{sha256}").is_file():
-        with open(str(cache_path(f"downloads/{sha256}")), "rb") as f:
-            return f.read()
-
-    logging.info(f"Downloading {url} ...")
-    content = __download(url)
+def _do_download_attempt(url: str, sha256: Optional[str]) -> bytes:
+    logging.info("Downloading %s ...", url)
+    content = _get_url_data(url)
     if sha256:
         # Validate the checksum.
         checksum = hashlib.sha256()
         checksum.update(content)
         actual_sha256 = checksum.hexdigest()
         if sha256 != actual_sha256:
-            raise OSError(
+            raise DownloadFailed(
                 f"Checksum of downloaded dataset does not match:\n"
                 f"Url: {url}\n"
                 f"Expected: {sha256}\n"
@@ -57,29 +56,57 @@ def _download(url: str, sha256: Optional[str]) -> bytes:
     return content
 
 
+def _download(urls: List[str], sha256: Optional[str], max_retries: int = 3) -> bytes:
+    # Cache hit.
+    if sha256 and cache_path(f"downloads/{sha256}").is_file():
+        with open(str(cache_path(f"downloads/{sha256}")), "rb") as f:
+            return f.read()
+
+    # A retry loop, and loop over all urls provided.
+    last_exception = None
+    for _ in range(max_retries):
+        for url in urls:
+            try:
+                return _do_download_attempt(url, sha256)
+            except DownloadFailed as e:
+                logging.info("Download failed")
+                last_exception = e
+    raise last_exception
+
+
 @fasteners.interprocess_locked(cache_path("downloads/LOCK"))
-def download(url: str, sha256: Optional[str] = None) -> bytes:
+def download(
+    urls: Union[str, List[str]], sha256: Optional[str] = None, max_retries: int = 3
+) -> bytes:
     """Download a file and return its contents.
 
-    If :code:`sha256` is provided and the download succeeds, the file contents are cached locally
-    in :code:`$cache_path/downloads/$sha256`. See :func:`compiler_gym.cache_path`.
+    If :code:`sha256` is provided and the download succeeds, the file contents
+    are cached locally in :code:`$cache_path/downloads/$sha256`. See
+    :func:`compiler_gym.cache_path`.
 
     An inter-process lock ensures that only a single call to this function may
     execute at a time.
 
-    :param url: The URL of the file to download.
+    :param urls: Either a single URL of the file to download, or a list of URLs
+        to download.
+
     :param sha256: The expected sha256 checksum of the file.
+
     :return: The contents of the downloaded file.
-    :raises OSError: If the download fails, or if the downloaded content does match the expected
-        :code:`sha256` checksum.
+
+    :raises OSError: If the download fails, or if the downloaded content does
+        match the expected :code:`sha256` checksum.
     """
+    # Convert a singular string into a list of strings.
+    urls = [urls] if not isinstance(urls, list) else urls
+
     # Only a single process may download a file at a time. The idea here is to
     # prevent redundant downloads when multiple simultaneous processes all try
     # and download the same resource. If we don't have an ID for the resource
     # then we just lock globally to reduce NIC thrashing.
     if sha256:
         with fasteners.InterProcessLock(cache_path("downloads/{sha256}.lock")):
-            return _download(url, sha256)
+            return _download(urls, sha256, max_retries)
     else:
         with fasteners.InterProcessLock(cache_path("downloads/LOCK")):
-            return _download(url, None)
+            return _download(urls, None, max_retries)


### PR DESCRIPTION
This is to support downloading from multiple mirrors. Each URL is
tried in order until one succeeds.

This also adds a retry loop so that downloads can be attempted
multiple times before failing.