### PR TITLE
Relax the pip dependency versions.

### DIFF
--- a/compiler_gym/requirements.txt
+++ b/compiler_gym/requirements.txt
@@ -1,13 +1,13 @@
 absl-py>=0.10.0
 deprecated>=1.2.12
-fasteners==0.15
+fasteners>=0.15
 # Version should be kept in step with @com_github_grpc_grpc in WORKSPACE.
 grpcio>=1.36.0
 gym>=0.18.0
 humanize>=2.6.0
-networkx==2.5
+networkx>=2.5
 numpy>=1.19.3
-protobuf==3.13.0
+protobuf>=3.13.0
 pydantic>=1.8.0
 requests>=2.24.0
-tabulate==0.8.7
+tabulate>=0.8.7


### PR DESCRIPTION
Let's not be overbearing in requiring a specific version of python
dependencies. We may have to revisit this over time as breaking
changes are introduced in these dependencies.