### PR TITLE
Move DefaultRewardFromObservation into spaces namespace.

### DIFF
--- a/compiler_gym/envs/compiler_env.py
+++ b/compiler_gym/envs/compiler_env.py
@@ -43,7 +43,7 @@ from compiler_gym.service.proto import (
     StartSessionRequest,
     StepRequest,
 )
-from compiler_gym.spaces import NamedDiscrete, Reward
+from compiler_gym.spaces import DefaultRewardFromObservation, NamedDiscrete, Reward
 from compiler_gym.util.debug_util import get_logging_level
 from compiler_gym.util.timer import Timer
 from compiler_gym.validation_result import ValidationError, ValidationResult
@@ -52,33 +52,6 @@ from compiler_gym.views import ObservationSpaceSpec, ObservationView, RewardView
 # Type hints.
 info_t = Dict[str, Any]
 step_t = Tuple[Optional[observation_t], Optional[float], bool, info_t]
-
-
-class DefaultRewardFromObservation(Reward):
-    def __init__(self, observation_name: str, **kwargs):
-        super().__init__(
-            observation_spaces=[observation_name], id=observation_name, **kwargs
-        )
-        self.previous_value: Optional[observation_t] = None
-
-    def reset(self, benchmark: str) -> None:
-        """Called on env.reset(). Reset incremental progress."""
-        del benchmark  # unused
-        self.previous_value = None
-
-    def update(
-        self,
-        action: int,
-        observations: List[observation_t],
-        observation_view: ObservationView,
-    ) -> float:
-        """Called on env.step(). Compute and return new reward."""
-        value: float = observations[0]
-        if self.previous_value is None:
-            self.previous_value = 0
-        reward = float(value - self.previous_value)
-        self.previous_value = value
-        return reward
 
 
 class CompilerEnv(gym.Env):

--- a/compiler_gym/spaces/__init__.py
+++ b/compiler_gym/spaces/__init__.py
@@ -4,15 +4,16 @@
 # LICENSE file in the root directory of this source tree.
 from compiler_gym.spaces.commandline import Commandline, CommandlineFlag
 from compiler_gym.spaces.named_discrete import NamedDiscrete
-from compiler_gym.spaces.reward import Reward
+from compiler_gym.spaces.reward import DefaultRewardFromObservation, Reward
 from compiler_gym.spaces.scalar import Scalar
 from compiler_gym.spaces.sequence import Sequence
 
 __all__ = [
-    "Scalar",
-    "Sequence",
-    "NamedDiscrete",
     "Commandline",
     "CommandlineFlag",
+    "DefaultRewardFromObservation",
+    "NamedDiscrete",
     "Reward",
+    "Scalar",
+    "Sequence",
 ]

--- a/compiler_gym/spaces/reward.py
+++ b/compiler_gym/spaces/reward.py
@@ -133,3 +133,32 @@ class Reward(Scalar):
 
     def __repr__(self):
         return self.id
+
+
+class DefaultRewardFromObservation(Reward):
+    def __init__(self, observation_name: str, **kwargs):
+        super().__init__(
+            observation_spaces=[observation_name], id=observation_name, **kwargs
+        )
+        self.previous_value: Optional[observation_t] = None
+
+    def reset(self, benchmark: str) -> None:
+        """Called on env.reset(). Reset incremental progress."""
+        del benchmark  # unused
+        self.previous_value = None
+
+    def update(
+        self,
+        action: int,
+        observations: List[observation_t],
+        observation_view: "compiler_gym.views.ObservationView",  # noqa: F821
+    ) -> float:
+        """Called on env.step(). Compute and return new reward."""
+        del action  # unused
+        del observation_view  # unused
+        value: float = observations[0]
+        if self.previous_value is None:
+            self.previous_value = 0
+        reward = float(value - self.previous_value)
+        self.previous_value = value
+        return reward


### PR DESCRIPTION
Move DefaultRewardFromObservation out of compiler_env.py and into the
compiler_gym.spaces namespace. This is just housekeeping to minimize
the number of classes and definitions in compiler_env.py.
