### PR TITLE
Implement CompilerEnv.seed()

### DIFF
--- a/compiler_gym/envs/compiler_env.py
+++ b/compiler_gym/envs/compiler_env.py
@@ -318,6 +318,19 @@ class CompilerEnv(gym.Env):
         """The version string of the underlying compiler that this service supports."""
         return self.versions.compiler_version
 
+    def seed(self, seed: Optional[int] = None) -> List[int]:
+        """Sets the seed for this environment's random number generator.
+
+        :return: A list containing a single seed value that is used for the
+            environment's random number generators. This value is equal to the
+            input argument :code:`seed`, unless :code:`seed=None`.
+        """
+        if seed is None:
+            seed = np.random.default_rng().integers((2 ** 63))
+
+        self.datasets.seed(seed)
+        return [seed]
+
     def commandline(self) -> str:
         """Interface for :class:`CompilerEnv` subclasses to provide an equivalent
         commandline invocation to the current environment state.

--- a/tests/compiler_env_test.py
+++ b/tests/compiler_env_test.py
@@ -80,5 +80,21 @@ def test_logger_forced():
         env_b.close()
 
 
+def test_set_seed(env: CompilerEnv):
+    assert env.seed(1) == [1]
+    assert env.seed(2) == [2]
+
+
+def test_choose_random_seed_different_values(env: CompilerEnv):
+    a, b = env.seed(), env.seed()
+    assert a != b, f"{a} != {b}"
+
+
+def test_choose_random_seed_unique_values(env: CompilerEnv):
+    """Check that calling seed multiple times returns unique values."""
+    seeds = [env.seed()[0] for _ in range(10)]
+    assert len(seeds) == len(set(seeds)), seeds
+
+
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
The new Datasets API is more explicit about its source of randomness when choosing benchmarks, so implement the standard gym `env.seed()` method to allow users to set and record this seed.

One quick of the `Env.seed` method is that when called with no arguments it should choose a seed randomly and return it. Given that we do not want to rely on any RNGs (that users may also have seeded), I chose instead to use the walltime to generate a seed.

Issue #45.