### PR TITLE
[llvm] Add a load test for download_llvm_files().

### DIFF
--- a/compiler_gym/third_party/llvm/__init__.py
+++ b/compiler_gym/third_party/llvm/__init__.py
@@ -34,22 +34,20 @@ _LLVM_DOWNLOAD_LOCK = Lock()
 _LLVM_DOWNLOADED = False
 
 
-def _download_llvm_files(unpacked_location: Path) -> Path:
+def _download_llvm_files(destination: Path) -> Path:
     """Download and unpack the LLVM data pack."""
     # Tidy up an incomplete unpack.
-    shutil.rmtree(unpacked_location, ignore_errors=True)
+    shutil.rmtree(destination, ignore_errors=True)
 
     tar_contents = io.BytesIO(download(_LLVM_URL, sha256=_LLVM_SHA256))
-    unpacked_location.parent.mkdir(parents=True, exist_ok=True)
+    destination.parent.mkdir(parents=True, exist_ok=True)
     with tarfile.open(fileobj=tar_contents, mode="r:bz2") as tar:
-        tar.extractall(unpacked_location)
-    assert unpacked_location.is_dir()
-    assert (unpacked_location / "LICENSE").is_file()
-    # Create the marker file to indicate that the directory is unpacked
-    # and ready to go.
-    (unpacked_location / ".unpacked").touch()
+        tar.extractall(destination)
 
-    return unpacked_location
+    assert destination.is_dir()
+    assert (destination / "LICENSE").is_file()
+
+    return destination
 
 
 def download_llvm_files() -> Path:
@@ -67,11 +65,16 @@ def download_llvm_files() -> Path:
         _LLVM_DOWNLOADED = True
         return unpacked_location
 
-    with _LLVM_DOWNLOAD_LOCK, InterProcessLock(cache_path("llvm-download.LOCK")):
+    with _LLVM_DOWNLOAD_LOCK, InterProcessLock(cache_path(".llvm-v0-install.LOCK")):
         # Now that the lock is acquired, repeat the check to see if it is
         # necessary to download the dataset.
-        if not (unpacked_location / ".unpacked").is_file():
-            _download_llvm_files(unpacked_location)
+        if (unpacked_location / ".unpacked").is_file():
+            return unpacked_location
+
+        _download_llvm_files(unpacked_location)
+        # Create the marker file to indicate that the directory is unpacked
+        # and ready to go.
+        (unpacked_location / ".unpacked").touch()
         _LLVM_DOWNLOADED = True
 
     return unpacked_location

--- a/tests/llvm/BUILD
+++ b/tests/llvm/BUILD
@@ -86,6 +86,17 @@ py_test(
 )
 
 py_test(
+    name = "download_llvm_test",
+    srcs = ["download_llvm_test.py"],
+    deps = [
+        "//compiler_gym/third_party/llvm",
+        "//compiler_gym/util",
+        "//tests:test_main",
+        "//tests/pytest_plugins:common",
+    ],
+)
+
+py_test(
     name = "fork_env_test",
     timeout = "long",
     srcs = ["fork_env_test.py"],

--- a/tests/llvm/download_llvm_test.py
+++ b/tests/llvm/download_llvm_test.py
@@ -1,0 +1,55 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+import os
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+from compiler_gym.third_party import llvm
+from compiler_gym.util.runfiles_path import site_data_path
+from tests.test_main import main
+
+pytest_plugins = ["tests.pytest_plugins.common"]
+
+
+def test_download_llvm_threaded_load_test(temporary_environ, tmpwd: Path, mocker):
+    """A load test for download_llvm_files() that checks that redundant
+    downloads are not performed when multiple simultaneous calls to
+    download_llvm_files() are issued.
+    """
+    mocker.spy(llvm, "_download_llvm_files")
+    mocker.spy(llvm, "download")
+
+    # Force the LLVM download function to run.
+    llvm._LLVM_DOWNLOADED = False
+
+    # Force a temporary new site data path and sanity check it.
+    temporary_environ["COMPILER_GYM_SITE_DATA"] = str(tmpwd)
+    assert str(site_data_path(".")).endswith(str(tmpwd))
+
+    # Perform a bunch of concurrent calls to download_llvm_files().
+    with ThreadPoolExecutor() as executor:
+        futures = [executor.submit(llvm.download_llvm_files) for _ in range(100)]
+        for future in futures:
+            future.result()
+
+    # For debugging in case of error.
+    print("Downloads:", llvm._download_llvm_files.call_count)  # pylint: disable
+    for root, _, filenames in os.walk(tmpwd):
+        print(root)
+        for filename in filenames:
+            print(Path(root) / filename)
+
+    # Check that the files were unpacked.
+    assert (tmpwd / "llvm-v0" / "LICENSE").is_file()
+    assert (tmpwd / "llvm-v0" / "bin" / "clang").is_file()
+
+    # Check that the underlying download implementation was only called a single
+    # time.
+    assert llvm._download_llvm_files.call_count == 1  # pylint: disable
+    assert llvm.download.call_count == 1
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/pytest_plugins/BUILD
+++ b/tests/pytest_plugins/BUILD
@@ -26,6 +26,9 @@ py_library(
     name = "common",
     testonly = 1,
     srcs = ["common.py"],
+    deps = [
+        "//compiler_gym/util",
+    ],
 )
 
 py_library(

--- a/tests/pytest_plugins/common.py
+++ b/tests/pytest_plugins/common.py
@@ -50,7 +50,7 @@ def temporary_environ():
     """A fixture that allows you to modify os.environ without affecting other tests."""
     old_env = os.environ.copy()
     try:
-        yield
+        yield os.environ
     finally:
         os.environ.clear()
         os.environ.update(old_env)

--- a/tests/pytest_plugins/common.py
+++ b/tests/pytest_plugins/common.py
@@ -12,6 +12,8 @@ from typing import List
 import pytest
 from absl import flags as absl_flags
 
+from compiler_gym.util.runfiles_path import transient_cache_path
+
 FLAGS = absl_flags.FLAGS
 
 # Decorator to skip a test in the CI environment.
@@ -36,7 +38,9 @@ bazel_only = pytest.mark.skipif(
 @pytest.fixture(scope="function")
 def tmpwd() -> Path:
     """A fixture that creates a temporary directory, changes to it, and yields the path."""
-    with tempfile.TemporaryDirectory(prefix="compiler_gym-test-") as d:
+    tmpdir_root = transient_cache_path("tests")
+    tmpdir_root.mkdir(exist_ok=True, parents=True)
+    with tempfile.TemporaryDirectory(dir=tmpdir_root, prefix="tmpwd-") as d:
         pwd = os.getcwd()
         try:
             os.chdir(d)


### PR DESCRIPTION
This adds a load test for download_llvm_files() that checks that
redundant downloads are not performed when multiple simultaneous calls
to download_llvm_files() are issued.
