### PR TITLE
Encourage open sourcing of leaderboard submissions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,12 +64,12 @@ and file a [Pull Request](#pull-requests). Please include:
    [submission template](/leaderboard/SUBMISSION_TEMPLATE.md) as a guide.
 
 Please make sure to update to the latest CompilerGym release prior to
-submission. We do not require that you submit the source code for your approach.
-Once you submit your pull request we will validate your results CSV files and
-may ask clarifying questions if we feel that those would be useful to improve
-reproducibility. [Take a look
-here](https://github.com/facebookresearch/CompilerGym/pull/117) for an example
-of a well-formed pull request submission.
+submission. We do not require that you submit the source code for your approach,
+though we encourage that you make it publicly available. Once you submit your
+pull request we will validate your results CSV files and may ask clarifying
+questions if we feel that those would be useful to improve reproducibility.
+[Take a look here](https://github.com/facebookresearch/CompilerGym/pull/117) for
+an example of a well-formed pull request submission.
 
 
 ## Code Style


### PR DESCRIPTION
It is not a requirement, but it is generally valuable for the research
community. Thanks @benoitsteiner for the suggestion.