### PR TITLE
[datasets-overhaul #3] Add Dataset helper subclasses.

### DIFF
--- a/compiler_gym/datasets/BUILD
+++ b/compiler_gym/datasets/BUILD
@@ -10,6 +10,8 @@ py_library(
         "__init__.py",
         "benchmark.py",
         "dataset.py",
+        "files_dataset.py",
+        "tar_dataset.py",
     ],
     visibility = ["//visibility:public"],
     deps = [

--- a/compiler_gym/datasets/__init__.py
+++ b/compiler_gym/datasets/__init__.py
@@ -17,6 +17,8 @@ from compiler_gym.datasets.dataset import (
     delete,
     require,
 )
+from compiler_gym.datasets.files_dataset import FilesDataset
+from compiler_gym.datasets.tar_dataset import TarDataset, TarDatasetWithManifest
 
 __all__ = [
     "activate",
@@ -27,6 +29,9 @@ __all__ = [
     "DatasetInitError",
     "deactivate",
     "delete",
+    "FilesDataset",
     "LegacyDataset",
     "require",
+    "TarDataset",
+    "TarDatasetWithManifest",
 ]

--- a/compiler_gym/datasets/files_dataset.py
+++ b/compiler_gym/datasets/files_dataset.py
@@ -1,0 +1,163 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+import os
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+from compiler_gym.datasets.dataset import Benchmark, Dataset
+from compiler_gym.util.decorators import memoized_property
+
+
+class FilesDataset(Dataset):
+    """A dataset comprising a directory tree of files.
+
+    A FilesDataset is a root directory that contains (a possibly nested tree of)
+    files, where each file represents a benchmark. Files can be filtered on
+    their expected filename suffix.
+
+    Every file that matches a filename suffix is a benchmark. The URI of a
+    benchmark is the relative path of the file, stripped of the filename suffix.
+    For example, given the following file tree:
+
+    .. code-block::
+
+        /tmp/dataset/a.txt
+        /tmp/dataset/LICENSE
+        /tmp/dataset/subdir/subdir/b.txt
+        /tmp/dataset/subdir/subdir/c.txt
+
+    a FilesDataset :code:`benchmark://ds-v0` rooted at :code:`/tmp/dataset` with
+    filename suffix :code:`.txt` will contain the following URIs:
+
+        >>> list(dataset.benchmark_uris())
+        [
+            "benchamrk://ds-v0/a",
+            "benchamrk://ds-v0/subdir/subdir/b",
+            "benchamrk://ds-v0/subdir/subdir/c",
+        ]
+    """
+
+    def __init__(
+        self,
+        dataset_root: Path,
+        benchmark_file_suffix: str = "",
+        memoize_uris: bool = True,
+        **dataset_args,
+    ):
+        """Constructor.
+
+        :param dataset_root: The root directory to look for benchmark files.
+
+        :param benchmark_file_suffix: A file extension that must be matched for
+            a file to be used as a benchmark.
+
+        :param memoize_uris: Whether to memoize the list of URIs contained in
+            the dataset. Memoizing the URIs is a tradeoff between *O(n)*
+            computation complexity of random access vs *O(n)* space complexity
+            of memoizing the URI list.
+
+        :param dataset_args: See :meth:`Dataset.__init__()
+            <compiler_gym.datasets.Dataset.__init__>`.
+        """
+        super().__init__(**dataset_args)
+        self.dataset_root = dataset_root
+        self.benchmark_file_suffix = benchmark_file_suffix
+        self.memoize_uris = memoize_uris
+        self._memoized_uris = None
+
+    @memoized_property
+    def n(self) -> int:  # pylint: disable=invalid-overriden-method
+        self.install()
+        return sum(
+            sum(1 for f in files if f.endswith(self.benchmark_file_suffix))
+            for (_, _, files) in os.walk(self.dataset_root)
+        )
+
+    @property
+    def _benchmark_uris_iter(self) -> Iterable[str]:
+        """Return an iterator over benchmark URIs that is consistent across runs."""
+        self.install()
+        for root, dirs, files in os.walk(self.dataset_root):
+            # Sort the subdirectories so that os.walk() order is stable between
+            # runs.
+            dirs.sort()
+            reldir = root[len(str(self.dataset_root)) + 1 :]
+            for filename in sorted(files):
+                # If we have an expected file suffix then ignore files that do
+                # not match, and strip the suffix from files that do match.
+                if self.benchmark_file_suffix:
+                    if not filename.endswith(self.benchmark_file_suffix):
+                        continue
+                    filename = filename[: -len(self.benchmark_file_suffix)]
+                # Use os.path.join() rather than simple '/' concatenation as
+                # reldir may be empty.
+                yield os.path.join(self.name, reldir, filename)
+
+    @property
+    def _benchmark_uris(self) -> List[str]:
+        return list(self._benchmark_uris_iter)
+
+    def benchmark_uris(self) -> Iterable[str]:
+        if self._memoized_uris:
+            yield from self._memoized_uris
+        elif self.memoize_uris:
+            self._memoized_uris = self._benchmark_uris
+            yield from self._memoized_uris
+        else:
+            yield from self._benchmark_uris_iter
+
+    def benchmark(self, uri: Optional[str] = None) -> Benchmark:
+        self.install()
+        if uri is None or len(uri) <= len(self.name) + 1:
+            if not self.n:
+                raise ValueError("No benchmarks")
+            return self._get_benchmark_by_index(self.random.integers(self.n))
+
+        relpath = f"{uri[len(self.name) + 1:]}{self.benchmark_file_suffix}"
+        abspath = self.dataset_root / relpath
+        if not abspath.is_file():
+            raise LookupError(f"Benchmark not found: {uri} (file not found: {abspath})")
+        return self.benchmark_class.from_file(uri, abspath)
+
+    def _get_benchmark_by_index(self, n: int) -> Benchmark:
+        """Look up a benchmark using a numeric index into the list of URIs,
+        without bounds checking.
+        """
+        # If we have memoized the benchmark IDs then just index into the list.
+        # Otherwise we will scan through the directory hierarchy.
+        if self.memoize_uris:
+            if not self._memoized_uris:
+                self._memoized_uris = self._benchmark_uris
+            return self.benchmark(self._memoized_uris[n])
+
+        i = 0
+        for root, dirs, files in os.walk(self.dataset_root):
+            reldir = root[len(str(self.dataset_root)) + 1 :]
+
+            # Filter only the files that match the target file suffix.
+            valid_files = [f for f in files if f.endswith(self.benchmark_file_suffix)]
+
+            if i + len(valid_files) <= n:
+                # There aren't enough files in this directory to bring us up to
+                # the target file index, so skip this directory and descend into
+                # subdirectories.
+                i += len(valid_files)
+                # Sort the subdirectories so that the iteration order is stable
+                # and consistent with benchmark_uris().
+                dirs.sort()
+            else:
+                valid_files.sort()
+                filename = valid_files[n - i]
+                name_stem = filename
+                if self.benchmark_file_suffix:
+                    name_stem = filename[: -len(self.benchmark_file_suffix)]
+                # Use os.path.join() rather than simple '/' concatenation as
+                # reldir may be empty.
+                uri = os.path.join(self.name, reldir, name_stem)
+                return self.benchmark_class.from_file(uri, os.path.join(root, filename))
+
+        # "Unreachable". _get_benchmark_by_index() should always be called with
+        # in-bounds values. Perhaps files have been deleted from site_data_path?
+        raise IndexError(f"Could not find benchmark with index {n} / {self.n}")

--- a/compiler_gym/datasets/tar_dataset.py
+++ b/compiler_gym/datasets/tar_dataset.py
@@ -1,0 +1,216 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+import bz2
+import gzip
+import io
+import shutil
+import tarfile
+from threading import Lock
+from typing import Iterable, List, Optional
+
+from fasteners import InterProcessLock
+
+from compiler_gym.datasets.files_dataset import FilesDataset
+from compiler_gym.util.decorators import memoized_property
+from compiler_gym.util.download import download
+from compiler_gym.util.filesystem import atomic_file_write
+
+
+class TarDataset(FilesDataset):
+    """A dataset comprising a files tree stored in a tar archive.
+
+    This extends the :class:`FilesDataset` class by adding support for
+    compressed archives of files. The archive is downloaded and unpacked
+    on-demand.
+    """
+
+    def __init__(
+        self,
+        tar_urls: List[str],
+        tar_sha256: Optional[str] = None,
+        tar_compression: str = "bz2",
+        strip_prefix: str = "",
+        **dataset_args,
+    ):
+        """Constructor.
+
+        :param tar_urls: A list of redundant URLS to download the tar archive from.
+
+        :param tar_sha256: The SHA256 checksum of the downloaded tar archive.
+
+        :param tar_compression: The tar archive compression type. One of
+            {"bz2", "gz"}.
+
+        :param strip_prefix: An optional path prefix to strip. Only files that
+            match this path prefix will be used as benchmarks.
+
+        :param dataset_args: See :meth:`FilesDataset.__init__()
+            <compiler_gym.datasets.FilesDataset.__init__>`.
+        """
+        super().__init__(
+            dataset_root=None,  # Set below once site_data_path is resolved.
+            **dataset_args,
+        )
+        self.dataset_root = self.site_data_path / "contents" / strip_prefix
+
+        self.tar_urls = tar_urls
+        self.tar_sha256 = tar_sha256
+        self.tar_compression = tar_compression
+        self.strip_prefix = strip_prefix
+
+        self._installed = False
+        self._tar_extracted_marker = self.site_data_path / ".extracted"
+        self._tar_lock = Lock()
+        self._tar_lockfile = self.site_data_path / "LOCK"
+
+    @property
+    def installed(self) -> bool:
+        # Fast path for repeated checks to 'installed' without a disk op.
+        if not self._installed:
+            self._installed = self._tar_extracted_marker.is_file()
+        return self._installed
+
+    def install(self) -> None:
+        if self.installed:
+            return
+
+        # Thread-level and process-level locks to prevent races.
+        with self._tar_lock, InterProcessLock(self._tar_lockfile):
+            # Repeat the check to see if we have already installed the
+            # dataset now that we have acquired the lock.
+            if self.installed:
+                return
+
+            # Remove any partially-completed prior extraction.
+            shutil.rmtree(self.site_data_path / "contents", ignore_errors=True)
+
+            self.logger.info("Downloading %s dataset", self.name)
+            tar_data = io.BytesIO(download(self.tar_urls, self.tar_sha256))
+            self.logger.info("Unpacking %s dataset", self.name)
+            with tarfile.open(
+                fileobj=tar_data, mode=f"r:{self.tar_compression}"
+            ) as arc:
+                arc.extractall(str(self.site_data_path / "contents"))
+
+            # We're done. The last thing we do is create the marker file to
+            # signal to any other install() invocations that the dataset is
+            # ready.
+            self._tar_extracted_marker.touch()
+
+        if self.strip_prefix and not self.dataset_root.is_dir():
+            raise FileNotFoundError(
+                f"Directory prefix '{self.strip_prefix}' not found in dataset '{self.name}'"
+            )
+
+
+class TarDatasetWithManifest(TarDataset):
+    """A tarball-based dataset that uses a separate file to list benchmark URIs.
+
+    The idea is to allow the list of benchmark URIs to be enumerated in a more
+    lightweight manner than downloading and unpacking the entire dataset. It
+    does this by downloading a "manifest", which is a plain text file containing
+    a list of benchmark names, one per line, and only downloads the actual
+    tarball containing the benchmarks when it is needed.
+
+    The manifest file is assumed to be correct and is not validated.
+    """
+
+    def __init__(
+        self,
+        manifest_urls: List[str],
+        manifest_sha256: str,
+        manifest_compression: str = "bz2",
+        **dataset_args,
+    ):
+        """Constructor.
+
+        :param manifest_urls: A list of redundant URLS to download the
+            compressed text file containing a list of benchmark URI suffixes,
+            one per line.
+
+        :param manifest_sha256: The sha256 checksum of the compressed manifest
+            file.
+
+        :param manifest_compression: The manifest compression type. One of
+            {"bz2", "gz"}.
+
+        :param dataset_args: See :meth:`TarDataset.__init__()
+            <compiler_gym.datasets.TarDataset.__init__>`.
+        """
+        super().__init__(**dataset_args)
+        self.manifest_urls = manifest_urls
+        self.manifest_sha256 = manifest_sha256
+        self.manifest_compression = manifest_compression
+        self._manifest_path = self.site_data_path / f"manifest-{manifest_sha256}.txt"
+
+        self._manifest_lock = Lock()
+        self._manifest_lockfile = self.site_data_path / "manifest.LOCK"
+
+    def _read_manifest(self, manifest_data: bytes) -> List[str]:
+        """Read the manifest data into a list of URIs. Does not validate the
+        manifest contents.
+        """
+        lines = manifest_data.rstrip().split("\n")
+        return [f"{self.name}/{line}" for line in lines]
+
+    def _read_manifest_file(self) -> List[str]:
+        """Read the benchmark URIs from an on-disk manifest file.
+
+        Does not check that the manifest file exists.
+        """
+        with open(self._manifest_path, encoding="utf-8") as f:
+            uris = self._read_manifest(f.read())
+        self.logger.debug("Read %s manifest, %d entries", self.name, len(uris))
+        return uris
+
+    @memoized_property
+    def _benchmark_uris(self) -> List[str]:
+        """Fetch or download the URI list."""
+        if self._manifest_path.is_file():
+            return self._read_manifest_file()
+
+        # Thread-level and process-level locks to prevent races.
+        with self._manifest_lock, InterProcessLock(self._manifest_lockfile):
+            # Now that we have acquired the lock, repeat the check, since
+            # another thread may have downloaded the manifest.
+            if self._manifest_path.is_file():
+                return self._read_manifest_file()
+
+            # Determine how to decompress the manifest data.
+            decompressor = {
+                "bz2": lambda compressed_data: bz2.BZ2File(compressed_data),
+                "gz": lambda compressed_data: gzip.GzipFile(compressed_data),
+            }.get(self.manifest_compression, None)
+            if not decompressor:
+                raise TypeError(
+                    f"Unknown manifest compression: {self.manifest_compression}"
+                )
+
+            # Decompress the manifest data.
+            self.logger.debug("Downloading %s manifest", self.name)
+            manifest_data = io.BytesIO(
+                download(self.manifest_urls, self.manifest_sha256)
+            )
+            with decompressor(manifest_data) as f:
+                manifest_data = f.read()
+
+            # Although we have exclusive-execution locks, we still need to
+            # create the manifest atomically to prevent calls to _benchmark_uris
+            # racing to read an incompletely written manifest.
+            with atomic_file_write(self._manifest_path, fileobj=True) as f:
+                f.write(manifest_data)
+
+            uris = self._read_manifest(manifest_data)
+            self.logger.debug(
+                "Downloaded %s manifest, %d entries", self.name, len(uris)
+            )
+            return uris
+
+    @memoized_property
+    def n(self) -> int:
+        return len(self._benchmark_uris)
+
+    def benchmark_uris(self) -> Iterable[str]:
+        yield from iter(self._benchmark_uris)

--- a/tests/datasets/BUILD
+++ b/tests/datasets/BUILD
@@ -25,3 +25,14 @@ py_test(
         "//tests/pytest_plugins:common",
     ],
 )
+
+py_test(
+    name = "files_dataset_test",
+    timeout = "short",
+    srcs = ["files_dataset_test.py"],
+    deps = [
+        "//compiler_gym/datasets",
+        "//tests:test_main",
+        "//tests/pytest_plugins:common",
+    ],
+)

--- a/tests/datasets/files_dataset_test.py
+++ b/tests/datasets/files_dataset_test.py
@@ -1,0 +1,203 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Unit tests for //compiler_gym/datasets:files_dataset_test."""
+import tempfile
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+from compiler_gym.datasets import FilesDataset
+from tests.test_main import main
+
+pytest_plugins = ["tests.pytest_plugins.common"]
+
+
+@pytest.fixture(scope="function")
+def empty_dataset() -> FilesDataset:
+    with tempfile.TemporaryDirectory() as d:
+        yield FilesDataset(
+            name="benchmark://test-v0",
+            description="",
+            license="MIT",
+            dataset_root=Path(d) / "files",
+            site_data_base=Path(d) / "site_data",
+        )
+
+
+@pytest.fixture(scope="function", params=["", "memoized-ids"])
+def populated_dataset(request) -> FilesDataset:
+    with tempfile.TemporaryDirectory() as d:
+        df = Path(d) / "files"
+        (df / "a").mkdir(parents=True)
+        (df / "b").mkdir()
+
+        (df / "e.txt").touch()
+        (df / "f.txt").touch()
+        (df / "g.jpg").touch()
+        (df / "a" / "a.txt").touch()
+        (df / "a" / "b.txt").touch()
+        (df / "b" / "a.txt").touch()
+        (df / "b" / "b.txt").touch()
+        (df / "b" / "c.txt").touch()
+        (df / "b" / "d.jpg").touch()
+
+        yield FilesDataset(
+            name="benchmark://test-v0",
+            description="",
+            license="MIT",
+            dataset_root=Path(d) / "files",
+            site_data_base=Path(d) / "site_data",
+            memoize_uris=request.param == "memoized-ids",
+        )
+
+
+def test_dataset_is_installed(empty_dataset: FilesDataset):
+    assert empty_dataset.installed
+
+
+def test_empty_dataset(empty_dataset: FilesDataset):
+    assert empty_dataset.n == 0
+    assert list(empty_dataset.benchmark_uris()) == []
+    assert list(empty_dataset.benchmarks()) == []
+
+
+def test_empty_dataset_benchmark(empty_dataset: FilesDataset):
+    with pytest.raises(ValueError) as e_ctx:
+        empty_dataset.benchmark()
+
+    assert str(e_ctx.value) == "No benchmarks"
+
+
+def test_populated_dataset(populated_dataset: FilesDataset):
+    for _ in range(2):
+        assert list(populated_dataset.benchmark_uris()) == [
+            "benchmark://test-v0/e.txt",
+            "benchmark://test-v0/f.txt",
+            "benchmark://test-v0/g.jpg",
+            "benchmark://test-v0/a/a.txt",
+            "benchmark://test-v0/a/b.txt",
+            "benchmark://test-v0/b/a.txt",
+            "benchmark://test-v0/b/b.txt",
+            "benchmark://test-v0/b/c.txt",
+            "benchmark://test-v0/b/d.jpg",
+        ]
+        assert populated_dataset.n == 9
+
+
+def test_populated_dataset_benchmark_lookup(populated_dataset: FilesDataset):
+    bm = populated_dataset.benchmark("benchmark://test-v0/e.txt")
+    assert bm.uri == "benchmark://test-v0/e.txt"
+    assert bm.proto.uri == "benchmark://test-v0/e.txt"
+    assert bm.proto.program.uri == f"file:///{populated_dataset.dataset_root}/e.txt"
+
+
+def test_populated_dataset_first_file(populated_dataset: FilesDataset):
+    bm = next(populated_dataset.benchmarks())
+    assert bm.uri == "benchmark://test-v0/e.txt"
+    assert bm.proto.uri == "benchmark://test-v0/e.txt"
+    assert bm.proto.program.uri == f"file:///{populated_dataset.dataset_root}/e.txt"
+
+
+def test_populated_dataset_benchmark_lookup_not_found(populated_dataset: FilesDataset):
+    with pytest.raises(LookupError) as e_ctx:
+        populated_dataset.benchmark("benchmark://test-v0/not/a/file")
+
+    assert str(e_ctx.value).startswith(
+        "Benchmark not found: benchmark://test-v0/not/a/file"
+    )
+
+
+def test_populated_dataset_with_file_extension_filter(populated_dataset: FilesDataset):
+    populated_dataset.benchmark_file_suffix = ".jpg"
+    assert list(populated_dataset.benchmark_uris()) == [
+        "benchmark://test-v0/g",
+        "benchmark://test-v0/b/d",
+    ]
+    assert populated_dataset.n == 2
+
+
+@pytest.mark.parametrize(
+    "requested_uri", (None, "benchmark://test-v0", "benchmark://test-v0/")
+)
+def test_populated_dataset_random_benchmark(
+    populated_dataset: FilesDataset, requested_uri: Optional[str]
+):
+    populated_dataset.benchmark_file_suffix = ".jpg"
+
+    populated_dataset.seed(1)
+    benchmarks_a = [populated_dataset.benchmark(requested_uri).uri for _ in range(50)]
+    populated_dataset.seed(1)
+    benchmarks_b = [populated_dataset.benchmark(requested_uri).uri for _ in range(50)]
+    populated_dataset.seed(2)
+    benchmarks_c = [populated_dataset.benchmark(requested_uri).uri for _ in range(50)]
+
+    assert benchmarks_a == benchmarks_b
+    assert benchmarks_b != benchmarks_c
+
+    assert set(benchmarks_a) == set(populated_dataset.benchmark_uris())
+    assert set(benchmarks_c) == set(populated_dataset.benchmark_uris())
+
+
+def test_populated_dataset_get_benchmark_by_index(populated_dataset: FilesDataset):
+    # pylint: disable=protected-access
+
+    i = 0
+    benchmark = populated_dataset._get_benchmark_by_index(i)
+    assert benchmark.uri == "benchmark://test-v0/e.txt"
+    assert Path(benchmark.proto.program.uri[len("file:///") :]).is_file()
+
+    i += 1
+    benchmark = populated_dataset._get_benchmark_by_index(i)
+    assert benchmark.uri == "benchmark://test-v0/f.txt"
+    assert Path(benchmark.proto.program.uri[len("file:///") :]).is_file()
+
+    i += 1
+    benchmark = populated_dataset._get_benchmark_by_index(i)
+    assert benchmark.uri == "benchmark://test-v0/g.jpg"
+    assert Path(benchmark.proto.program.uri[len("file:///") :]).is_file()
+
+    i += 1
+    benchmark = populated_dataset._get_benchmark_by_index(i)
+    assert benchmark.uri == "benchmark://test-v0/a/a.txt"
+    assert Path(benchmark.proto.program.uri[len("file:///") :]).is_file()
+
+    i += 1
+    benchmark = populated_dataset._get_benchmark_by_index(i)
+    assert benchmark.uri == "benchmark://test-v0/a/b.txt"
+    assert Path(benchmark.proto.program.uri[len("file:///") :]).is_file()
+
+    i += 1
+    benchmark = populated_dataset._get_benchmark_by_index(i)
+    assert benchmark.uri == "benchmark://test-v0/b/a.txt"
+    assert Path(benchmark.proto.program.uri[len("file:///") :]).is_file()
+
+    i += 1
+    benchmark = populated_dataset._get_benchmark_by_index(i)
+    assert benchmark.uri == "benchmark://test-v0/b/b.txt"
+    assert Path(benchmark.proto.program.uri[len("file:///") :]).is_file()
+
+    i += 1
+    benchmark = populated_dataset._get_benchmark_by_index(i)
+    assert benchmark.uri == "benchmark://test-v0/b/c.txt"
+    assert Path(benchmark.proto.program.uri[len("file:///") :]).is_file()
+
+    i += 1
+    benchmark = populated_dataset._get_benchmark_by_index(i)
+    assert benchmark.uri == "benchmark://test-v0/b/d.jpg"
+    assert Path(benchmark.proto.program.uri[len("file:///") :]).is_file()
+
+
+def test_populated_dataset_get_benchmark_by_index_out_of_range(
+    populated_dataset: FilesDataset,
+):
+    # pylint: disable=protected-access
+    with pytest.raises(IndexError):
+        populated_dataset._get_benchmark_by_index(-1)
+        populated_dataset._get_benchmark_by_index(10)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This adds three helper classes for describing datasets:

* `FilesDataset` - A dataset comprising a directory tree files.
* `TarDataset` - A dataset comprising a files tree stored in a tar archive.
* `TarDatasetWithManifest` - A tarball-based dataset that has a manifest file which lists the URIs.

Issue #45.
