### PR TITLE
Make CompilerEnv.observation_space a gym.Space.

### DIFF
--- a/compiler_gym/bin/manual_env.py
+++ b/compiler_gym/bin/manual_env.py
@@ -411,7 +411,7 @@ The 'tutorial' command will give a step by step guide."""
 
             if self.env.observation_space and observation is not None:
                 print(
-                    f"Observation: {self.env.observation_space.to_string(observation)}"
+                    f"Observation: {self.env.observation_space_spec.to_string(observation)}"
                 )
 
             self.set_prompt()
@@ -486,7 +486,7 @@ The 'tutorial' command will give a step by step guide."""
                 # Print the observation, if available.
                 if self.env.observation_space and observation is not None:
                     print(
-                        f"Observation: {self.env.observation_space.to_string(observation)}"
+                        f"Observation: {self.env.observation_space_spec.to_string(observation)}"
                     )
 
                 # Print the reward, if available.
@@ -684,7 +684,7 @@ The 'tutorial' command will give a step by step guide."""
             return
 
         if arg == "" and self.env.observation_space:
-            arg = self.env.observation_space.id
+            arg = self.env.observation_space_spec.id
 
         if self.observations.count(arg):
             with Timer() as timer:

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -145,9 +145,9 @@ The observation space is described by
 The :ref:`Autophase <llvm/index:Autophase>` observation space is a 56-dimension
 vector of integers:
 
-    >>> env.observation_space.space.shape
+    >>> env.observation_space.shape
     (56,)
-    >>> env.observation_space.space.dtype
+    >>> env.observation_space.dtype
     dtype('int64')
 
 The upper and lower bounds of the reward signal are described by

--- a/examples/getting-started.ipynb
+++ b/examples/getting-started.ipynb
@@ -238,7 +238,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "env.observation_space.space.shape"
+    "env.observation_space.shape"
    ]
   },
   {
@@ -247,7 +247,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "env.observation_space.space.dtype"
+    "env.observation_space.dtype"
    ]
   },
   {

--- a/examples/random_walk.py
+++ b/examples/random_walk.py
@@ -56,7 +56,7 @@ def run_random_walk(env: CompilerEnv, step_count: int) -> None:
             rewards.append(reward)
             actions.append(env.action_space.names[action_index])
             print(f"Reward:       {reward}")
-            if env._default_observation:
+            if env.observation_space:
                 print(f"Observation:\n{observation}")
             print(f"Step time:    {step_time}")
             if done:

--- a/tests/llvm/BUILD
+++ b/tests/llvm/BUILD
@@ -131,6 +131,16 @@ py_test(
 )
 
 py_test(
+    name = "gym_interface_compatability",
+    timeout = "short",
+    srcs = ["gym_interface_compatability.py"],
+    deps = [
+        "//compiler_gym",
+        "//tests:test_main",
+    ],
+)
+
+py_test(
     name = "llvm_benchmarks_test",
     srcs = ["llvm_benchmarks_test.py"],
     deps = [

--- a/tests/llvm/gym_interface_compatability.py
+++ b/tests/llvm/gym_interface_compatability.py
@@ -1,0 +1,81 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Test that LlvmEnv is compatible with OpenAI gym interface."""
+import gym
+import pytest
+
+import compiler_gym  # noqa Register Environments
+from compiler_gym.envs import CompilerEnv
+from tests.test_main import main
+
+
+@pytest.fixture(scope="function")
+def env() -> CompilerEnv:
+    env = gym.make("llvm-autophase-ic-v0")
+    try:
+        yield env
+    finally:
+        env.close()
+
+
+def test_type_classes(env: CompilerEnv):
+    assert isinstance(env, gym.Env)
+    assert isinstance(env, CompilerEnv)
+    assert isinstance(env.unwrapped, CompilerEnv)
+    assert isinstance(env.action_space, gym.Space)
+    assert isinstance(env.observation_space, gym.Space)
+    assert isinstance(env.reward_range[0], float)
+    assert isinstance(env.reward_range[1], float)
+
+
+def test_optional_properties(env: CompilerEnv):
+    assert "render.modes" in env.metadata
+    assert env.spec
+
+
+def test_contextmanager(env: CompilerEnv, mocker):
+    mocker.spy(env, "close")
+    assert env.close.call_count == 0
+    with env:
+        pass
+    assert env.close.call_count == 1
+
+
+def test_contextmanager_gym_make(mocker):
+    with gym.make("llvm-v0") as env:
+        mocker.spy(env, "close")
+        assert env.close.call_count == 0
+        with env:
+            pass
+        assert env.close.call_count == 1
+
+
+def test_observation_wrapper(env: CompilerEnv):
+    class WrappedEnv(gym.ObservationWrapper):
+        def observation(self, observation):
+            return "Hello"
+
+    wrapped = WrappedEnv(env)
+    observation = wrapped.reset()
+    assert observation == "Hello"
+
+    observation, _, _, _ = wrapped.step(0)
+    assert observation == "Hello"
+
+
+def test_reward_wrapper(env: CompilerEnv):
+    class WrappedEnv(gym.RewardWrapper):
+        def reward(self, reward):
+            return 1
+
+    wrapped = WrappedEnv(env)
+    wrapped.reset()
+
+    _, reward, _, _ = wrapped.step(0)
+    assert reward == 1
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/llvm/llvm_env_test.py
+++ b/tests/llvm/llvm_env_test.py
@@ -167,7 +167,7 @@ def test_gym_make_kwargs():
         "llvm-v0", observation_space="Autophase", reward_space="IrInstructionCount"
     )
     try:
-        assert env.observation_space.id == "Autophase"
+        assert env.observation_space_spec.id == "Autophase"
         assert env.reward_space.id == "IrInstructionCount"
     finally:
         env.close()

--- a/tests/llvm/observation_spaces_test.py
+++ b/tests/llvm/observation_spaces_test.py
@@ -22,15 +22,16 @@ pytest_plugins = ["tests.pytest_plugins.llvm"]
 
 def test_default_observation_space(env: LlvmEnv):
     env.observation_space = "Autophase"
-    assert env.observation_space.id == "Autophase"
+    assert env.observation_space.shape == (56,)
+    assert env.observation_space_spec.id == "Autophase"
 
     env.observation_space = None
     assert env.observation_space is None
+    assert env.observation_space_spec is None
 
     invalid = "invalid value"
-    with pytest.raises(LookupError) as ctx:
+    with pytest.raises(LookupError, match=f"Observation space not found: {invalid}"):
         env.observation_space = invalid
-    assert str(ctx.value) == f"Observation space not found: {invalid}"
 
 
 def test_observation_spaces(env: LlvmEnv):


### PR DESCRIPTION
This changes the type of observation_space from ObservationSpaceSpec
to gym.Space. This is to maintain compatibility with the gym
interface, which requires that the observation_space is a Space. The
ObservationSpaceSpec is now available at
CompilerEnv.observation_space_spec.

Fixes #225.
