### PR TITLE
[env] Add initial observations to StartSession calls.

### DIFF
--- a/compiler_gym/envs/compiler_env.py
+++ b/compiler_gym/envs/compiler_env.py
@@ -710,6 +710,11 @@ class CompilerEnv(gym.Env):
                         if self.action_space_name
                         else 0
                     ),
+                    observation_space=(
+                        [self.observation_space.index]
+                        if self.observation_space
+                        else None
+                    ),
                 ),
             )
         except (ServiceError, ServiceTransportError, TimeoutError) as e:
@@ -749,7 +754,13 @@ class CompilerEnv(gym.Env):
             self.episode_reward = 0
 
         if self.observation_space:
-            return self.observation[self.observation_space.id]
+            if len(reply.observation) != 1:
+                raise OSError(
+                    f"Expected one observation from service, received {len(reply.observation)}"
+                )
+            return self.observation.spaces[self.observation_space.id].translate(
+                reply.observation[0]
+            )
 
     def step(self, action: Union[int, Iterable[int]]) -> step_t:
         """Take a step.

--- a/compiler_gym/envs/llvm/service/LlvmSession.h
+++ b/compiler_gym/envs/llvm/service/LlvmSession.h
@@ -51,13 +51,13 @@ class LlvmSession {
   // since the start of the session. This is just for logging and has no effect.
   inline int actionCount() const { return actionCount_; }
 
- protected:
   // Run the requested action.
   [[nodiscard]] grpc::Status runAction(LlvmAction action, StepReply* reply);
 
   // Compute the requested observation.
   [[nodiscard]] grpc::Status getObservation(LlvmObservationSpace space, Observation* reply);
 
+ protected:
   // Run the given pass, possibly modifying the underlying LLVM module.
   void runPass(llvm::Pass* pass, StepReply* reply);
   void runPass(llvm::FunctionPass* pass, StepReply* reply);

--- a/compiler_gym/service/proto/compiler_gym_service.proto
+++ b/compiler_gym/service/proto/compiler_gym_service.proto
@@ -71,6 +71,8 @@ message StartSessionRequest {
   // space that is to be used for this session. Once set, the action space
   // cannot be changed for the duration of the session.
   int32 action_space = 2;
+  // A list of indices into the GetSpacesReply.observation_space_list
+  repeated int32 observation_space = 3;
 }
 
 message StartSessionReply {
@@ -85,6 +87,8 @@ message StartSessionReply {
   // space and replace it with this one. Else, the action space remains
   // unchanged.
   ActionSpace new_action_space = 3;
+  // Observed states after completing the action.
+  repeated Observation observation = 4;
 }
 
 // ===========================================================================

--- a/examples/example_compiler_gym_service/service_cc/ExampleService.h
+++ b/examples/example_compiler_gym_service/service_cc/ExampleService.h
@@ -67,9 +67,9 @@ class ExampleCompilationSession {
 
   [[nodiscard]] grpc::Status Step(const StepRequest* request, StepReply* reply);
 
- private:
   grpc::Status getObservation(int32_t observationSpace, Observation* reply);
 
+ private:
   const std::string benchmark_;
   ActionSpace actionSpace_;
 };


### PR DESCRIPTION
This patch modifies the StartSessionRequest RPC call to add a list of
observations to compute. This means that env.reset() requires only a
single RPC roundtrip, rather than needing to call StartSession()
followed by Step().

The result is a **15%-21% speedup** in `env.reset()` runtime, depending on
the size of the benchmark (slower benchmarks benefit more):

```
---------------------------------------------------------------------------- benchmark 'test_reset[fast_benchmark]': 2 tests ----------------------------------------------------------------------------
Name (time in ms)                               Min               Max              Mean            StdDev            Median               IQR            Outliers       OPS            Rounds  Iterations
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_reset[fast_benchmark] (development)     1.8736 (1.26)     2.0939 (1.17)     1.9388 (1.15)     0.0411 (1.25)     1.9368 (1.15)     0.0583 (1.0)         181;1  515.7798 (0.87)        500         200
test_reset[fast_benchmark] (reset)           1.4903 (1.0)      1.7889 (1.0)      1.6839 (1.0)      0.0330 (1.0)      1.6773 (1.0)      0.0596 (1.02)        151;1  593.8650 (1.0)         500         200
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

------------------------------------------------------------------------------ benchmark 'test_reset[slow_benchmark]': 2 tests ------------------------------------------------------------------------------
Name (time in ms)                                Min                 Max               Mean            StdDev             Median               IQR            Outliers      OPS            Rounds  Iterations
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_reset[slow_benchmark] (development)     83.2942 (1.21)     108.7450 (1.24)     93.9165 (1.21)     3.5005 (1.11)     93.7544 (1.21)     3.4142 (1.0)        128;38  10.6478 (0.83)        500           1
test_reset[slow_benchmark] (reset)           69.0844 (1.0)       87.8784 (1.0)      77.7085 (1.0)      3.1453 (1.0)      77.4392 (1.0)      3.5923 (1.05)       163;18  12.8686 (1.0)         500           1
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```