### PR TITLE
Use pydantic for CompilerEnvState.

### DIFF
--- a/compiler_gym/BUILD
+++ b/compiler_gym/BUILD
@@ -24,6 +24,9 @@ py_library(
     name = "compiler_env_state",
     srcs = ["compiler_env_state.py"],
     visibility = ["//compiler_gym:__subpackages__"],
+    deps = [
+        "//compiler_gym/datasets:uri",
+    ],
 )
 
 py_library(
@@ -54,6 +57,7 @@ py_library(
     srcs = ["validate.py"],
     visibility = ["//compiler_gym:__subpackages__"],
     deps = [
+        ":validation_error",
         ":validation_result",
         "//compiler_gym/envs:compiler_env",
         "//compiler_gym/spaces",
@@ -62,11 +66,18 @@ py_library(
 )
 
 py_library(
+    name = "validation_error",
+    srcs = ["validation_error.py"],
+    visibility = ["//compiler_gym:__subpackages__"],
+)
+
+py_library(
     name = "validation_result",
     srcs = ["validation_result.py"],
     visibility = ["//compiler_gym:__subpackages__"],
     deps = [
         ":compiler_env_state",
+        ":validation_error",
         "//compiler_gym/util",
     ],
 )

--- a/compiler_gym/__init__.py
+++ b/compiler_gym/__init__.py
@@ -44,7 +44,8 @@ from compiler_gym.util.runfiles_path import (
     transient_cache_path,
 )
 from compiler_gym.validate import validate_states
-from compiler_gym.validation_result import ValidationError, ValidationResult
+from compiler_gym.validation_error import ValidationError
+from compiler_gym.validation_result import ValidationResult
 
 # The top-level compiler_gym API.
 __all__ = [

--- a/compiler_gym/datasets/BUILD
+++ b/compiler_gym/datasets/BUILD
@@ -16,8 +16,15 @@ py_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        ":uri",
         "//compiler_gym:validation_result",
         "//compiler_gym/service/proto",
         "//compiler_gym/util",
     ],
+)
+
+py_library(
+    name = "uri",
+    srcs = ["uri.py"],
+    visibility = ["//compiler_gym:__subpackages__"],
 )

--- a/compiler_gym/datasets/benchmark.py
+++ b/compiler_gym/datasets/benchmark.py
@@ -2,7 +2,6 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-import re
 from concurrent.futures import as_completed
 from pathlib import Path
 from typing import Callable, Iterable, List, NamedTuple, Optional, Union
@@ -11,39 +10,12 @@ from compiler_gym.service.proto import Benchmark as BenchmarkProto
 from compiler_gym.service.proto import File
 from compiler_gym.util import thread_pool
 from compiler_gym.util.decorators import memoized_property
-from compiler_gym.validation_result import ValidationError
+from compiler_gym.validation_error import ValidationError
 
 # A validation callback is a function that takes a single CompilerEnv instance
 # as its argument and returns an iterable sequence of zero or more
 # ValidationError tuples.
 ValidationCallback = Callable[["CompilerEnv"], Iterable[ValidationError]]  # noqa: F821
-
-
-# Regular expression that matches the full two-part URI prefix of a dataset:
-#     {{protocol}}://{{dataset}}
-#
-# An optional trailing slash is permitted.
-#
-# Example matches: "benchmark://foo-v0", "generator://bar-v0/".
-DATASET_NAME_RE = re.compile(
-    r"(?P<dataset>(?P<dataset_protocol>[a-zA-z0-9-_]+)://(?P<dataset_name>[a-zA-z0-9-_]+-v(?P<dataset_version>[0-9]+)))/?"
-)
-
-# Regular expression that matches the full three-part format of a benchmark URI:
-#     {{protocol}}://{{dataset}}/{{id}}
-#
-# Example matches: "benchmark://foo-v0/foo" or "generator://bar-v1/foo/bar.txt".
-BENCHMARK_URI_RE = re.compile(
-    r"(?P<dataset>(?P<dataset_protocol>[a-zA-z0-9-_]+)://(?P<dataset_name>[a-zA-z0-9-_]+-v(?P<dataset_version>[0-9]+)))/(?P<benchmark_name>[^\s]+)$"
-)
-
-
-def resolve_uri_protocol(uri: str) -> str:
-    """Require that the URI has a protocol by applying a default "benchmark"
-    protocol if none is set."""
-    if "://" not in uri:
-        return f"benchmark://{uri}"
-    return uri
 
 
 class BenchmarkSource(NamedTuple):

--- a/compiler_gym/datasets/dataset.py
+++ b/compiler_gym/datasets/dataset.py
@@ -15,7 +15,8 @@ from typing import Dict, Iterable, List, NamedTuple, Optional, Union
 import fasteners
 from deprecated.sphinx import deprecated
 
-from compiler_gym.datasets.benchmark import DATASET_NAME_RE, Benchmark
+from compiler_gym.datasets.benchmark import Benchmark
+from compiler_gym.datasets.uri import DATASET_NAME_RE
 from compiler_gym.util.debug_util import get_logging_level
 from compiler_gym.util.download import download
 

--- a/compiler_gym/datasets/datasets.py
+++ b/compiler_gym/datasets/datasets.py
@@ -5,12 +5,9 @@
 from collections import deque
 from typing import Dict, Iterable, Set, TypeVar
 
-from compiler_gym.datasets.benchmark import (
-    BENCHMARK_URI_RE,
-    Benchmark,
-    resolve_uri_protocol,
-)
+from compiler_gym.datasets.benchmark import Benchmark
 from compiler_gym.datasets.dataset import Dataset
+from compiler_gym.datasets.uri import BENCHMARK_URI_RE, resolve_uri_protocol
 
 T = TypeVar("T")
 

--- a/compiler_gym/datasets/uri.py
+++ b/compiler_gym/datasets/uri.py
@@ -1,0 +1,30 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""This module contains utility code for working with URIs."""
+import re
+
+# Regular expression that matches the full two-part URI prefix of a dataset:
+#     {{protocol}}://{{dataset}}
+#
+# An optional trailing slash is permitted.
+#
+# Example matches: "benchmark://foo-v0", "generator://bar-v0/".
+DATASET_NAME_PATTERN = r"(?P<dataset>(?P<dataset_protocol>[a-zA-z0-9-_]+)://(?P<dataset_name>[a-zA-z0-9-_]+-v(?P<dataset_version>[0-9]+)))/?"
+DATASET_NAME_RE = re.compile(DATASET_NAME_PATTERN)
+
+# Regular expression that matches the full three-part format of a benchmark URI:
+#     {{protocol}}://{{dataset}}/{{id}}
+#
+# Example matches: "benchmark://foo-v0/foo" or "generator://bar-v1/foo/bar.txt".
+BENCHMARK_URI_PATTERN = r"(?P<dataset>(?P<dataset_protocol>[a-zA-z0-9-_]+)://(?P<dataset_name>[a-zA-z0-9-_]+-v(?P<dataset_version>[0-9]+)))/(?P<benchmark_name>[^\s]+)$"
+BENCHMARK_URI_RE = re.compile(BENCHMARK_URI_PATTERN)
+
+
+def resolve_uri_protocol(uri: str) -> str:
+    """Require that the URI has a protocol by applying a default "benchmark"
+    protocol if none is set."""
+    if "://" not in uri:
+        return f"benchmark://{uri}"
+    return uri

--- a/compiler_gym/envs/compiler_env.py
+++ b/compiler_gym/envs/compiler_env.py
@@ -48,7 +48,8 @@ from compiler_gym.service.proto import (
 from compiler_gym.spaces import DefaultRewardFromObservation, NamedDiscrete, Reward
 from compiler_gym.util.debug_util import get_logging_level
 from compiler_gym.util.timer import Timer
-from compiler_gym.validation_result import ValidationError, ValidationResult
+from compiler_gym.validation_error import ValidationError
+from compiler_gym.validation_result import ValidationResult
 from compiler_gym.views import ObservationSpaceSpec, ObservationView, RewardView
 
 # Type hints.

--- a/compiler_gym/envs/llvm/legacy_datasets.py
+++ b/compiler_gym/envs/llvm/legacy_datasets.py
@@ -27,7 +27,7 @@ from compiler_gym.util import thread_pool
 from compiler_gym.util.download import download
 from compiler_gym.util.runfiles_path import cache_path, site_data_path
 from compiler_gym.util.timer import Timer
-from compiler_gym.validation_result import ValidationError
+from compiler_gym.validation_error import ValidationError
 
 _CBENCH_DATA_URL = (
     "https://dl.fbaipublicfiles.com/compiler_gym/cBench-v0-runtime-data.tar.bz2"

--- a/compiler_gym/envs/llvm/llvm_env.py
+++ b/compiler_gym/envs/llvm/llvm_env.py
@@ -32,7 +32,7 @@ from compiler_gym.third_party.inst2vec import Inst2vecEncoder
 from compiler_gym.third_party.llvm import download_llvm_files
 from compiler_gym.third_party.llvm.instcount import INST_COUNT_FEATURE_NAMES
 from compiler_gym.util.runfiles_path import runfiles_path, site_data_path
-from compiler_gym.validation_result import ValidationError
+from compiler_gym.validation_error import ValidationError
 
 _ACTIONS_LIST = Path(
     runfiles_path("compiler_gym/envs/llvm/service/passes/actions_list.txt")

--- a/compiler_gym/leaderboard/llvm_instcount.py
+++ b/compiler_gym/leaderboard/llvm_instcount.py
@@ -115,12 +115,8 @@ class _EvalPolicyWorker(Thread):
                 ), "Policy changed environment reward space"
 
                 # Override walltime in the generated state.
-                state = CompilerEnvState(
-                    benchmark=self.env.state.benchmark,
-                    reward=self.env.state.reward,
-                    walltime=timer.time,
-                    commandline=self.env.state.commandline,
-                )
+                state = self.env.state.copy()
+                state.walltime = timer.time
                 print(state.to_csv(), file=logfile, flush=True)
                 self.states.append(state)
 

--- a/compiler_gym/requirements.txt
+++ b/compiler_gym/requirements.txt
@@ -8,5 +8,6 @@ humanize>=2.6.0
 networkx==2.5
 numpy>=1.19.3
 protobuf==3.13.0
+pydantic>=1.8.0
 requests>=2.24.0
 tabulate==0.8.7

--- a/compiler_gym/validation_error.py
+++ b/compiler_gym/validation_error.py
@@ -1,0 +1,41 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""This module defines the validation error` tuple."""
+from typing import Any, Dict, NamedTuple
+
+
+class ValidationError(NamedTuple):
+    """A ValidationError describes an error encountered in a call to
+    :meth:`env.validate() <compiler_gym.envs.CompilerEnv.validate>`.
+    """
+
+    type: str
+    """A short name describing the type of error that occured. E.g.
+    :code:`"Runtime crash"`.
+    """
+
+    data: Dict[str, Any] = {}
+    """A JSON-serialized dictionary of data that further describes the error.
+    This data dictionary can contain any information that may be relevant for
+    diagnosing the underlying issue, such as a stack trace or an error line
+    number. There is no specified schema for this data, validators are free to
+    return whatever data they like. Setting this field is optional.
+    """
+
+    def json(self):
+        """Get the error as a JSON-serializable dictionary.
+
+        :return: A JSON dict.
+        """
+        return self._asdict()  # pylint: disable=no-member
+
+    @classmethod
+    def from_json(cls, data) -> "ValidationError":
+        """Create a validation error from JSON data.
+
+        :param data: A JSON dict.
+        :return: A validation error.
+        """
+        return cls(**data)

--- a/compiler_gym/validation_result.py
+++ b/compiler_gym/validation_result.py
@@ -4,48 +4,15 @@
 # LICENSE file in the root directory of this source tree.
 """This module defines the validation result tuple."""
 import itertools
+import json
 import re
 from collections import Counter
-from typing import Any, Dict, Iterable, List, NamedTuple
+from typing import Iterable, List, NamedTuple
 
 from compiler_gym.compiler_env_state import CompilerEnvState
 from compiler_gym.util.shell_format import plural
 from compiler_gym.util.truncate import truncate
-
-
-class ValidationError(NamedTuple):
-    """A ValidationError describes an error encountered in a call to
-    :meth:`env.validate() <compiler_gym.envs.CompilerEnv.validate>`.
-    """
-
-    type: str
-    """A short name describing the type of error that occured. E.g.
-    :code:`"Runtime crash"`.
-    """
-
-    data: Dict[str, Any] = {}
-    """A JSON-serialized dictionary of data that further describes the error.
-    This data dictionary can contain any information that may be relevant for
-    diagnosing the underlying issue, such as a stack trace or an error line
-    number. There is no specified schema for this data, validators are free to
-    return whatever data they like. Setting this field is optional.
-    """
-
-    def json(self):
-        """Get the error as a JSON-serializable dictionary.
-
-        :return: A JSON dict.
-        """
-        return self._asdict()  # pylint: disable=no-member
-
-    @classmethod
-    def from_json(cls, data) -> "ValidationResult":
-        """Create a validation error from JSON data.
-
-        :param data: A JSON dict.
-        :return: A validation error.
-        """
-        return cls(**data)
+from compiler_gym.validation_error import ValidationError
 
 
 class ValidationResult(NamedTuple):
@@ -168,7 +135,7 @@ class ValidationResult(NamedTuple):
         :param data: A JSON dict.
         :return: A validation result instance.
         """
-        data["state"] = CompilerEnvState.from_json(data["state"])
+        data["state"] = CompilerEnvState(**json.loads(data["state"]))
         data["errors"] = [ValidationError.from_json(e) for e in data["errors"]]
         return cls(**data)
 

--- a/tests/datasets/benchmark_test.py
+++ b/tests/datasets/benchmark_test.py
@@ -8,14 +8,10 @@ from pathlib import Path
 
 import pytest
 
-from compiler_gym.datasets.benchmark import (
-    BENCHMARK_URI_RE,
-    DATASET_NAME_RE,
-    Benchmark,
-    BenchmarkSource,
-)
+from compiler_gym.datasets import Benchmark, BenchmarkSource
+from compiler_gym.datasets.uri import BENCHMARK_URI_RE, DATASET_NAME_RE
 from compiler_gym.service.proto import Benchmark as BenchmarkProto
-from compiler_gym.validation_result import ValidationError
+from compiler_gym.validation_error import ValidationError
 from tests.test_main import main
 
 pytest_plugins = ["tests.pytest_plugins.common"]

--- a/tests/llvm/benchmark_semantics_validation_test.py
+++ b/tests/llvm/benchmark_semantics_validation_test.py
@@ -74,7 +74,7 @@ def test_validate_state_invalid_reward():
     assert result.reward_validated
     assert result.reward_validation_failed
     assert (
-        str(result) == "❌  cBench-v1/crc32  Expected reward 1 but received reward 0.0"
+        str(result) == "❌  cBench-v1/crc32  Expected reward 1.0 but received reward 0.0"
     )
 
 

--- a/tests/validation_result_test.py
+++ b/tests/validation_result_test.py
@@ -45,7 +45,7 @@ def test_validation_error_json():
 def test_validation_result_json():
     result = ValidationResult(
         state=CompilerEnvState(
-            benchmark="benchmark://example/test",
+            benchmark="benchmark://example-v0/test",
             commandline="test",
             walltime=1,
         ),
@@ -64,7 +64,7 @@ def test_validation_result_json():
 def test_validation_result_equality_different_states():
     a = ValidationResult(
         state=CompilerEnvState(
-            benchmark="benchmark://example/test/a",
+            benchmark="benchmark://example-v0/test/a",
             commandline="test",
             walltime=1,
         ),
@@ -72,7 +72,7 @@ def test_validation_result_equality_different_states():
     )
     b = ValidationResult(
         state=CompilerEnvState(
-            benchmark="benchmark://example/test/b",
+            benchmark="benchmark://example-v0/test/b",
             commandline="test",
             walltime=1,
         ),
@@ -84,7 +84,7 @@ def test_validation_result_equality_different_states():
 def test_validation_result_equality_different_walltimes():
     a = ValidationResult(
         state=CompilerEnvState(
-            benchmark="benchmark://example/test",
+            benchmark="benchmark://example-v0/test",
             commandline="test",
             walltime=1,
         ),
@@ -92,7 +92,7 @@ def test_validation_result_equality_different_walltimes():
     )
     b = ValidationResult(
         state=CompilerEnvState(
-            benchmark="benchmark://example/test",
+            benchmark="benchmark://example-v0/test",
             commandline="test",
             walltime=10,
         ),
@@ -104,7 +104,7 @@ def test_validation_result_equality_different_walltimes():
 def test_validation_result_equality_different_errors_order():
     a = ValidationResult(
         state=CompilerEnvState(
-            benchmark="benchmark://example/test",
+            benchmark="benchmark://example-v0/test",
             commandline="test",
             walltime=1,
         ),
@@ -122,7 +122,7 @@ def test_validation_result_equality_different_errors_order():
     )
     b = ValidationResult(
         state=CompilerEnvState(
-            benchmark="benchmark://example/test",
+            benchmark="benchmark://example-v0/test",
             commandline="test",
             walltime=1,
         ),
@@ -150,7 +150,7 @@ def test_validation_result_join_no_inputs():
 def test_validation_result_join_one_input():
     result = ValidationResult(
         state=CompilerEnvState(
-            benchmark="benchmark://example/test",
+            benchmark="benchmark://example-v0/test",
             commandline="test",
             walltime=1,
         ),
@@ -170,7 +170,7 @@ def test_validation_result_join_one_input():
 def test_validation_result_join_two_inputs_different_errors():
     a = ValidationResult(
         state=CompilerEnvState(
-            benchmark="benchmark://example/test",
+            benchmark="benchmark://example-v0/test",
             commandline="test",
             walltime=1,
         ),
@@ -184,7 +184,7 @@ def test_validation_result_join_two_inputs_different_errors():
     )
     b = ValidationResult(
         state=CompilerEnvState(
-            benchmark="benchmark://example/test",
+            benchmark="benchmark://example-v0/test",
             commandline="test",
             walltime=10,
         ),
@@ -200,7 +200,7 @@ def test_validation_result_join_two_inputs_different_errors():
     c = ValidationResult.join([a, b])
     assert c == ValidationResult(
         state=CompilerEnvState(
-            benchmark="benchmark://example/test",
+            benchmark="benchmark://example-v0/test",
             commandline="test",
             walltime=10,
         ),


### PR DESCRIPTION
This changes the CompilerEnvState class to be a subclass of
[pydantic.BaseModel](https://pydantic-docs.helpmanual.io/usage/models/#basic-model-usage) rather than `NamedTuple`. The reasons for this are:

1) pydantic has robust APIs for parsing and serializing/deserializing
from various data types.

2) pydantic makes it easy to add validation logic to fields. For
CompilerEnvState, the constructor will now validate that the given URI
matches the expected regex, and that the walltime is nonnegative.

Issue #216.