### PR TITLE
[tests] Filter noisy warnings on install-test.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,9 +220,10 @@ install-test-datasets:
 
 install-test: install-test-datasets
 	mkdir -p /tmp/compiler_gym/wheel_tests
-	rm -f /tmp/compiler_gym/wheel_tests/tests
+	rm -f /tmp/compiler_gym/wheel_tests/tests /tmp/compiler_gym/wheel_tests/tox.ini
 	ln -s $(ROOT)/tests /tmp/compiler_gym/wheel_tests
-	cd /tmp/compiler_gym/wheel_tests && pytest tests -n auto -k "not fuzz"
+	ln -s $(ROOT)/tox.ini /tmp/compiler_gym/wheel_tests
+	cd /tmp/compiler_gym/wheel_tests && pytest tests --benchmark-disable -n auto -k "not fuzz"
 
 # The minimum number of seconds to run the fuzz tests in a loop for. Override
 # this at the commandline, e.g. `FUZZ_SECONDS=1800 make fuzz`.

--- a/tox.ini
+++ b/tox.ini
@@ -8,3 +8,7 @@ line_length = 88
 
 [flake8]
 ignore = E501, E302, W503, E203
+
+[pytest]
+filterwarnings =
+    ignore::pytest.PytestAssertRewriteWarning:


### PR DESCRIPTION
Filter the unactionable warnings generated by pytest.
