### PR TITLE
[datasets-overhaul #2] Add a new Dataset class.

### DIFF
--- a/compiler_gym/bin/BUILD
+++ b/compiler_gym/bin/BUILD
@@ -22,7 +22,7 @@ py_binary(
     srcs = ["datasets.py"],
     visibility = ["//visibility:public"],
     deps = [
-        "//compiler_gym/datasets:dataset",
+        "//compiler_gym/datasets",
         "//compiler_gym/envs",
         "//compiler_gym/util",
         "//compiler_gym/util/flags:env_from_flags",

--- a/compiler_gym/datasets/BUILD
+++ b/compiler_gym/datasets/BUILD
@@ -18,12 +18,3 @@ py_library(
         "//compiler_gym/util",
     ],
 )
-
-py_library(
-    name = "dataset",
-    srcs = ["dataset.py"],
-    visibility = ["//compiler_gym:__subpackages__"],
-    deps = [
-        "//compiler_gym/util",
-    ],
-)

--- a/compiler_gym/datasets/__init__.py
+++ b/compiler_gym/datasets/__init__.py
@@ -9,6 +9,8 @@ from compiler_gym.datasets.benchmark import (
     BenchmarkSource,
 )
 from compiler_gym.datasets.dataset import (
+    Dataset,
+    DatasetInitError,
     LegacyDataset,
     activate,
     deactivate,
@@ -21,6 +23,8 @@ __all__ = [
     "Benchmark",
     "BenchmarkInitError",
     "BenchmarkSource",
+    "Dataset",
+    "DatasetInitError",
     "deactivate",
     "delete",
     "LegacyDataset",

--- a/compiler_gym/datasets/dataset.py
+++ b/compiler_gym/datasets/dataset.py
@@ -4,22 +4,338 @@
 # LICENSE file in the root directory of this source tree.
 import io
 import json
+import logging
 import os
 import shutil
 import tarfile
 import warnings
 from pathlib import Path
-from typing import List, NamedTuple, Optional, Union
+from typing import Dict, Iterable, List, NamedTuple, Optional, Union
 
 import fasteners
+import numpy as np
 from deprecated.sphinx import deprecated
 
+from compiler_gym.datasets.benchmark import DATASET_NAME_RE, Benchmark
+from compiler_gym.util.debug_util import get_logging_level
 from compiler_gym.util.download import download
+
+
+class Dataset(object):
+    """A dataset is a collection of benchmarks.
+
+    The Dataset class has methods for installing and managing groups of
+    benchmarks, for listing the available benchmark URIs, and for instantiating
+    :class:`Benchmark <compiler_gym.datasets.Benchmark>` objects.
+
+    The Dataset class is an abstract base for implementing datasets. At a
+    minimum, subclasses must implement the :meth:`benchmark()
+    <compiler_gym.datasets.Dataset.benchmark>` and :meth:`benchmark_uris()
+    <compiler_gym.datasets.Dataset.benchmark_uris>` methods. Other methods such
+    as :meth:`install() <compiler_gym.datasets.Dataset.install>` may be used
+    where helpful.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        description: str,
+        license: str,  # pylint: disable=redefined-builtin
+        site_data_base: Path,
+        benchmark_class=Benchmark,
+        references: Optional[Dict[str, str]] = None,
+        random: Optional[np.random.Generator] = None,
+        hidden: bool = False,
+        sort_order: int = 0,
+        logger: Optional[logging.Logger] = None,
+        validatable: str = "No",
+    ):
+        """Constructor.
+
+        :param name: The name of the dataset. Must conform to the pattern
+            :code:`{{protocol}}://{{name}}-v{{version}}`.
+
+        :param description: A short human-readable description of the dataset.
+
+        :param license: The name of the dataset's license.
+
+        :param site_data_base: The base path of a directory that will be used to
+            store installed files.
+
+        :param benchmark_class: The class to use when instantiating benchmarks.
+            It must have the same constructor signature as :class:`Benchmark
+            <compiler_gym.datasets.Benchmark>`.
+
+        :param references: A dictionary containing URLs for this dataset, keyed
+            by their name. E.g. :code:`references["Paper"] = "https://..."`.
+
+        :param random: A source of randomness for selecting benchmarks.
+
+        :param hidden: Whether the dataset should be excluded from the
+            :meth:`datasets() <compiler_gym.datasets.Datasets.dataset>` iterator
+            of any :class:`Datasets <compiler_gym.datasets.Datasets>` container.
+
+        :param sort_order: An optional numeric value that should be used to
+            order this dataset relative to others. Lowest value sorts first.
+
+        :param validatable: Whether the dataset is validatable. A validatable
+            dataset is one where the behavior of the benchmarks can be checked
+            by compiling the programs to binaries and executing them. If the
+            benchmarks crash, or are found to have different behavior, then
+            validation fails. This type of validation is used to check that the
+            compiler has not broken the semantics of the program. This value
+            takes a string and is used for documentation purposes only.
+            Suggested values are "Yes", "No", or "Partial".
+        """
+        self._name = name
+        components = DATASET_NAME_RE.match(name)
+        if not components:
+            raise ValueError(
+                f"Invalid dataset name: '{name}'. "
+                "Dataset name must be in the form: '{{protocol}}://{{name}}-v{{version}}'"
+            )
+        self._description = description
+        self._license = license
+        self._protocol = components.group("dataset_protocol")
+        self._version = int(components.group("dataset_version"))
+        self._references = references or {}
+        self._hidden = hidden
+        self._validatable = validatable
+
+        self.random = random or np.random.default_rng()
+        self._logger = logger
+        self.sort_order = sort_order
+        self.benchmark_class = benchmark_class
+
+        # Set up the site data name.
+        basename = components.group("dataset_name")
+        self._site_data_path = Path(site_data_base).resolve() / self.protocol / basename
+
+    def __repr__(self):
+        return self.name
+
+    def seed(self, seed: int):
+        """Set the random state.
+
+        Setting a random state will fix the order that
+        :meth:`dataset.benchmark() <compiler_gym.datasets.Dataset.benchmark>`
+        returns benchmarks when called without arguments.
+
+        :param seed: A number.
+        """
+        self.random = np.random.default_rng(seed)
+
+    @property
+    def logger(self) -> logging.Logger:
+        """The logger for this dataset.
+
+        :type: logging.Logger
+        """
+        # NOTE(cummins): Default logger instantiation is deferred since in
+        # Python 3.6 the Logger instance contains an un-pickle-able Rlock()
+        # which can prevent gym.make() from working. This is a workaround that
+        # can be removed once Python 3.6 support is dropped.
+        if self._logger is None:
+            self._logger = logging.getLogger("compiler_gym.datasets")
+            self._logger.setLevel(get_logging_level())
+        return self._logger
+
+    @property
+    def name(self) -> str:
+        """The name of the dataset.
+
+        :type: str
+        """
+        return self._name
+
+    @property
+    def description(self) -> str:
+        """A short human-readable description of the dataset.
+
+        :type: str
+        """
+        return self._description
+
+    @property
+    def license(self) -> str:
+        """The name of the license of the dataset.
+
+        :type: str
+        """
+        return self._license
+
+    @property
+    def protocol(self) -> str:
+        """The URI protocol that is used to identify benchmarks in this dataset.
+
+        :type: str
+        """
+        return self._protocol
+
+    @property
+    def version(self) -> int:
+        """A version tag for this dataset.
+
+        :type: int
+        """
+        return self._version
+
+    @property
+    def references(self) -> Dict[str, str]:
+        """A dictionary containing URLs for this dataset, keyed by their name.
+        E.g. :code:`references["Paper"] = "https://..."`.
+
+        :type: Dict[str, str]
+        """
+        return self._references
+
+    @property
+    def hidden(self) -> str:
+        """Whether the dataset is included in the iterable sequence of datasets
+        of a containing :class:`Datasets <compiler_gym.datasets.Datasets>`
+        collection.
+
+        :type: bool
+        """
+        return self._hidden
+
+    @property
+    def validatable(self) -> str:
+        """Whether the dataset is validatable. A validatable dataset is one
+        where the behavior of the benchmarks can be checked by compiling the
+        programs to binaries and executing them. If the benchmarks crash, or are
+        found to have different behavior, then validation fails. This type of
+        validation is used to check that the compiler has not broken the
+        semantics of the program.
+
+        This property takes a string and is used for documentation purposes
+        only. Suggested values are "Yes", "No", or "Partial".
+
+        :type: str
+        """
+        return self._validatable
+
+    @property
+    def site_data_path(self) -> Path:
+        """The filesystem path used to store persistent dataset files.
+
+        This directory may not exist.
+
+        :type: Path
+        """
+        return self._site_data_path
+
+    @property
+    def site_data_size_in_bytes(self) -> int:
+        """The total size of the on-disk data used by this dataset.
+
+        :type: int
+        """
+        if not self.site_data_path.is_dir():
+            return 0
+
+        total_size = 0
+        for dirname, _, filenames in os.walk(self.site_data_path):
+            total_size += sum(
+                os.path.getsize(os.path.join(dirname, f)) for f in filenames
+            )
+        return total_size
+
+    @property
+    def n(self) -> int:
+        """The number of benchmarks in the dataset. This value is negative if
+        the number of benchmarks in the dataset is unbounded, for example
+        because the dataset represents a program generator that can produce an
+        infinite number of programs.
+
+        :type: int
+        """
+        return 0
+
+    @property
+    def installed(self) -> bool:
+        """Whether the dataset is installed locally. Installation occurs
+        automatically on first use, or by calling :meth:`install()
+        <compiler_gym.datasets.Dataset.install>`.
+
+        :type: bool
+        """
+        return True
+
+    def install(self) -> None:
+        """Install this dataset locally.
+
+        Implementing this method is optional.
+
+        This method should not perform redundant work - it should detect whether
+        any work needs to be done so that repeated calls to install will
+        complete quickly.
+        """
+
+    def uninstall(self) -> None:
+        """Remove any local data for this benchmark.
+
+        The dataset can still be used after calling this method. This method
+        just undoes the work of :meth:`install()
+        <compiler_gym.datasets.Dataset.install>`.
+        """
+        if self.site_data_path.is_dir():
+            shutil.rmtree(self.site_data_path)
+
+    def benchmarks(self) -> Iterable[Benchmark]:
+        """Enumerate the (possibly infinite) benchmarks lazily.
+
+        Benchmark order is consistent across runs. The order of
+        :meth:`benchmarks() <compiler_gym.datasets.Dataset.benchmarks>` and
+        :meth:`benchmark_uris() <compiler_gym.datasets.Dataset.benchmark_uris>`
+        is the same.
+
+        :return: An iterable sequence of :class:`Benchmark
+            <compiler_gym.datasets.Benchmark>` instances.
+        """
+        # Default implementation. Subclasses may wish to provide an alternative
+        # implementation that is optimized to specific use cases.
+        yield from (self.benchmark(uri) for uri in self.benchmark_uris())
+
+    def benchmark_uris(self) -> Iterable[str]:
+        """Enumerate the (possibly infinite) benchmark URIs.
+
+        Benchmark URI order is consistent across runs. The order of
+        :meth:`benchmarks() <compiler_gym.datasets.Dataset.benchmarks>` and
+        :meth:`benchmark_uris() <compiler_gym.datasets.Dataset.benchmark_uris>`
+        is the same.
+
+        :return: An iterable sequence of benchmark URI strings.
+        """
+        raise NotImplementedError("abstract class")
+
+    def benchmark(self, uri: Optional[str] = None) -> Benchmark:
+        """Select a benchmark.
+
+        If a URI is given, the corresponding :class:`Benchmark
+        <compiler_gym.datasets.Benchmark>` is returned. Otherwise, a benchmark
+        is selected uniformly randomly.
+
+        Use :meth:`seed() <compiler_gym.datasets.Dataset.seed>` to force a
+        reproducible order for randomly selected benchmarks.
+
+        :param uri: The URI of the benchmark to return. If :code:`None`, select
+            a benchmark randomly using :code:`self.random`.
+
+        :return: A :class:`Benchmark <compiler_gym.datasets.Benchmark>`
+            instance.
+
+        :raise LookupError: If :code:`uri` is provided but does not exist.
+        """
+        raise NotImplementedError("abstract class")
+
+
+class DatasetInitError(OSError):
+    """Base class for errors raised if a dataset fails to initialize."""
 
 
 class LegacyDataset(NamedTuple):
     """A collection of benchmarks for use by an environment.
-
     .. deprecated:: 0.1.4
        The next release of CompilerGym will introduce a new API for describing
        datasets with extended functionality. See
@@ -67,7 +383,6 @@ class LegacyDataset(NamedTuple):
     @classmethod
     def from_json_file(cls, path: Path) -> "LegacyDataset":
         """Construct a dataset form a JSON metadata file.
-
         :param path: Path of the JSON metadata.
         :return: A LegacyDataset instance.
         """
@@ -84,7 +399,6 @@ class LegacyDataset(NamedTuple):
 
     def to_json_file(self, path: Path) -> Path:
         """Write the dataset metadata to a JSON file.
-
         :param path: Path of the file to write.
         :return: The path of the written file.
         """
@@ -102,7 +416,6 @@ class LegacyDataset(NamedTuple):
 )
 def activate(env, name: str) -> bool:
     """Move a directory from the inactive to active benchmark directory.
-
     :param: The name of a dataset.
     :return: :code:`True` if the dataset was activated, else :code:`False` if
         already active.
@@ -131,7 +444,6 @@ def activate(env, name: str) -> bool:
 )
 def delete(env, name: str) -> bool:
     """Delete a directory in the inactive benchmark directory.
-
     :param: The name of a dataset.
     :return: :code:`True` if the dataset was deleted, else :code:`False` if
         already deleted.
@@ -158,7 +470,6 @@ def delete(env, name: str) -> bool:
 )
 def deactivate(env, name: str) -> bool:
     """Move a directory from active to the inactive benchmark directory.
-
     :param: The name of a dataset.
     :return: :code:`True` if the dataset was deactivated, else :code:`False` if
         already inactive.
@@ -176,17 +487,13 @@ def deactivate(env, name: str) -> bool:
 
 def require(env, dataset: Union[str, LegacyDataset]) -> bool:
     """Require that the given dataset is available to the environment.
-
     This will download and activate the dataset if it is not already installed.
     After calling this function, benchmarks from the dataset will be available
     to use.
-
     Example usage:
-
         >>> env = gym.make("llvm-v0")
         >>> require(env, "blas-v0")
         >>> env.reset(benchmark="blas-v0/1")
-
     :param env: The environment that this dataset is required for.
     :param dataset: The name of the dataset to download, the URL of the dataset,
         or a :class:`LegacyDataset` instance.

--- a/compiler_gym/envs/BUILD
+++ b/compiler_gym/envs/BUILD
@@ -21,7 +21,7 @@ py_library(
     deps = [
         "//compiler_gym:compiler_env_state",
         "//compiler_gym:validation_result",
-        "//compiler_gym/datasets:dataset",
+        "//compiler_gym/datasets",
         "//compiler_gym/service",
         "//compiler_gym/service/proto",
         "//compiler_gym/spaces",

--- a/compiler_gym/envs/llvm/BUILD
+++ b/compiler_gym/envs/llvm/BUILD
@@ -35,7 +35,7 @@ py_library(
     srcs = ["legacy_datasets.py"],
     visibility = ["//tests:__subpackages__"],
     deps = [
-        "//compiler_gym/datasets:dataset",
+        "//compiler_gym/datasets",
         "//compiler_gym/third_party/llvm",
         "//compiler_gym/util",
     ],

--- a/tests/datasets/BUILD
+++ b/tests/datasets/BUILD
@@ -14,3 +14,14 @@ py_test(
         "//tests/pytest_plugins:common",
     ],
 )
+
+py_test(
+    name = "dataset_test",
+    timeout = "short",
+    srcs = ["dataset_test.py"],
+    deps = [
+        "//compiler_gym/datasets",
+        "//tests:test_main",
+        "//tests/pytest_plugins:common",
+    ],
+)

--- a/tests/datasets/dataset_test.py
+++ b/tests/datasets/dataset_test.py
@@ -1,0 +1,138 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Unit tests for //compiler_gym/datasets."""
+from pathlib import Path
+
+import pytest
+
+from compiler_gym.datasets.dataset import Dataset
+from tests.test_main import main
+
+pytest_plugins = ["tests.pytest_plugins.common"]
+
+# pylint: disable=abstract-method
+
+
+@pytest.mark.parametrize(
+    "invalid_name", ["benchmark://test", "test-v0", "benchmark://v0"]
+)
+def test_dataset__invalid_name(invalid_name: str):
+    """Test that invalid dataset names raise an error on init."""
+
+    with pytest.raises(ValueError) as e_ctx:
+        Dataset(
+            name=invalid_name,
+            description="A test dataset",
+            license="MIT",
+            site_data_base="test",
+        )
+
+    assert str(e_ctx.value) == (
+        f"Invalid dataset name: '{invalid_name}'. "
+        "Dataset name must be in the form: '{{protocol}}://{{name}}-v{{version}}'"
+    )
+
+
+def test_dataset_properties():
+    """Test the dataset property values."""
+    dataset = Dataset(
+        name="benchmark://test-v0",
+        description="A test dataset",
+        license="MIT",
+        site_data_base="test",
+    )
+
+    assert dataset.name == "benchmark://test-v0"
+    assert dataset.protocol == "benchmark"
+    assert dataset.description == "A test dataset"
+    assert dataset.license == "MIT"
+
+
+def test_dataset_optional_properties():
+    """Test the default values of optional dataset properties."""
+    dataset = Dataset(
+        name="benchmark://test-v0",
+        description="A test dataset",
+        license="MIT",
+        site_data_base="test",
+    )
+
+    assert dataset.references == {}  # Default value.
+    assert not dataset.hidden
+    assert dataset.sort_order == 0
+    assert dataset.validatable == "No"
+
+
+def test_dataset_optional_properties_explicit_values():
+    """Test the non-default values of optional dataset properties."""
+    dataset = Dataset(
+        name="benchmark://test-v0",
+        description="A test dataset",
+        license="MIT",
+        site_data_base="test",
+        references={"GitHub": "https://github.com/facebookresearch/CompilerGym"},
+        hidden=True,
+        sort_order=10,
+        validatable="Yes",
+    )
+
+    assert dataset.references == {
+        "GitHub": "https://github.com/facebookresearch/CompilerGym"
+    }
+    assert dataset.hidden
+    assert dataset.sort_order == 10
+    assert dataset.validatable == "Yes"
+
+
+def test_dataset_inferred_properties():
+    """Test the values of inferred dataset properties."""
+    dataset = Dataset(
+        name="benchmark://test-v0",
+        description="A test dataset",
+        license="MIT",
+        site_data_base="test",
+    )
+
+    assert dataset.protocol == "benchmark"
+    assert dataset.version == 0
+
+
+def test_dataset_properties_read_only(tmpwd: Path):
+    """Test that dataset properties are read-only."""
+    dataset = Dataset(
+        name="benchmark://test-v0",
+        description="A test dataset",
+        license="MIT",
+        site_data_base="test",
+    )
+
+    with pytest.raises(AttributeError):
+        dataset.name = "benchmark://test-v1"
+    with pytest.raises(AttributeError):
+        dataset.description = "A test dataset"
+    with pytest.raises(AttributeError):
+        dataset.license = "MIT"
+    with pytest.raises(AttributeError):
+        dataset.site_data_path = tmpwd
+
+
+def test_dataset_site_data_directory(tmpwd: Path):
+    """Test the path generated for site data."""
+    dataset = Dataset(
+        name="benchmark://test-v0",
+        description="A test dataset",
+        license="MIT",
+        site_data_base="test",
+    )
+
+    # Use endswith() since tmpwd on macOS may have a '/private' prefix.
+    assert str(dataset.site_data_path).endswith(
+        str(tmpwd / "test" / "benchmark" / "test-v0")
+    )
+    assert not dataset.site_data_path.is_dir()  # Dir is not created until needed.
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
A dataset is a collection of benchmarks.

Datasets provide a convenience abstraction for installing and managing groups of benchmarks. Datasets provide the API for instantiating benchmarks, either by randomly selecting from the available benchmarks or by selecting by URI.

The Dataset class is an abstract base for implementing datasets. At a minimum, subclasses must implement the `benchmark()` and `benchmark_uris()` methods. Other methods such as `install()` may be used where helpful.

Issue #45.