### PR TITLE
[llvm] Port some of the LLVM datasets to the new interface.

### DIFF
--- a/compiler_gym/envs/llvm/BUILD
+++ b/compiler_gym/envs/llvm/BUILD
@@ -53,6 +53,7 @@ py_library(
         ":llvm_benchmark",
         ":llvm_rewards",
         "//compiler_gym/envs:compiler_env",
+        "//compiler_gym/envs/llvm/datasets",
         "//compiler_gym/spaces",
         "//compiler_gym/third_party/autophase",
         "//compiler_gym/third_party/inst2vec",

--- a/compiler_gym/envs/llvm/datasets/BUILD
+++ b/compiler_gym/envs/llvm/datasets/BUILD
@@ -1,0 +1,20 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+load("@rules_python//python:defs.bzl", "py_library")
+
+py_library(
+    name = "datasets",
+    srcs = [
+        "__init__.py",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//compiler_gym/datasets",
+        "//compiler_gym/envs/llvm:llvm_benchmark",
+        "//compiler_gym/service/proto",
+        "//compiler_gym/third_party/llvm",
+        "//compiler_gym/util",
+    ],
+)

--- a/compiler_gym/envs/llvm/datasets/__init__.py
+++ b/compiler_gym/envs/llvm/datasets/__init__.py
@@ -1,0 +1,219 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+import sys
+from pathlib import Path
+from typing import Iterable, Optional
+
+from compiler_gym.datasets import Dataset, TarDatasetWithManifest
+from compiler_gym.util.runfiles_path import site_data_path
+
+
+class BlasDataset(TarDatasetWithManifest):
+    def __init__(self, site_data_base: Path, sort_order: int = 0):
+        super().__init__(
+            name="benchmark://blas-v0",
+            tar_urls=[
+                "https://dl.fbaipublicfiles.com/compiler_gym/llvm_bitcodes-10.0.0-blas-v0.tar.bz2"
+            ],
+            tar_sha256="e724a8114709f8480adeb9873d48e426e8d9444b00cddce48e342b9f0f2b096d",
+            manifest_urls=[
+                "https://dl.fbaipublicfiles.com/compiler_gym/llvm_bitcodes-10.0.0-blas-v0-manifest.bz2"
+            ],
+            manifest_sha256="6946437dcb0da5fad3ed8a7fd83eb4294964198391d5537b1310e22d7ceebff4",
+            references={
+                "Paper": "https://strum355.netsoc.co/books/PDF/Basic%20Linear%20Algebra%20Subprograms%20for%20Fortran%20Usage%20-%20BLAS%20(1979).pdf",
+                "Homepage": "http://www.netlib.org/blas/",
+            },
+            license="BSD 3-Clause",
+            strip_prefix="blas-v0",
+            description="Basic linear algebra kernels",
+            benchmark_file_suffix=".bc",
+            site_data_base=site_data_base,
+            sort_order=sort_order,
+        )
+
+
+class GitHubDataset(TarDatasetWithManifest):
+    def __init__(self, site_data_base: Path, sort_order: int = 0):
+        manifest_url, manifest_sha256 = {
+            "darwin": (
+                "https://dl.fbaipublicfiles.com/compiler_gym/llvm_bitcodes-10.0.0-github-v0-macos-manifest.bz2",
+                "10d933a7d608248be286d756b27813794789f7b87d8561c241d0897fb3238503",
+            ),
+            "linux": (
+                "https://dl.fbaipublicfiles.com/compiler_gym/llvm_bitcodes-10.0.0-github-v0-linux-manifest.bz2",
+                "aede9ca78657b4694ada9a4592d93f0bbeb3b3bd0fff3b537209850228480d3b",
+            ),
+        }[sys.platform]
+        super().__init__(
+            name="benchmark://github-v0",
+            tar_urls=[
+                "https://dl.fbaipublicfiles.com/compiler_gym/llvm_bitcodes-10.0.0-github-v0.tar.bz2"
+            ],
+            tar_sha256="880269dd7a5c2508ea222a2e54c318c38c8090eb105c0a87c595e9dd31720764",
+            manifest_urls=[manifest_url],
+            manifest_sha256=manifest_sha256,
+            license="CC BY 4.0",
+            references={
+                "Paper": "https://arxiv.org/pdf/2012.01470.pdf",
+            },
+            strip_prefix="github-v0",
+            description="Compile-only C/C++ objects from GitHub",
+            benchmark_file_suffix=".bc",
+            site_data_base=site_data_base,
+            sort_order=sort_order,
+        )
+
+
+class LinuxDataset(TarDatasetWithManifest):
+    def __init__(self, site_data_base: Path, sort_order: int = 0):
+        manifest_url, manifest_sha256 = {
+            "darwin": (
+                "https://dl.fbaipublicfiles.com/compiler_gym/llvm_bitcodes-10.0.0-linux-v0-macos-manifest.bz2",
+                "dfc87b94c7a43e899e76507398a5af22178aebaebcb5d7e24e82088aeecb0690",
+            ),
+            "linux": (
+                "https://dl.fbaipublicfiles.com/compiler_gym/llvm_bitcodes-10.0.0-linux-v0-linux-manifest.bz2",
+                "32ceb8576f683798010816ac605ee496f386ddbbe64be9e0796015d247a73f92",
+            ),
+        }[sys.platform]
+        super().__init__(
+            name="benchmark://linux-v0",
+            tar_urls=[
+                "https://dl.fbaipublicfiles.com/compiler_gym/llvm_bitcodes-10.0.0-linux-v0.tar.bz2"
+            ],
+            tar_sha256="a1ae5c376af30ab042c9e54dc432f89ce75f9ebaee953bc19c08aff070f12566",
+            manifest_urls=[manifest_url],
+            manifest_sha256=manifest_sha256,
+            references={"Homepage": "https://www.linux.org/"},
+            license="GPL-2.0",
+            strip_prefix="linux-v0",
+            description="Compile-only object files from C Linux kernel",
+            benchmark_file_suffix=".bc",
+            site_data_base=site_data_base,
+            sort_order=sort_order,
+        )
+
+
+class MibenchDataset(TarDatasetWithManifest):
+    def __init__(self, site_data_base: Path, sort_order: int = 0):
+        super().__init__(
+            name="benchmark://mibench-v0",
+            tar_urls=[
+                "https://dl.fbaipublicfiles.com/compiler_gym/llvm_bitcodes-10.0.0-mibench-v0.tar.bz2"
+            ],
+            tar_sha256="128c090c40b955b99fdf766da167a5f642018fb35c16a1d082f63be2e977eb13",
+            manifest_urls=[
+                "https://dl.fbaipublicfiles.com/compiler_gym/llvm_bitcodes-10.0.0-mibench-v0-manifest.bz2"
+            ],
+            manifest_sha256="8ed985d685b48f444a3312cd84ccc5debda4a839850e442a3cdc93910ba0dc5f",
+            references={
+                "Paper": "http://vhosts.eecs.umich.edu/mibench/Publications/MiBench.pdf"
+            },
+            license="BSD 3-Clause",
+            strip_prefix="mibench-v0",
+            description="C benchmarks",
+            benchmark_file_suffix=".bc",
+            site_data_base=site_data_base,
+            sort_order=sort_order,
+        )
+
+
+class NPBDataset(TarDatasetWithManifest):
+    def __init__(self, site_data_base: Path, sort_order: int = 0):
+        super().__init__(
+            name="benchmark://npb-v0",
+            tar_urls=[
+                "https://dl.fbaipublicfiles.com/compiler_gym/llvm_bitcodes-10.0.0-npb-v0.tar.bz2"
+            ],
+            tar_sha256="793ac2e7a4f4ed83709e8a270371e65b724da09eaa0095c52e7f4209f63bb1f2",
+            manifest_urls=[
+                "https://dl.fbaipublicfiles.com/compiler_gym/llvm_bitcodes-10.0.0-npb-v0-manifest.bz2"
+            ],
+            manifest_sha256="89eccb7f1b0b9e1f82b9b900b9f686ff5b189a2a67a4f8969a15901cd315dba2",
+            references={
+                "Paper": "http://optout.csc.ncsu.edu/~mueller/codeopt/codeopt05/projects/www4.ncsu.edu/~pgauria/csc791a/papers/NAS-95-020.pdf"
+            },
+            license="NASA Open Source Agreement v1.3",
+            strip_prefix="npb-v0",
+            description="NASA Parallel Benchmarks",
+            benchmark_file_suffix=".bc",
+            site_data_base=site_data_base,
+            sort_order=sort_order,
+        )
+
+
+class OpenCVDataset(TarDatasetWithManifest):
+    def __init__(self, site_data_base: Path, sort_order: int = 0):
+        super().__init__(
+            name="benchmark://opencv-v0",
+            tar_urls=[
+                "https://dl.fbaipublicfiles.com/compiler_gym/llvm_bitcodes-10.0.0-opencv-v0.tar.bz2"
+            ],
+            tar_sha256="003df853bd58df93572862ca2f934c7b129db2a3573bcae69a2e59431037205c",
+            manifest_urls=[
+                "https://dl.fbaipublicfiles.com/compiler_gym/llvm_bitcodes-10.0.0-opencv-v0-manifest.bz2"
+            ],
+            manifest_sha256="8de96f722fab18f3a2a74db74b4038c7947fe8b3da867c9260206fdf5338cd81",
+            references={
+                "Paper": "https://mipro-proceedings.com/sites/mipro-proceedings.com/files/upload/sp/sp_008.pdf",
+                "Homepage": "https://opencv.org/",
+            },
+            license="Apache 2.0",
+            strip_prefix="opencv-v0",
+            description="Compile-only object files from C++ OpenCV library",
+            benchmark_file_suffix=".bc",
+            site_data_base=site_data_base,
+            sort_order=sort_order,
+        )
+
+
+class TensorflowDataset(TarDatasetWithManifest):
+    def __init__(self, site_data_base: Path, sort_order: int = 0):
+        super().__init__(
+            name="benchmark://tensorflow-v0",
+            tar_urls=[
+                "https://dl.fbaipublicfiles.com/compiler_gym/llvm_bitcodes-10.0.0-tensorflow-v0.tar.bz2"
+            ],
+            tar_sha256="f77dd1988c772e8359e1303cc9aba0d73d5eb27e0c98415ac3348076ab94efd1",
+            manifest_urls=[
+                "https://dl.fbaipublicfiles.com/compiler_gym/llvm_bitcodes-10.0.0-tensorflow-v0-manifest.bz2"
+            ],
+            manifest_sha256="cffc45cd10250d483cb093dec913c8a7da64026686284cccf404623bd1da6da8",
+            references={
+                "Paper": "https://www.usenix.org/system/files/conference/osdi16/osdi16-abadi.pdf",
+                "Homepage": "https://www.tensorflow.org/",
+            },
+            license="Apache 2.0",
+            strip_prefix="tensorflow-v0",
+            description="Compile-only object files from C++ TensorFlow library",
+            benchmark_file_suffix=".bc",
+            site_data_base=site_data_base,
+            sort_order=sort_order,
+        )
+
+
+def get_llvm_datasets(site_data_base: Optional[Path] = None) -> Iterable[Dataset]:
+    site_data_base = site_data_base or site_data_path("llvm-v0")
+
+    yield BlasDataset(site_data_base=site_data_base, sort_order=0)
+    yield GitHubDataset(site_data_base=site_data_base, sort_order=0)
+    yield LinuxDataset(site_data_base=site_data_base, sort_order=0)
+    yield MibenchDataset(site_data_base=site_data_base, sort_order=0)
+    yield NPBDataset(site_data_base=site_data_base, sort_order=0)
+    yield OpenCVDataset(site_data_base=site_data_base, sort_order=0)
+    yield TensorflowDataset(site_data_base=site_data_base, sort_order=0)
+
+
+__all__ = [
+    "BlasDataset",
+    "get_llvm_datasets",
+    "GitHubDataset",
+    "LinuxDataset",
+    "MibenchDataset",
+    "NPBDataset",
+    "OpenCVDataset",
+    "TensorflowDataset",
+]

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setuptools.setup(
     packages=[
         "compiler_gym.bin",
         "compiler_gym.datasets",
+        "compiler_gym.envs.llvm.datasets",
         "compiler_gym.envs.llvm.service.passes",
         "compiler_gym.envs.llvm.service",
         "compiler_gym.envs.llvm",

--- a/tests/llvm/datasets/BUILD
+++ b/tests/llvm/datasets/BUILD
@@ -1,0 +1,19 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+load("@rules_python//python:defs.bzl", "py_test")
+
+py_test(
+    name = "github_test",
+    timeout = "long",
+    srcs = ["github_test.py"],
+    shard_count = 8,
+    deps = [
+        "//compiler_gym/envs/llvm",
+        "//compiler_gym/envs/llvm/datasets",
+        "//tests:test_main",
+        "//tests/pytest_plugins:common",
+        "//tests/pytest_plugins:llvm",
+    ],
+)

--- a/tests/llvm/datasets/github_test.py
+++ b/tests/llvm/datasets/github_test.py
@@ -1,0 +1,47 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Tests for the GitHub dataset."""
+import sys
+from itertools import islice
+
+import gym
+import pytest
+
+import compiler_gym.envs.llvm  # noqa register environments
+from compiler_gym.envs.llvm import LlvmEnv
+from compiler_gym.envs.llvm.datasets import GitHubDataset
+from tests.pytest_plugins.common import skip_on_ci
+from tests.test_main import main
+
+pytest_plugins = ["tests.pytest_plugins.common", "tests.pytest_plugins.llvm"]
+
+
+@pytest.fixture(scope="module")
+def github_dataset() -> GitHubDataset:
+    env = gym.make("llvm-v0")
+    try:
+        ds = env.datasets["github-v0"]
+    finally:
+        env.close()
+    yield ds
+
+
+def test_github_size(github_dataset: GitHubDataset):
+    if sys.platform == "linux":
+        assert github_dataset.size == 49738
+    else:
+        assert github_dataset.size == 47806
+
+
+@skip_on_ci
+@pytest.mark.parametrize("index", range(250))
+def test_github_random_select(env: LlvmEnv, github_dataset: GitHubDataset, index: int):
+    uri = next(islice(github_dataset.benchmark_uris(), index, None))
+    benchmark = github_dataset.benchmark(uri)
+    env.reset(benchmark=benchmark)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This adds new Dataset class implementations of some of the LLVM
datasets. The original LegacyDatasets are still used for now, they
will be migrated once everything is in place.

Issue #45.
