### PR TITLE
[env] Add a SessionNotFound error.

### DIFF
--- a/compiler_gym/envs/llvm/service/LlvmService.cc
+++ b/compiler_gym/envs/llvm/service/LlvmService.cc
@@ -181,7 +181,7 @@ Status LlvmService::GetBenchmarks(ServerContext* /* unused */,
 Status LlvmService::session(uint64_t id, LlvmSession** environment) {
   auto it = sessions_.find(id);
   if (it == sessions_.end()) {
-    return Status(StatusCode::INVALID_ARGUMENT, fmt::format("Session not found: {}", id));
+    return Status(StatusCode::NOT_FOUND, fmt::format("Session not found: {}", id));
   }
 
   *environment = it->second.get();
@@ -191,7 +191,7 @@ Status LlvmService::session(uint64_t id, LlvmSession** environment) {
 Status LlvmService::session(uint64_t id, const LlvmSession** environment) const {
   auto it = sessions_.find(id);
   if (it == sessions_.end()) {
-    return Status(StatusCode::INVALID_ARGUMENT, fmt::format("Session not found: {}", id));
+    return Status(StatusCode::NOT_FOUND, fmt::format("Session not found: {}", id));
   }
 
   *environment = it->second.get();

--- a/compiler_gym/service/__init__.py
+++ b/compiler_gym/service/__init__.py
@@ -10,17 +10,19 @@ from compiler_gym.service.connection import (
     ServiceIsClosed,
     ServiceOSError,
     ServiceTransportError,
+    SessionNotFound,
 )
 from compiler_gym.service.proto2py import observation_t, scalar_range2tuple
 
 __all__ = [
+    "CompilerGymServiceConnection",
+    "ConnectionOpts",
+    "observation_t",
+    "scalar_range2tuple",
     "ServiceError",
     "ServiceInitError",
     "ServiceIsClosed",
-    "ServiceTransportError",
     "ServiceOSError",
-    "CompilerGymServiceConnection",
-    "ConnectionOpts",
-    "scalar_range2tuple",
-    "observation_t",
+    "ServiceTransportError",
+    "SessionNotFound",
 ]

--- a/compiler_gym/service/connection.py
+++ b/compiler_gym/service/connection.py
@@ -86,6 +86,10 @@ class ServiceError(Exception):
     """Error raised from the service."""
 
 
+class SessionNotFound(ServiceError):
+    """Requested session ID not found in service."""
+
+
 class ServiceOSError(ServiceError, OSError):
     """System error raised from the service."""
 

--- a/examples/example_compiler_gym_service/env_tests.py
+++ b/examples/example_compiler_gym_service/env_tests.py
@@ -11,6 +11,7 @@ from gym.spaces import Box
 import compiler_gym
 import examples.example_compiler_gym_service  # noqa Register environments.
 from compiler_gym.envs import CompilerEnv
+from compiler_gym.service import SessionNotFound
 from compiler_gym.spaces import NamedDiscrete, Scalar, Sequence
 from tests.test_main import main
 
@@ -71,16 +72,16 @@ def test_step_before_reset(env: CompilerEnv):
 
 def test_observation_before_reset(env: CompilerEnv):
     """Taking an observation before reset() is illegal."""
-    with pytest.raises(ValueError) as ctx:
+    with pytest.raises(SessionNotFound) as ctx:
         _ = env.observation["ir"]
-    assert str(ctx.value) == "Session ID not found"
+    assert str(ctx.value).startswith("Session not found")
 
 
 def test_reward_before_reset(env: CompilerEnv):
     """Taking a reward before reset() is illegal."""
-    with pytest.raises(ValueError) as ctx:
+    with pytest.raises(SessionNotFound) as ctx:
         _ = env.reward["runtime"]
-    assert str(ctx.value) == "Session ID not found"
+    assert str(ctx.value).startswith("Session not found")
 
 
 def test_reset_invalid_benchmark(env: CompilerEnv):

--- a/examples/example_compiler_gym_service/service_cc/BUILD
+++ b/examples/example_compiler_gym_service/service_cc/BUILD
@@ -25,5 +25,6 @@ cc_library(
         "//compiler_gym/util:Version",
         "@boost//:filesystem",
         "@com_github_grpc_grpc//:grpc++",
+        "@fmt",
     ],
 )

--- a/examples/example_compiler_gym_service/service_cc/ExampleService.cc
+++ b/examples/example_compiler_gym_service/service_cc/ExampleService.cc
@@ -5,6 +5,8 @@
 
 #include "examples/example_compiler_gym_service/service_cc/ExampleService.h"
 
+#include <fmt/format.h>
+
 #include "compiler_gym/service/proto/compiler_gym_service.pb.h"
 #include "compiler_gym/util/GrpcStatusMacros.h"
 #include "compiler_gym/util/Version.h"
@@ -159,7 +161,7 @@ Status ExampleService::GetBenchmarks(grpc::ServerContext* /*unused*/,
 Status ExampleService::session(uint64_t id, ExampleCompilationSession** sess) {
   auto it = sessions_.find(id);
   if (it == sessions_.end()) {
-    return Status(StatusCode::INVALID_ARGUMENT, "Session ID not found");
+    return Status(StatusCode::NOT_FOUND, fmt::format("Session not found: {}", id));
   }
   *sess = it->second.get();
   return Status::OK;

--- a/examples/example_compiler_gym_service/service_py/example_service.py
+++ b/examples/example_compiler_gym_service/service_py/example_service.py
@@ -203,8 +203,8 @@ class ExampleCompilerGymService(proto.CompilerGymServiceServicer):
     def Step(self, request: proto.StepRequest, context) -> proto.StepReply:
         logging.debug("Step()")
         if request.session_id not in self.sessions:
-            context.set_code(grpc.StatusCode.INVALID_ARGUMENT)
-            context.set_details("Session ID not found")
+            context.set_code(grpc.StatusCode.NOT_FOUND)
+            context.set_details(f"Session not found: {request.session_id}")
             return
 
         return self.sessions[request.session_id].step(request, context)


### PR DESCRIPTION
A compiler service supports multiple simultaneous sessions. Frontend
code uses a Session ID value to identify the correct session when
making requests. This session ID lookup could fail for a number of
reasons - perhaps the service has restarted, the session was evicted
due to operating constraints, or the environment was configured
incorrectly.

This patch adds anew SessionNotFound error that can be used by
services to identify this particular error case so that it can be
handled appropriately. Before, it would just raise a ValueError
because of the INVALID_ARGUMENT gRPC status code.