### PR TITLE
[datasets] Add Dataset __getitem__, __iter__, and __len__.

### DIFF
--- a/compiler_gym/datasets/files_dataset.py
+++ b/compiler_gym/datasets/files_dataset.py
@@ -68,7 +68,7 @@ class FilesDataset(Dataset):
         self._memoized_uris = None
 
     @memoized_property
-    def n(self) -> int:  # pylint: disable=invalid-overriden-method
+    def size(self) -> int:  # pylint: disable=invalid-overriden-method
         self.install()
         return sum(
             sum(1 for f in files if f.endswith(self.benchmark_file_suffix))
@@ -111,9 +111,9 @@ class FilesDataset(Dataset):
     def benchmark(self, uri: Optional[str] = None) -> Benchmark:
         self.install()
         if uri is None or len(uri) <= len(self.name) + 1:
-            if not self.n:
+            if not self.size:
                 raise ValueError("No benchmarks")
-            return self._get_benchmark_by_index(self.random.integers(self.n))
+            return self._get_benchmark_by_index(self.random.integers(self.size))
 
         relpath = f"{uri[len(self.name) + 1:]}{self.benchmark_file_suffix}"
         abspath = self.dataset_root / relpath
@@ -160,4 +160,4 @@ class FilesDataset(Dataset):
 
         # "Unreachable". _get_benchmark_by_index() should always be called with
         # in-bounds values. Perhaps files have been deleted from site_data_path?
-        raise IndexError(f"Could not find benchmark with index {n} / {self.n}")
+        raise IndexError(f"Could not find benchmark with index {n} / {self.size}")

--- a/compiler_gym/datasets/tar_dataset.py
+++ b/compiler_gym/datasets/tar_dataset.py
@@ -209,7 +209,7 @@ class TarDatasetWithManifest(TarDataset):
             return uris
 
     @memoized_property
-    def n(self) -> int:
+    def size(self) -> int:
         return len(self._benchmark_uris)
 
     def benchmark_uris(self) -> Iterable[str]:

--- a/tests/datasets/dataset_test.py
+++ b/tests/datasets/dataset_test.py
@@ -134,5 +134,53 @@ def test_dataset_site_data_directory(tmpwd: Path):
     assert not dataset.site_data_path.is_dir()  # Dir is not created until needed.
 
 
+class TestDataset(Dataset):
+    """A dataset to use for testing."""
+
+    def __init__(self, benchmarks=None):
+        super().__init__(
+            name="benchmark://test-v0",
+            description="A test dataset",
+            license="MIT",
+            site_data_base="test",
+        )
+        self._benchmarks = benchmarks or {
+            "benchmark://test-v0/a": 1,
+            "benchmark://test-v0/b": 2,
+            "benchmark://test-v0/c": 3,
+        }
+
+    def benchmark_uris(self):
+        return sorted(self._benchmarks)
+
+    def benchmark(self, uri):
+        if uri:
+            return self._benchmarks[uri]
+        else:
+            return next(iter(self._benchmarks.values()))
+
+    @property
+    def size(self):
+        return len(self._benchmarks)
+
+
+def test_dataset_size():
+    dataset = TestDataset()
+    assert dataset.size == 3
+    assert len(dataset) == 3
+
+
+def test_benchmarks_lookup_by_uri():
+    dataset = TestDataset()
+    assert dataset.benchmark("benchmark://test-v0/b") == 2
+    assert dataset["benchmark://test-v0/b"] == 2
+
+
+def test_benchmarks_iter():
+    dataset = TestDataset()
+    assert list(dataset.benchmarks()) == [1, 2, 3]
+    assert list(dataset) == [1, 2, 3]
+
+
 if __name__ == "__main__":
     main()

--- a/tests/datasets/files_dataset_test.py
+++ b/tests/datasets/files_dataset_test.py
@@ -59,7 +59,7 @@ def test_dataset_is_installed(empty_dataset: FilesDataset):
 
 
 def test_empty_dataset(empty_dataset: FilesDataset):
-    assert empty_dataset.n == 0
+    assert empty_dataset.size == 0
     assert list(empty_dataset.benchmark_uris()) == []
     assert list(empty_dataset.benchmarks()) == []
 
@@ -84,7 +84,7 @@ def test_populated_dataset(populated_dataset: FilesDataset):
             "benchmark://test-v0/b/c.txt",
             "benchmark://test-v0/b/d.jpg",
         ]
-        assert populated_dataset.n == 9
+        assert populated_dataset.size == 9
 
 
 def test_populated_dataset_benchmark_lookup(populated_dataset: FilesDataset):
@@ -116,7 +116,7 @@ def test_populated_dataset_with_file_extension_filter(populated_dataset: FilesDa
         "benchmark://test-v0/g",
         "benchmark://test-v0/b/d",
     ]
-    assert populated_dataset.n == 2
+    assert populated_dataset.size == 2
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This adds python operator overloads that alias to existing methods to
make the Dataset class "feel" more like a regular python dictionary:

```py
>>> len(dataset)  # equivalent to dataset.n
23

>>> for benchmark in dataset:  # iterate over the class directly
...     pass

>>> dataset["cbench-v1/crc32"]  # key a benchmark
```

This also renames Dataset.n to Dataset.size for consistent with other
containers like np.ndarray, and returns math.inf if the number of
benchmarks is infinite, not a negative integer. The advantage of
math.inf is that will poison any integer arithemtic, e.g.

```py
>>> sum(d.size for d in datasets)
inf
```

if any one of the datasets has an infinite size. With a negative
number, this would instead compute a regular integer value.

Issue #45.