### PR TITLE
[env] Replace `logging_level` init arg with `logger`.

### DIFF
--- a/compiler_gym/envs/compiler_env.py
+++ b/compiler_gym/envs/compiler_env.py
@@ -160,7 +160,7 @@ class CompilerEnv(gym.Env):
         action_space: Optional[str] = None,
         connection_settings: Optional[ConnectionOpts] = None,
         service_connection: Optional[CompilerGymServiceConnection] = None,
-        logging_level: Optional[int] = None,
+        logger: Optional[logging.Logger] = None,
     ):
         """Construct and initialize a CompilerGym service environment.
 
@@ -199,10 +199,10 @@ class CompilerEnv(gym.Env):
             with the remote service.
         :param service_connection: An existing compiler gym service connection
             to use.
-        :param logging_level: The integer logging level to use for logging. By
-            default, the value reported by
-            :func:`get_logging_level() <compiler_gym.get_logging_level>` is
-            used.
+        :param logger: The logger to use for this environment. If not provided,
+            a :code:`compiler_gym.envs` logger is used and assigned the
+            verbosity returned by
+            :func:`get_logging_level() <compiler_gym.get_logging_level>`.
         :raises FileNotFoundError: If service is a path to a file that is not
             found.
         :raises TimeoutError: If the compiler service fails to initialize
@@ -210,11 +210,10 @@ class CompilerEnv(gym.Env):
         """
         self.metadata = {"render.modes": ["human", "ansi"]}
 
-        # Set up logging.
-        self.logger = logging.getLogger("compiler_gym.envs")
-        if logging_level is None:
-            logging_level = get_logging_level()
-        self.logger.setLevel(logging_level)
+        if logger is None:
+            logger = logging.getLogger("compiler_gym.envs")
+            logger.setLevel(get_logging_level())
+        self.logger = logger
 
         # A compiler service supports multiple simultaneous environments. This
         # session ID is used to identify this environment.

--- a/tests/compiler_env_test.py
+++ b/tests/compiler_env_test.py
@@ -3,6 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 """Unit tests for //compiler_gym/envs."""
+import logging
 import sys
 
 import gym
@@ -65,6 +66,18 @@ def test_benchmark_constructor_arg(env: CompilerEnv):
         assert env.benchmark == "cBench-v1/dijkstra"
     finally:
         env.close()
+
+
+def test_logger_forced():
+    logger = logging.getLogger("test_logger")
+    env_a = gym.make("llvm-v0")
+    env_b = gym.make("llvm-v0", logger=logger)
+    try:
+        assert env_a.logger != logger
+        assert env_b.logger == logger
+    finally:
+        env_a.close()
+        env_b.close()
 
 
 if __name__ == "__main__":

--- a/tests/llvm/llvm_env_test.py
+++ b/tests/llvm/llvm_env_test.py
@@ -3,7 +3,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 """Integrations tests for the LLVM CompilerGym environments."""
-import logging
 from enum import Enum
 from pathlib import Path
 from typing import List
@@ -295,14 +294,6 @@ def test_generate_enum_declarations(env: LlvmEnv):
 
 def test_logging_default_level(env: LlvmEnv):
     assert env.logger.level == dbg.get_logging_level()
-
-
-def test_logging_forced_level():
-    env = gym.make("llvm-v0", logging_level=logging.INFO)
-    try:
-        assert env.logger.level == logging.INFO
-    finally:
-        env.close()
 
 
 def test_step_multiple_actions_list(env: LlvmEnv):


### PR DESCRIPTION
Using a logger instance as the input to a CompilerEnv allows for more
fine grained control than simply specifying the log verbosity level.

