### PR TITLE
[datasets-overhaul #1.5] Update make_benchmark() to use the new Benchmark class.

### DIFF
--- a/compiler_gym/envs/llvm/BUILD
+++ b/compiler_gym/envs/llvm/BUILD
@@ -11,19 +11,20 @@ py_library(
         ":specs.py",
     ],
     data = ["//compiler_gym/envs/llvm/service"],
-    visibility = ["//compiler_gym:__subpackages__"],
+    visibility = ["//visibility:public"],
     deps = [
-        ":benchmarks",
+        ":llvm_benchmark",
         ":llvm_env",
         "//compiler_gym/util",
     ],
 )
 
 py_library(
-    name = "benchmarks",
-    srcs = ["benchmarks.py"],
+    name = "llvm_benchmark",
+    srcs = ["llvm_benchmark.py"],
     visibility = ["//compiler_gym:__subpackages__"],
     deps = [
+        "//compiler_gym/datasets",
         "//compiler_gym/service/proto",
         "//compiler_gym/third_party/llvm",
         "//compiler_gym/util",
@@ -48,8 +49,8 @@ py_library(
         "//compiler_gym/envs/llvm/service/passes:actions_genfiles",
     ],
     deps = [
-        ":benchmarks",
         ":legacy_datasets",
+        ":llvm_benchmark",
         ":llvm_rewards",
         "//compiler_gym/envs:compiler_env",
         "//compiler_gym/spaces",

--- a/compiler_gym/envs/llvm/__init__.py
+++ b/compiler_gym/envs/llvm/__init__.py
@@ -5,7 +5,7 @@
 """Register the LLVM environments."""
 from itertools import product
 
-from compiler_gym.envs.llvm.benchmarks import (
+from compiler_gym.envs.llvm.llvm_benchmark import (
     ClangInvocation,
     get_system_includes,
     make_benchmark,

--- a/compiler_gym/envs/llvm/llvm_benchmark.py
+++ b/compiler_gym/envs/llvm/llvm_benchmark.py
@@ -8,16 +8,16 @@ import random
 import subprocess
 import sys
 import tempfile
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import as_completed
 from datetime import datetime
-from multiprocessing import cpu_count
 from pathlib import Path
 from signal import Signals
 from typing import Iterable, List, Optional, Union
 
-from compiler_gym.service.proto import Benchmark, File
+from compiler_gym.datasets import Benchmark, BenchmarkInitError
 from compiler_gym.third_party import llvm
-from compiler_gym.util.runfiles_path import cache_path
+from compiler_gym.util.runfiles_path import transient_cache_path
+from compiler_gym.util.thread_pool import get_thread_pool_executor
 
 
 def _communicate(process, input=None, timeout=None):
@@ -137,107 +137,15 @@ class ClangInvocation(object):
 
         return cmd
 
-
-def _run_command(cmd: List[str], timeout: int):
-    process = subprocess.Popen(
-        cmd, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, universal_newlines=True
-    )
-    _, stderr = _communicate(process, timeout=timeout)
-    if process.returncode:
-        returncode = process.returncode
-        try:
-            # Try and decode the name of a signal. Signal returncodes
-            # are negative.
-            returncode = f"{returncode} ({Signals(abs(returncode)).name})"
-        except ValueError:
-            pass
-        raise OSError(
-            f"Compilation job failed with returncode {returncode}\n"
-            f"Command: {' '.join(cmd)}\n"
-            f"Stderr: {stderr.strip()}"
-        )
-
-
-def make_benchmark(
-    inputs: Union[str, Path, ClangInvocation, List[Union[str, Path, ClangInvocation]]],
-    copt: Optional[List[str]] = None,
-    system_includes: bool = True,
-    timeout: int = 600,
-) -> Benchmark:
-    """Create a benchmark for use by LLVM environments.
-
-    This function takes one or more inputs and uses them to create a benchmark
-    that can be passed to :meth:`compiler_gym.envs.LlvmEnv.reset`.
-
-    For single-source C/C++ programs, you can pass the path of the source file:
-
-    >>> benchmark = make_benchmark('my_app.c')
-    >>> env = gym.make("llvm-v0")
-    >>> env.reset(benchmark=benchmark)
-
-    The clang invocation used is roughly equivalent to:
-
-    .. code-block::
-
-        $ clang my_app.c -O0 -c -emit-llvm -o benchmark.bc
-
-    Additional compile-time arguments to clang can be provided using the
-    :code:`copt` argument:
-
-    >>> benchmark = make_benchmark('/path/to/my_app.cpp', copt=['-O2'])
-
-    If you need more fine-grained control over the options, you can directly
-    construct a :class:`ClangInvocation <compiler_gym.envs.llvm.ClangInvocation>`
-    to pass a list of arguments to clang:
-
-    >>> benchmark = make_benchmark(
-        ClangInvocation(['/path/to/my_app.c'], timeout=10)
-    )
-
-    For multi-file programs, pass a list of inputs that will be compiled
-    separately and then linked to a single module:
-
-    >>> benchmark = make_benchmark([
-        'main.c',
-        'lib.cpp',
-        'lib2.bc',
-    ])
-
-    If you already have prepared bitcode files, those can be linked and used
-    directly:
-
-    >>> benchmark = make_benchmark([
-        'bitcode1.bc',
-        'bitcode2.bc',
-    ])
-
-    .. note::
-        LLVM bitcode compatibility is
-        `not guaranteed <https://llvm.org/docs/DeveloperPolicy.html#ir-backwards-compatibility>`_,
-        so you must ensure that any precompiled bitcodes are compatible with the
-        LLVM version used by CompilerGym, which can be queried using
-        :func:`LlvmEnv.compiler_version <compiler_gym.envs.CompilerEnv.compiler_version>`.
-
-    :param inputs: An input, or list of inputs.
-    :param copt: A list of command line options to pass to clang when compiling
-        source files.
-    :param system_includes: Whether to include the system standard libraries
-        during compilation jobs. This requires a system toolchain. See
-        :func:`get_system_includes`.
-    :param timeout: The maximum number of seconds to allow clang to run before
-        terminating.
-    :return: A :code:`Benchmark` message.
-    :raises FileNotFoundError: If any input sources are not found.
-    :raises TypeError: If the inputs are of unsupported types.
-    :raises OSError: If a compilation job fails.
-    :raises TimeoutExpired: If a compilation job exceeds :code:`timeout` seconds.
-    """
-    copt = copt or []
-
-    bitcodes: List[Path] = []
-    clang_jobs: List[ClangInvocation] = []
-
-    def _add_path(path: Path):
+    @classmethod
+    def from_c_file(
+        cls,
+        path: Path,
+        copt: Optional[List[str]] = None,
+        system_includes: bool = True,
+        timeout: int = 600,
+    ) -> "ClangInvocation":
+        copt = copt or []
         # NOTE(cummins): There is some discussion about the best way to create a
         # bitcode that is unoptimized yet does not hinder downstream
         # optimization opportunities. Here we are using a configuration based on
@@ -259,6 +167,129 @@ def make_benchmark(
             "-disable-llvm-optzns",
         ]
 
+        return cls(
+            DEFAULT_COPT + copt + [str(path)],
+            system_includes=system_includes,
+            timeout=timeout,
+        )
+
+
+def _run_command(cmd: List[str], timeout: int):
+    process = subprocess.Popen(
+        cmd, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, universal_newlines=True
+    )
+    _, stderr = _communicate(process, timeout=timeout)
+    if process.returncode:
+        returncode = process.returncode
+        try:
+            # Try and decode the name of a signal. Signal returncodes
+            # are negative.
+            returncode = f"{returncode} ({Signals(abs(returncode)).name})"
+        except ValueError:
+            pass
+        raise BenchmarkInitError(
+            f"Compilation job failed with returncode {returncode}\n"
+            f"Command: {' '.join(cmd)}\n"
+            f"Stderr: {stderr.strip()}"
+        )
+
+
+def make_benchmark(
+    inputs: Union[str, Path, ClangInvocation, List[Union[str, Path, ClangInvocation]]],
+    copt: Optional[List[str]] = None,
+    system_includes: bool = True,
+    timeout: int = 600,
+) -> Benchmark:
+    """Create a benchmark for use by LLVM environments.
+
+    This function takes one or more inputs and uses them to create a benchmark
+    that can be passed to :meth:`compiler_gym.envs.LlvmEnv.reset`.
+
+    For single-source C/C++ programs, you can pass the path of the source file:
+
+        >>> benchmark = make_benchmark('my_app.c')
+        >>> env = gym.make("llvm-v0")
+        >>> env.reset(benchmark=benchmark)
+
+    The clang invocation used is roughly equivalent to:
+
+    .. code-block::
+
+        $ clang my_app.c -O0 -c -emit-llvm -o benchmark.bc
+
+    Additional compile-time arguments to clang can be provided using the
+    :code:`copt` argument:
+
+        >>> benchmark = make_benchmark('/path/to/my_app.cpp', copt=['-O2'])
+
+    If you need more fine-grained control over the options, you can directly
+    construct a :class:`ClangInvocation
+    <compiler_gym.envs.llvm.ClangInvocation>` to pass a list of arguments to
+    clang:
+
+        >>> benchmark = make_benchmark(
+            ClangInvocation(['/path/to/my_app.c'], timeout=10)
+        )
+
+    For multi-file programs, pass a list of inputs that will be compiled
+    separately and then linked to a single module:
+
+        >>> benchmark = make_benchmark([
+            'main.c',
+            'lib.cpp',
+            'lib2.bc',
+        ])
+
+    If you already have prepared bitcode files, those can be linked and used
+    directly:
+
+        >>> benchmark = make_benchmark([
+            'bitcode1.bc',
+            'bitcode2.bc',
+        ])
+
+    Text-format LLVM assembly can also be used:
+
+        >>> benchmark = make_benchmark('module.ll')
+
+    .. note::
+
+        LLVM bitcode compatibility is
+        `not guaranteed <https://llvm.org/docs/DeveloperPolicy.html#ir-backwards-compatibility>`_,
+        so you must ensure that any precompiled bitcodes are compatible with the
+        LLVM version used by CompilerGym, which can be queried using
+        :func:`env.compiler_version <compiler_gym.envs.CompilerEnv.compiler_version>`.
+
+    :param inputs: An input, or list of inputs.
+
+    :param copt: A list of command line options to pass to clang when compiling
+        source files.
+
+    :param system_includes: Whether to include the system standard libraries
+        during compilation jobs. This requires a system toolchain. See
+        :func:`get_system_includes`.
+
+    :param timeout: The maximum number of seconds to allow clang to run before
+        terminating.
+
+    :return: A :code:`Benchmark` instance.
+
+    :raises FileNotFoundError: If any input sources are not found.
+
+    :raises TypeError: If the inputs are of unsupported types.
+
+    :raises OSError: If a compilation job fails.
+
+    :raises TimeoutExpired: If a compilation job exceeds :code:`timeout`
+        seconds.
+    """
+    copt = copt or []
+
+    bitcodes: List[Path] = []
+    clang_jobs: List[ClangInvocation] = []
+    ll_paths: List[Path] = []
+
+    def _add_path(path: Path):
         if not path.is_file():
             raise FileNotFoundError(path)
 
@@ -266,12 +297,12 @@ def make_benchmark(
             bitcodes.append(path)
         elif path.suffix in {".c", ".cxx", ".cpp", ".cc"}:
             clang_jobs.append(
-                ClangInvocation(
-                    [str(path)] + DEFAULT_COPT + copt,
-                    system_includes=system_includes,
-                    timeout=timeout,
+                ClangInvocation.from_c_file(
+                    path, copt=copt, system_includes=system_includes, timeout=timeout
                 )
             )
+        elif path.suffix == ".ll":
+            ll_paths.append(path)
         else:
             raise ValueError(f"Unrecognized file type: {path.name}")
 
@@ -290,40 +321,66 @@ def make_benchmark(
             else:
                 raise TypeError(f"Invalid input type: {type(input).__name__}")
 
-    if not bitcodes and not clang_jobs:
-        raise ValueError("No inputs")
-
     # Shortcut if we only have a single pre-compiled bitcode.
     if len(bitcodes) == 1 and not clang_jobs:
         bitcode = bitcodes[0]
-        return Benchmark(
-            uri=f"file:///{bitcode}", program=File(uri=f"file:///{bitcode}")
-        )
+        return Benchmark.from_file(uri=f"file:///{bitcode}", path=bitcode)
 
-    tmpdir_root = cache_path(".")
+    tmpdir_root = transient_cache_path(".")
     tmpdir_root.mkdir(exist_ok=True, parents=True)
-    with tempfile.TemporaryDirectory(dir=tmpdir_root) as d:
+    with tempfile.TemporaryDirectory(
+        dir=tmpdir_root, prefix="llvm-make_benchmark-"
+    ) as d:
         working_dir = Path(d)
 
-        # Run the clang invocations in parallel.
         clang_outs = [
-            working_dir / f"out-{i}.bc" for i in range(1, len(clang_jobs) + 1)
+            working_dir / f"clang-out-{i}.bc" for i in range(1, len(clang_jobs) + 1)
         ]
-        with ThreadPoolExecutor(max_workers=cpu_count()) as executor:
-            futures = (
+        llvm_as_outs = [
+            working_dir / f"llvm-as-out-{i}.bc" for i in range(1, len(ll_paths) + 1)
+        ]
+
+        # Run the clang and llvm-as invocations in parallel. Avoid running this
+        # code path if possible as get_thread_pool_executor() requires locking.
+        if clang_jobs or ll_paths:
+            llvm_as_path = str(llvm.llvm_as_path())
+            executor = get_thread_pool_executor()
+
+            llvm_as_commands = [
+                [llvm_as_path, str(ll_path), "-o", bc_path]
+                for ll_path, bc_path in zip(ll_paths, llvm_as_outs)
+            ]
+
+            # Fire off the clang and llvm-as jobs.
+            futures = [
                 executor.submit(_run_command, job.command(out), job.timeout)
                 for job, out in zip(clang_jobs, clang_outs)
-            )
+            ] + [
+                executor.submit(_run_command, command, timeout)
+                for command in llvm_as_commands
+            ]
+
+            # Block until finished.
             list(future.result() for future in as_completed(futures))
 
-        # Check that the expected files were generated.
-        for i, b in enumerate(clang_outs):
-            if not b.is_file():
-                raise OSError(
-                    f"Clang invocation failed to produce a file: {' '.join(clang_jobs[i].command(clang_outs[i]))}"
-                )
+            # Check that the expected files were generated.
+            for clang_job, bc_path in zip(clang_jobs, clang_outs):
+                if not bc_path.is_file():
+                    raise BenchmarkInitError(
+                        f"clang failed: {' '.join(clang_job.command(bc_path))}"
+                    )
+            for command, bc_path in zip(llvm_as_commands, llvm_as_outs):
+                if not bc_path.is_file():
+                    raise BenchmarkInitError(f"llvm-as failed: {command}")
 
-        if len(bitcodes + clang_outs) > 1:
+        all_outs = bitcodes + clang_outs + llvm_as_outs
+        if not all_outs:
+            raise ValueError("No inputs")
+        elif len(all_outs) == 1:
+            # We only have a single bitcode so read it.
+            with open(str(all_outs[0]), "rb") as f:
+                bitcode = f.read()
+        else:
             # Link all of the bitcodes into a single module.
             llvm_link_cmd = [str(llvm.llvm_link_path()), "-o", "-"] + [
                 str(path) for path in bitcodes + clang_outs
@@ -333,15 +390,10 @@ def make_benchmark(
             )
             bitcode, stderr = _communicate(llvm_link, timeout=timeout)
             if llvm_link.returncode:
-                raise OSError(
+                raise BenchmarkInitError(
                     f"Failed to link LLVM bitcodes with error: {stderr.decode('utf-8')}"
                 )
-        else:
-            # We only have a single bitcode so read it.
-            with open(str(list(bitcodes + clang_outs)[0]), "rb") as f:
-                bitcode = f.read()
 
-    timestamp = datetime.now().strftime(f"%Y%m%HT%H%M%S-{random.randrange(16**4):04x}")
-    return Benchmark(
-        uri=f"benchmark://user/{timestamp}", program=File(contents=bitcode)
-    )
+    timestamp = datetime.now().strftime("%Y%m%HT%H%M%S")
+    uri = f"benchmark://user/{timestamp}-{random.randrange(16**4):04x}"
+    return Benchmark.from_file_contents(uri, bitcode)

--- a/compiler_gym/envs/llvm/service/Cost.cc
+++ b/compiler_gym/envs/llvm/service/Cost.cc
@@ -70,8 +70,8 @@ Status getTextSizeInBytes(llvm::Module& module, int64_t* value,
 #else
 Status getTextSizeInBytes(llvm::Module& module, int64_t* value, const fs::path& workingDirectory) {
 #endif
-  const auto clangPath = util::getSiteDataPath("llvm/10.0.0/bin/clang");
-  const auto llvmSizePath = util::getSiteDataPath("llvm/10.0.0/bin/llvm-size");
+  const auto clangPath = util::getSiteDataPath("llvm-v0/bin/clang");
+  const auto llvmSizePath = util::getSiteDataPath("llvm-v0/bin/llvm-size");
   DCHECK(fs::exists(clangPath)) << fmt::format("File not found: {}", clangPath.string());
   DCHECK(fs::exists(llvmSizePath)) << fmt::format("File not found: {}", llvmSizePath.string());
 

--- a/compiler_gym/envs/llvm/service/LlvmSession.cc
+++ b/compiler_gym/envs/llvm/service/LlvmSession.cc
@@ -218,7 +218,7 @@ Status LlvmSession::runOptWithArgs(const std::vector<std::string>& optArgs) {
   RETURN_IF_ERROR(writeBitcodeToFile(benchmark().module(), before_path));
 
   // Build a command line invocation: `opt input.bc -o output.bc <optArgs...>`.
-  const auto optPath = util::getSiteDataPath("llvm/10.0.0/bin/opt");
+  const auto optPath = util::getSiteDataPath("llvm-v0/bin/opt");
   if (!fs::exists(optPath)) {
     return Status(StatusCode::INTERNAL, fmt::format("File not found: {}", optPath.string()));
   }

--- a/compiler_gym/third_party/cBench/BUILD
+++ b/compiler_gym/third_party/cBench/BUILD
@@ -94,7 +94,7 @@ py_binary(
     name = "make_llvm_module",
     srcs = ["make_llvm_module.py"],
     deps = [
-        "//compiler_gym/envs/llvm:benchmarks",
+        "//compiler_gym/envs/llvm:llvm_benchmark",
     ],
 )
 

--- a/compiler_gym/third_party/cBench/make_llvm_module.py
+++ b/compiler_gym/third_party/cBench/make_llvm_module.py
@@ -14,7 +14,7 @@ import sys
 from pathlib import Path
 from typing import List
 
-from compiler_gym.envs.llvm.benchmarks import make_benchmark
+from compiler_gym.envs.llvm.llvm_benchmark import make_benchmark
 
 
 def make_cbench_llvm_module(
@@ -32,7 +32,7 @@ def make_cbench_llvm_module(
     benchmark = make_benchmark(inputs=src_files, copt=cflags or [])
     # Write just the bitcode to file.
     with open(output_path, "wb") as f:
-        f.write(benchmark.program.contents)
+        f.write(benchmark.proto.program.contents)
 
 
 def main():

--- a/compiler_gym/third_party/llvm/BUILD
+++ b/compiler_gym/third_party/llvm/BUILD
@@ -47,21 +47,27 @@ cc_binary(
 # genrule(
 #     name = "llvm_data_tar",
 #     srcs = [":llvm_data"],
-#     outs = ["llvm.tar.bz2"],
+#     outs = ["llvm-v0.tar.bz2"],
 #     cmd = "mkdir -p $(@D)/lib && tar cjfh $@ -C $(@D) LICENSE bin lib",
 # )
 #
 # filegroup(
 #     name = "llvm_data",
 #     srcs = [
-#         "LICENSE",
 #         "bin/clang",
+#         "bin/llc",
 #         "bin/lli",
+#         "bin/llvm-as",
+#         "bin/llvm-bcanalyzer",
+#         "bin/llvm-config",
 #         "bin/llvm-diff",
+#         "bin/llvm-dis",
 #         "bin/llvm-link",
+#         "bin/llvm-mca",
 #         "bin/llvm-size",
 #         "bin/llvm-stress",
 #         "bin/opt",
+#         "LICENSE",
 #     ] + select({
 #         "@llvm//:darwin": [],
 #         "//conditions:default": [
@@ -105,6 +111,90 @@ cc_binary(
 #         ],
 #     }),
 #     outs = ["bin/lli"],
+#     cmd = "mkdir -p $$(dirname $@) && cp $< $@",
+# )
+
+# genrule(
+#     name = "make_llc",
+#     srcs = select({
+#         "@llvm//:darwin": [
+#             "@clang-llvm-10.0.0-x86_64-apple-darwin//:llc",
+#         ],
+#         "//conditions:default": [
+#             "@clang-llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04//:llc",
+#         ],
+#     }),
+#     outs = ["bin/llc"],
+#     cmd = "mkdir -p $$(dirname $@) && cp $< $@",
+# )
+#
+# genrule(
+#     name = "make_llvm-as",
+#     srcs = select({
+#         "@llvm//:darwin": [
+#             "@clang-llvm-10.0.0-x86_64-apple-darwin//:llvm-as",
+#         ],
+#         "//conditions:default": [
+#             "@clang-llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04//:llvm-as",
+#         ],
+#     }),
+#     outs = ["bin/llvm-as"],
+#     cmd = "mkdir -p $$(dirname $@) && cp $< $@",
+# )
+#
+# genrule(
+#     name = "make_llvm-mca",
+#     srcs = select({
+#         "@llvm//:darwin": [
+#             "@clang-llvm-10.0.0-x86_64-apple-darwin//:llvm-mca",
+#         ],
+#         "//conditions:default": [
+#             "@clang-llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04//:llvm-mca",
+#         ],
+#     }),
+#     outs = ["bin/llvm-mca"],
+#     cmd = "mkdir -p $$(dirname $@) && cp $< $@",
+# )
+#
+# genrule(
+#     name = "make_llvm-bcanalyzer",
+#     srcs = select({
+#         "@llvm//:darwin": [
+#             "@clang-llvm-10.0.0-x86_64-apple-darwin//:llvm-bcanalyzer",
+#         ],
+#         "//conditions:default": [
+#             "@clang-llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04//:llvm-bcanalyzer",
+#         ],
+#     }),
+#     outs = ["bin/llvm-bcanalyzer"],
+#     cmd = "mkdir -p $$(dirname $@) && cp $< $@",
+# )
+
+# genrule(
+#     name = "make_llvm-config",
+#     srcs = select({
+#         "@llvm//:darwin": [
+#             "@clang-llvm-10.0.0-x86_64-apple-darwin//:llvm-config",
+#         ],
+#         "//conditions:default": [
+#             "@clang-llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04//:llvm-config",
+#         ],
+#     }),
+#     outs = ["bin/llvm-config"],
+#     cmd = "mkdir -p $$(dirname $@) && cp $< $@",
+# )
+#
+# genrule(
+#     name = "make_llvm-dis",
+#     srcs = select({
+#         "@llvm//:darwin": [
+#             "@clang-llvm-10.0.0-x86_64-apple-darwin//:llvm-dis",
+#         ],
+#         "//conditions:default": [
+#             "@clang-llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04//:llvm-dis",
+#         ],
+#     }),
+#     outs = ["bin/llvm-dis"],
 #     cmd = "mkdir -p $$(dirname $@) && cp $< $@",
 # )
 #

--- a/compiler_gym/third_party/llvm/__init__.py
+++ b/compiler_gym/third_party/llvm/__init__.py
@@ -17,12 +17,12 @@ from compiler_gym.util.runfiles_path import cache_path, site_data_path
 # (url, sha256) tuples for the LLVM download data packs.
 _LLVM_URLS = {
     "darwin": (
-        "https://dl.fbaipublicfiles.com/compiler_gym/llvm-10.0.0-macos.tar.bz2",
-        "ff74da7a5423528de0e25d1c79926f2ddd95e02b5c25d1b501637af63b29dba6",
+        "https://dl.fbaipublicfiles.com/compiler_gym/llvm-10.0.0-v0-macos.tar.bz2",
+        "ab89ccfe3841b16251deb495af68dcd121fec39f70c67281e521d8cc331b9d71",
     ),
     "linux": (
-        "https://dl.fbaipublicfiles.com/compiler_gym/llvm-10.0.0-linux.tar.bz2",
-        "c9bf5bfda3c2fa1d1a9e7ebc93da4398a6f6841c28b5d368e0eb29a153856a93",
+        "https://dl.fbaipublicfiles.com/compiler_gym/llvm-10.0.0-v0-linux.tar.bz2",
+        "995aea899b6adfb075cfe1fbebe53a33165e9e106766d979de0a9717335bab08",
     ),
 }
 
@@ -73,14 +73,24 @@ def clang_path() -> Path:
     return download_llvm_files() / "bin/clang"
 
 
+def lli_path() -> Path:
+    """Return the path of lli."""
+    return download_llvm_files() / "bin/lli"
+
+
+def llvm_as_path() -> Path:
+    """Return the path of llvm-as."""
+    return download_llvm_files() / "bin/llvm-as"
+
+
 def llvm_link_path() -> Path:
     """Return the path of llvm-link."""
     return download_llvm_files() / "bin/llvm-link"
 
 
-def lli_path() -> Path:
-    """Return the path of lli."""
-    return download_llvm_files() / "bin/lli"
+def llvm_stress_path() -> Path:
+    """Return the path of llvm-stress."""
+    return download_llvm_files() / "bin/llvm-stress"
 
 
 def opt_path() -> Path:

--- a/compiler_gym/third_party/llvm/__init__.py
+++ b/compiler_gym/third_party/llvm/__init__.py
@@ -4,27 +4,28 @@
 # LICENSE file in the root directory of this source tree.
 """Module for resolving paths to LLVM binaries and libraries."""
 import io
+import shutil
 import sys
 import tarfile
 from pathlib import Path
 from threading import Lock
 
-import fasteners
+from fasteners import InterProcessLock
 
 from compiler_gym.util.download import download
 from compiler_gym.util.runfiles_path import cache_path, site_data_path
 
-# (url, sha256) tuples for the LLVM download data packs.
-_LLVM_URLS = {
+# The data archive containing LLVM binaries and libraries.
+_LLVM_URL, _LLVM_SHA256 = {
     "darwin": (
-        "https://dl.fbaipublicfiles.com/compiler_gym/llvm-10.0.0-v0-macos.tar.bz2",
-        "ab89ccfe3841b16251deb495af68dcd121fec39f70c67281e521d8cc331b9d71",
+        "https://dl.fbaipublicfiles.com/compiler_gym/llvm-v0-macos.tar.bz2",
+        "731ae351b62c5713fb5043e0ccc56bfba4609e284dc816f0b2a5598fb809bf6b",
     ),
     "linux": (
-        "https://dl.fbaipublicfiles.com/compiler_gym/llvm-10.0.0-v0-linux.tar.bz2",
-        "995aea899b6adfb075cfe1fbebe53a33165e9e106766d979de0a9717335bab08",
+        "https://dl.fbaipublicfiles.com/compiler_gym/llvm-v0-linux.tar.bz2",
+        "59c3f328efd51994a11168ca15e43a8d422233796c6bc167c9eb771c7bd6b57e",
     ),
-}
+}[sys.platform]
 
 
 # Thread lock to prevent race on download_llvm_files() from multi-threading.
@@ -35,37 +36,45 @@ _LLVM_DOWNLOADED = False
 
 def _download_llvm_files(unpacked_location: Path) -> Path:
     """Download and unpack the LLVM data pack."""
-    global _LLVM_DOWNLOADED
-    _LLVM_DOWNLOADED = True
-    if not (unpacked_location / ".unpacked").is_file():
-        url, sha256 = _LLVM_URLS[sys.platform]
-        tar_contents = io.BytesIO(download(url, sha256=sha256))
-        unpacked_location.parent.mkdir(parents=True, exist_ok=True)
-        with tarfile.open(fileobj=tar_contents, mode="r:bz2") as tar:
-            tar.extractall(unpacked_location)
-        assert unpacked_location.is_dir()
-        assert (unpacked_location / "LICENSE").is_file()
-        # Create the marker file to indicate that the directory is unpacked
-        # and ready to go.
-        (unpacked_location / ".unpacked").touch()
+    # Tidy up an incomplete unpack.
+    shutil.rmtree(unpacked_location, ignore_errors=True)
+
+    tar_contents = io.BytesIO(download(_LLVM_URL, sha256=_LLVM_SHA256))
+    unpacked_location.parent.mkdir(parents=True, exist_ok=True)
+    with tarfile.open(fileobj=tar_contents, mode="r:bz2") as tar:
+        tar.extractall(unpacked_location)
+    assert unpacked_location.is_dir()
+    assert (unpacked_location / "LICENSE").is_file()
+    # Create the marker file to indicate that the directory is unpacked
+    # and ready to go.
+    (unpacked_location / ".unpacked").touch()
 
     return unpacked_location
 
 
 def download_llvm_files() -> Path:
     """Download and unpack the LLVM data pack."""
-    unpacked_location = site_data_path("llvm/10.0.0")
+    global _LLVM_DOWNLOADED
+
+    unpacked_location = site_data_path("llvm-v0")
     # Fast path for repeated calls.
     if _LLVM_DOWNLOADED:
         return unpacked_location
+
     # Fast path for first call. This check will be repeated inside the locked
     # region if required.
     if (unpacked_location / ".unpacked").is_file():
+        _LLVM_DOWNLOADED = True
         return unpacked_location
 
-    with _LLVM_DOWNLOAD_LOCK:
-        with fasteners.InterProcessLock(cache_path("llvm-download.LOCK")):
-            return _download_llvm_files(unpacked_location)
+    with _LLVM_DOWNLOAD_LOCK, InterProcessLock(cache_path("llvm-download.LOCK")):
+        # Now that the lock is acquired, repeat the check to see if it is
+        # necessary to download the dataset.
+        if not (unpacked_location / ".unpacked").is_file():
+            _download_llvm_files(unpacked_location)
+        _LLVM_DOWNLOADED = True
+
+    return unpacked_location
 
 
 def clang_path() -> Path:

--- a/tests/llvm/BUILD
+++ b/tests/llvm/BUILD
@@ -72,6 +72,7 @@ py_test(
     name = "custom_benchmarks_test",
     srcs = ["custom_benchmarks_test.py"],
     data = [
+        "invalid_ir.ll",
         "//compiler_gym/third_party/cBench:crc32",
     ],
     deps = [
@@ -79,6 +80,7 @@ py_test(
         "//compiler_gym/service/proto",
         "//compiler_gym/util",
         "//tests:test_main",
+        "//tests/pytest_plugins:common",
         "//tests/pytest_plugins:llvm",
     ],
 )

--- a/tests/llvm/custom_benchmarks_test.py
+++ b/tests/llvm/custom_benchmarks_test.py
@@ -11,13 +11,18 @@ from pathlib import Path
 import gym
 import pytest
 
+from compiler_gym.datasets import Benchmark
 from compiler_gym.envs import LlvmEnv, llvm
-from compiler_gym.service.proto import Benchmark, File
+from compiler_gym.service.proto import Benchmark as BenchmarkProto
+from compiler_gym.service.proto import File
 from compiler_gym.util.runfiles_path import runfiles_path
+from tests.pytest_plugins.common import bazel_only
 from tests.test_main import main
 
 pytest_plugins = ["tests.pytest_plugins.llvm"]
 
+# The path of an IR file that assembles but does not compile.
+INVALID_IR_PATH = runfiles_path("tests/llvm/invalid_ir.ll")
 EXAMPLE_BITCODE_FILE = runfiles_path(
     "compiler_gym/third_party/cBench/cBench-v1/crc32.bc"
 )
@@ -33,8 +38,8 @@ def test_reset_invalid_benchmark(env: LlvmEnv):
 
 
 def test_invalid_benchmark_data(env: LlvmEnv):
-    benchmark = Benchmark(
-        uri="benchmark://new", program=File(contents="Invalid bitcode".encode("utf-8"))
+    benchmark = Benchmark.from_file_contents(
+        "benchmark://new", "Invalid bitcode".encode("utf-8")
     )
 
     with pytest.raises(ValueError) as ctx:
@@ -45,7 +50,9 @@ def test_invalid_benchmark_data(env: LlvmEnv):
 
 def test_invalid_benchmark_missing_file(env: LlvmEnv):
     benchmark = Benchmark(
-        uri="benchmark://new",
+        BenchmarkProto(
+            uri="benchmark://new",
+        )
     )
 
     with pytest.raises(ValueError) as ctx:
@@ -54,27 +61,12 @@ def test_invalid_benchmark_missing_file(env: LlvmEnv):
     assert str(ctx.value) == "No program set"
 
 
-def test_benchmark_path_not_found(env: LlvmEnv):
-    with tempfile.TemporaryDirectory() as tmpdir:
-        tmpdir = Path(tmpdir)
-        benchmark = Benchmark(
-            uri="benchmark://new", program=File(uri=f"file:///{tmpdir}/not_found")
-        )
-
-        with pytest.raises(FileNotFoundError) as ctx:
-            env.reset(benchmark=benchmark)
-
-    assert str(ctx.value) == f'File not found: "{tmpdir}/not_found"'
-
-
 def test_benchmark_path_empty_file(env: LlvmEnv):
     with tempfile.TemporaryDirectory() as tmpdir:
         tmpdir = Path(tmpdir)
         (tmpdir / "test.bc").touch()
 
-        benchmark = Benchmark(
-            uri="benchmark://new", program=File(uri=f"file:///{tmpdir}/test.bc")
-        )
+        benchmark = Benchmark.from_file("benchmark://new", tmpdir / "test.bc")
 
         with pytest.raises(ValueError) as ctx:
             env.reset(benchmark=benchmark)
@@ -88,9 +80,7 @@ def test_invalid_benchmark_path_contents(env: LlvmEnv):
         with open(str(tmpdir / "test.bc"), "w") as f:
             f.write("Invalid bitcode")
 
-        benchmark = Benchmark(
-            uri="benchmark://new", program=File(uri=f"file:///{tmpdir}/test.bc")
-        )
+        benchmark = Benchmark.from_file("benchmark://new", tmpdir / "test.bc")
 
         with pytest.raises(ValueError) as ctx:
             env.reset(benchmark=benchmark)
@@ -100,7 +90,9 @@ def test_invalid_benchmark_path_contents(env: LlvmEnv):
 
 def test_benchmark_path_invalid_protocol(env: LlvmEnv):
     benchmark = Benchmark(
-        uri="benchmark://new", program=File(uri="invalid_protocol://test")
+        BenchmarkProto(
+            uri="benchmark://new", program=File(uri="invalid_protocol://test")
+        ),
     )
 
     with pytest.raises(ValueError) as ctx:
@@ -113,17 +105,13 @@ def test_benchmark_path_invalid_protocol(env: LlvmEnv):
 
 
 def test_custom_benchmark(env: LlvmEnv):
-    benchmark = Benchmark(
-        uri="benchmark://new", program=File(uri=f"file:///{EXAMPLE_BITCODE_FILE}")
-    )
+    benchmark = Benchmark.from_file("benchmark://new", EXAMPLE_BITCODE_FILE)
     env.reset(benchmark=benchmark)
     assert env.benchmark == "benchmark://new"
 
 
 def test_custom_benchmark_constructor():
-    benchmark = Benchmark(
-        uri="benchmark://new", program=File(uri=f"file:///{EXAMPLE_BITCODE_FILE}")
-    )
+    benchmark = Benchmark.from_file("benchmark://new", EXAMPLE_BITCODE_FILE)
     env = gym.make("llvm-v0", benchmark=benchmark)
     try:
         env.reset()
@@ -135,12 +123,19 @@ def test_custom_benchmark_constructor():
 def test_make_benchmark_single_bitcode(env: LlvmEnv):
     benchmark = llvm.make_benchmark(EXAMPLE_BITCODE_FILE)
 
-    assert benchmark.uri == f"file:///{EXAMPLE_BITCODE_FILE}"
-    assert benchmark.program.uri == f"file:///{EXAMPLE_BITCODE_FILE}"
+    assert benchmark == f"file:///{EXAMPLE_BITCODE_FILE}"
+    assert benchmark.proto.program.uri == f"file:///{EXAMPLE_BITCODE_FILE}"
 
     env.reset(benchmark=benchmark)
     assert env.benchmark == benchmark.uri
     assert env.observation["IrInstructionCount"] == EXAMPLE_BITCODE_IR_INSTRUCTION_COUNT
+
+
+@bazel_only
+def test_make_benchmark_single_ll():
+    """Test passing a single .ll file into make_benchmark()."""
+    benchmark = llvm.make_benchmark(INVALID_IR_PATH)
+    assert benchmark.uri.startswith("benchmark://user/")
 
 
 def test_make_benchmark_single_clang_job(env: LlvmEnv):
@@ -287,8 +282,11 @@ def test_two_custom_benchmarks_reset(env: LlvmEnv):
     assert env.benchmark == benchmark1.uri
     env.reset()
     assert env.benchmark == benchmark1.uri
-    env.benchmark = benchmark2
-    # assert env.benchmark == benchmark1.uri
+    with pytest.warns(
+        UserWarning,
+        match=r"Changing the benchmark has no effect until reset\(\) is called",
+    ):
+        env.benchmark = benchmark2
     env.reset()
     assert env.benchmark == benchmark2.uri
 
@@ -299,7 +297,9 @@ def test_get_system_includes_nonzero_exit_status():
     os.environ["CXX"] = "false"
     try:
         with pytest.raises(OSError) as ctx:
-            list(llvm.benchmarks._get_system_includes())
+            list(
+                llvm.llvm_benchmark._get_system_includes()  # pylint: disable=protected-access
+            )
         assert "Failed to invoke false" in str(ctx.value)
     finally:
         if old_cxx:
@@ -312,7 +312,9 @@ def test_get_system_includes_output_parse_failure():
     os.environ["CXX"] = "echo"
     try:
         with pytest.raises(OSError) as ctx:
-            list(llvm.benchmarks._get_system_includes())
+            list(
+                llvm.llvm_benchmark._get_system_includes()  # pylint: disable=protected-access
+            )
         assert "Failed to parse '#include <...>' search paths from echo" in str(
             ctx.value
         )

--- a/tests/llvm/invalid_ir.ll
+++ b/tests/llvm/invalid_ir.ll
@@ -1,0 +1,148 @@
+; Generated using llvm-stress --seed=1068
+; This IR file can be assembled: $ lvm-as tests/llvm/invalid_ir.ll
+; But it cannot be compiled:     $ clang tests/llvm/invalid_ir.ll
+; The error is: "error in backend: Cannot emit physreg copy instruction"
+
+; ModuleID = '<stdin>'
+source_filename = "/tmp/autogen.bc"
+
+define void @autogen_SD1068(i8* %0, i32* %1, i64* %2, i32 %3, i64 %4, i8 %5) {
+BB:
+  %A4 = alloca <8 x i32>
+  %A3 = alloca <16 x double>
+  %A2 = alloca <8 x double>
+  %A1 = alloca <1 x float>
+  %A = alloca <1 x i64>
+  %L = load i8, i8* %0
+  store <1 x i64> <i64 -1>, <1 x i64>* %A
+  %E = extractelement <16 x i32> zeroinitializer, i32 7
+  %Shuff = shufflevector <2 x i1> zeroinitializer, <2 x i1> zeroinitializer, <2 x i32> <i32 undef, i32 0>
+  %I = insertelement <2 x i1> zeroinitializer, i1 true, i32 0
+  %B = srem i8 %5, %5
+  %FC = uitofp <4 x i1> zeroinitializer to <4 x double>
+  %Sl = select i1 false, i16 -83, i16 -1
+  %Cmp = icmp slt <16 x i32> zeroinitializer, zeroinitializer
+  %L5 = load i8, i8* %0
+  store i8 -11, i8* %0
+  %E6 = extractelement <2 x i1> zeroinitializer, i32 1
+  br label %CF74
+
+CF74:                                             ; preds = %BB
+  %Shuff7 = shufflevector <2 x i1> zeroinitializer, <2 x i1> %Shuff, <2 x i32> <i32 undef, i32 2>
+  %I8 = insertelement <2 x i1> %Shuff, i1 false, i32 0
+  %B9 = and i16 %Sl, -25375
+  %FC10 = uitofp <2 x i1> zeroinitializer to <2 x float>
+  %Sl11 = select i1 false, i16 -25375, i16 -1
+  %Cmp12 = icmp uge <2 x i1> %I, %Shuff
+  %L13 = load i8, i8* %0
+  store i8 -111, i8* %0
+  %E14 = extractelement <4 x double> %FC, i32 3
+  %Shuff15 = shufflevector <2 x i1> zeroinitializer, <2 x i1> %Shuff, <2 x i32> <i32 2, i32 0>
+  %I16 = insertelement <2 x float> %FC10, float 0xB8A8325C00000000, i32 0
+  %B17 = srem <2 x i64> zeroinitializer, zeroinitializer
+  %PC = bitcast <8 x i32>* %A4 to i1*
+  %Sl18 = select i1 false, <2 x float> %FC10, <2 x float> %FC10
+  %Cmp19 = icmp ule <8 x i16> zeroinitializer, zeroinitializer
+  %L20 = load i1, i1* %PC
+  br label %CF
+
+CF:                                               ; preds = %CF76, %CF82, %CF, %CF74
+  store i1 true, i1* %PC
+  %E21 = extractelement <2 x i1> zeroinitializer, i32 1
+  br i1 %E21, label %CF, label %CF77
+
+CF77:                                             ; preds = %CF83, %CF77, %CF
+  %Shuff22 = shufflevector <2 x i1> zeroinitializer, <2 x i1> zeroinitializer, <2 x i32> <i32 0, i32 2>
+  %I23 = insertelement <2 x i16> zeroinitializer, i16 -83, i32 0
+  %B24 = shl <2 x i16> zeroinitializer, zeroinitializer
+  %FC25 = fptosi float 0x3C2A305E00000000 to i32
+  %Sl26 = select i1 true, <8 x i8> zeroinitializer, <8 x i8> zeroinitializer
+  %L27 = load i1, i1* %PC
+  br i1 %L27, label %CF77, label %CF83
+
+CF83:                                             ; preds = %CF77
+  store i32 %FC25, i32* %1
+  %E28 = extractelement <4 x double> %FC, i32 0
+  %Shuff29 = shufflevector <2 x i1> zeroinitializer, <2 x i1> %Shuff, <2 x i32> <i32 3, i32 1>
+  %I30 = insertelement <16 x i32> zeroinitializer, i32 484009, i32 1
+  %B31 = fdiv float 0x3C2A305E00000000, 0x401A204E00000000
+  %Sl32 = select i1 false, double %E14, double 0xE8B721D6BDB52C54
+  %Cmp33 = fcmp une float 0xB8A8325C00000000, %B31
+  br i1 %Cmp33, label %CF77, label %CF79
+
+CF79:                                             ; preds = %CF79, %CF83
+  %L34 = load i1, i1* %PC
+  br i1 %L34, label %CF79, label %CF80
+
+CF80:                                             ; preds = %CF80, %CF79
+  store i1 false, i1* %PC
+  %E35 = extractelement <8 x i1> %Cmp19, i32 1
+  br i1 %E35, label %CF80, label %CF82
+
+CF82:                                             ; preds = %CF80
+  %Shuff36 = shufflevector <16 x i32> zeroinitializer, <16 x i32> zeroinitializer, <16 x i32> <i32 4, i32 6, i32 8, i32 10, i32 12, i32 14, i32 undef, i32 18, i32 20, i32 22, i32 undef, i32 26, i32 28, i32 30, i32 0, i32 undef>
+  %I37 = insertelement <16 x i32> zeroinitializer, i32 48253, i32 6
+  %ZE = zext <2 x i1> %Shuff29 to <2 x i64>
+  %Sl38 = select i1 true, i1 false, i1 false
+  br i1 %Sl38, label %CF, label %CF75
+
+CF75:                                             ; preds = %CF81, %CF75, %CF82
+  %L39 = load i8, i8* %0
+  store i1 true, i1* %PC
+  %E40 = extractelement <16 x i32> zeroinitializer, i32 9
+  %Shuff41 = shufflevector <2 x i1> %Shuff29, <2 x i1> %Shuff29, <2 x i32> <i32 0, i32 2>
+  %I42 = insertelement <2 x i1> zeroinitializer, i1 false, i32 0
+  %Tr = trunc <16 x i32> %I37 to <16 x i16>
+  %Sl43 = select i1 %Sl38, i16 %Sl, i16 %Sl
+  %Cmp44 = icmp sge <2 x i1> zeroinitializer, zeroinitializer
+  %L45 = load i8, i8* %0
+  store i8 %5, i8* %0
+  %E46 = extractelement <2 x i16> %B24, i32 1
+  %Shuff47 = shufflevector <2 x i1> %Shuff41, <2 x i1> %Shuff, <2 x i32> <i32 0, i32 2>
+  %I48 = insertelement <2 x i1> zeroinitializer, i1 %E6, i32 0
+  %B49 = shl i32 48253, %FC25
+  %FC50 = uitofp <2 x i1> %Cmp12 to <2 x double>
+  %Sl51 = select i1 %E6, <16 x i32> %I30, <16 x i32> zeroinitializer
+  %Cmp52 = fcmp ult double 0x840B362A8B09F2A8, %E14
+  br i1 %Cmp52, label %CF75, label %CF78
+
+CF78:                                             ; preds = %CF78, %CF75
+  %L53 = load i8, i8* %0
+  store i8 -79, i8* %0
+  %E54 = extractelement <8 x i16> zeroinitializer, i32 4
+  %Shuff55 = shufflevector <2 x i1> %Shuff, <2 x i1> %Shuff, <2 x i32> <i32 3, i32 undef>
+  %I56 = insertelement <2 x i1> %I8, i1 %Cmp52, i32 1
+  %Sl57 = select i1 %Cmp52, i8 %L13, i8 %L39
+  %Cmp58 = icmp ne <2 x i64> zeroinitializer, %B17
+  %L59 = load i1, i1* %PC
+  br i1 %L59, label %CF78, label %CF81
+
+CF81:                                             ; preds = %CF78
+  store i8 -111, i8* %0
+  %E60 = extractelement <2 x i1> %Shuff7, i32 1
+  br i1 %E60, label %CF75, label %CF76
+
+CF76:                                             ; preds = %CF81
+  %Shuff61 = shufflevector <2 x i1> zeroinitializer, <2 x i1> %Shuff47, <2 x i32> <i32 2, i32 0>
+  %I62 = insertelement <2 x i1> zeroinitializer, i1 %E21, i32 0
+  %B63 = frem double %Sl32, %E14
+  %ZE64 = zext i1 false to i8
+  %Sl65 = select i1 false, <2 x i1> %Shuff61, <2 x i1> %Shuff
+  %Cmp66 = icmp uge i64 %4, %4
+  br i1 %Cmp66, label %CF, label %CF73
+
+CF73:                                             ; preds = %CF76
+  %L67 = load i8, i8* %0
+  store i8 -111, i8* %0
+  %E68 = extractelement <2 x i16> %B24, i32 1
+  %Shuff69 = shufflevector <16 x i32> zeroinitializer, <16 x i32> %I30, <16 x i32> <i32 14, i32 16, i32 undef, i32 20, i32 22, i32 24, i32 26, i32 28, i32 30, i32 0, i32 2, i32 4, i32 6, i32 8, i32 10, i32 12>
+  %I70 = insertelement <16 x i32> zeroinitializer, i32 %B49, i32 0
+  %Tr71 = fptrunc double 0x840B362A8B09F2A8 to float
+  %Sl72 = select i1 %Cmp52, i32 %FC25, i32 48253
+  store i8 %L39, i8* %0
+  store i8 %L13, i8* %0
+  store i1 %Cmp52, i1* %PC
+  store <1 x i64> <i64 -1>, <1 x i64>* %A
+  store i8 %L39, i8* %0
+  ret void
+}


### PR DESCRIPTION
* Change `make_benchmark()` so that it returns a `Benchmark` class instance, rather than a protocol buffer.
* Add support for assembling `*.ll` files when constructing benchmarks.

Issue #45.
