### PR TITLE
[benchmarks] Add example C++/Python micro-benchmarks.

### DIFF
--- a/benchmarks/BUILD
+++ b/benchmarks/BUILD
@@ -10,6 +10,7 @@ py_test(
     shard_count = 8,
     deps = [
         "//compiler_gym",
+        "//examples/example_compiler_gym_service",
         "//tests:test_main",
         "//tests/pytest_plugins:llvm",
     ],

--- a/benchmarks/bench_test.py
+++ b/benchmarks/bench_test.py
@@ -4,8 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 """Microbenchmarks for CompilerGym environments.
 
-To run these benchmarks within bazel, compile with optimiztions and stream the
-test output:
+To run these benchmarks an optimized build using bazel:
 
     $ bazel test -c opt --test_output=streamed //benchmarks:bench_test
 
@@ -14,17 +13,33 @@ A record of the benchmark results is stored in
 multiple runs using:
 
     $ pytest-benchmark compare --group-by=name --sort=fullname \
-        /tmp/compiler_gym/pytest_benchmark/*_bench_test.json
+        /tmp/compiler_gym/pytest_benchmark/*/*_bench_test.json
 """
-# pylint: disable=redefined-outer-name
 import gym
 import pytest
 
+import examples.example_compiler_gym_service as dummy
 from compiler_gym.envs import CompilerEnv, LlvmEnv, llvm
 from compiler_gym.service import CompilerGymServiceConnection
+from tests.pytest_plugins.llvm import OBSERVATION_SPACE_NAMES, REWARD_SPACE_NAMES
 from tests.test_main import main
 
-pytest_plugins = ["tests.pytest_plugins.llvm"]
+
+@pytest.fixture(
+    params=["llvm-v0", "example-cc-v0", "example-py-v0"],
+    ids=["llvm", "dummy-cc", "dummy-py"],
+)
+def env_id(request) -> str:
+    yield request.param
+
+
+@pytest.fixture(
+    params=["llvm-v0", "example-cc-v0", "example-py-v0"],
+    ids=["llvm", "dummy-cc", "dummy-py"],
+)
+def env(request) -> CompilerEnv:
+    yield request.param
+
 
 # Redefine this fixture since running all of the benchmarks in cBench would
 # take too long, but we do want to use at least one small and one large
@@ -41,57 +56,152 @@ def benchmark_name(request) -> str:
     yield request.param
 
 
-@pytest.fixture(params=["cBench-v1/crc32"], ids=["fast_benchmark"])
-def fast_benchmark_name(request) -> str:
-    yield request.param
+# @pytest.fixture(params=["cBench-v1/crc32"], ids=["fast_benchmark"])
+# def fast_benchmark_name(request) -> str:
+#     yield request.param
 
 
-@pytest.fixture(params=["-globaldce", "-gvn"], ids=["fast_action", "slow_action"])
-def action_name(request) -> str:
-    yield request.param
+# @pytest.fixture(params=["-globaldce", "-gvn"], ids=["fast_action", "slow_action"])
+# def action_name(request) -> str:
+#     yield request.param
 
 
-def test_make_local(benchmark):
-    benchmark(lambda: gym.make("llvm-v0").close())
+@pytest.mark.parametrize(
+    "env_id",
+    ["llvm-v0", "example-cc-v0", "example-py-v0"],
+    ids=["llvm", "dummy-cc", "dummy-py"],
+)
+def test_make_local(benchmark, env_id):
+    benchmark(lambda: gym.make(env_id).close())
 
 
-def test_make_service(benchmark):
-    service = CompilerGymServiceConnection(llvm.LLVM_SERVICE_BINARY)
+@pytest.mark.parametrize(
+    "args",
+    [
+        (llvm.LLVM_SERVICE_BINARY, LlvmEnv),
+        (dummy.EXAMPLE_CC_SERVICE_BINARY, CompilerEnv),
+        (dummy.EXAMPLE_PY_SERVICE_BINARY, CompilerEnv),
+    ],
+    ids=["llvm", "dummy-cc", "dummy-py"],
+)
+def test_make_service(benchmark, args):
+    service_binary, env_class = args
+    service = CompilerGymServiceConnection(service_binary)
     try:
-        benchmark(lambda: LlvmEnv(service=service.connection.url).close())
+        benchmark(lambda: env_class(service=service.connection.url).close())
     finally:
         service.close()
 
 
-def test_reset(benchmark, env: CompilerEnv, benchmark_name):
-    env.observation_space = "Autophase"
-    benchmark(env.reset, benchmark_name)
+@pytest.mark.parametrize(
+    "make_env",
+    [
+        lambda: gym.make("llvm-autophase-ic-v0", benchmark="cBench-v1/crc32"),
+        lambda: gym.make("llvm-autophase-ic-v0", benchmark="cBench-v1/jpeg-d"),
+        lambda: gym.make("example-cc-v0"),
+        lambda: gym.make("example-py-v0"),
+    ],
+    ids=["llvm;fast-benchmark", "llvm;slow-benchmark", "dummy-cc", "dummy-py"],
+)
+def test_reset(benchmark, make_env: CompilerEnv):
+    with make_env() as env:
+        benchmark(env.reset)
 
 
-def test_step(benchmark, env: CompilerEnv, benchmark_name, action_name):
-    env.observation_space = "Autophase"
-    env.reward_space = "IrInstructionCount"
+@pytest.mark.parametrize(
+    "args",
+    [
+        (
+            lambda: gym.make("llvm-autophase-ic-v0", benchmark="cBench-v1/crc32"),
+            "-globaldce",
+        ),
+        (lambda: gym.make("llvm-autophase-ic-v0", benchmark="cBench-v1/crc32"), "-gvn"),
+        (
+            lambda: gym.make("llvm-autophase-ic-v0", benchmark="cBench-v1/jpeg-d"),
+            "-globaldce",
+        ),
+        (
+            lambda: gym.make("llvm-autophase-ic-v0", benchmark="cBench-v1/jpeg-d"),
+            "-gvn",
+        ),
+        (lambda: gym.make("example-cc-v0"), "a"),
+        (lambda: gym.make("example-py-v0"), "a"),
+    ],
+    ids=[
+        "llvm;fast-benchmark;fast-action",
+        "llvm;fast-benchmark;slow-action",
+        "llvm;slow-benchmark;fast-action",
+        "llvm;slow-benchmark;slow-action",
+        "dummy-cc",
+        "dummy-py",
+    ],
+)
+def test_step(benchmark, args):
+    make_env, action_name = args
+    with make_env() as env:
+        env.reset()
+        action = env.action_space[action_name]
+        benchmark(env.step, action)
 
-    env.reset(benchmark_name)
-    action = env.action_space.flags.index(action_name)
-    benchmark(env.step, action)
+
+_args = dict(
+    {
+        f"llvm;{obs}": (lambda: gym.make("llvm-v0", benchmark="cBench-v1/qsort"), obs)
+        for obs in OBSERVATION_SPACE_NAMES
+    },
+    **{
+        "dummy-cc": (lambda: gym.make("example-cc-v0"), "ir"),
+        "dummy-py": (lambda: gym.make("example-py-v0"), "features"),
+    },
+)
 
 
-def test_observation(
-    benchmark, env: CompilerEnv, fast_benchmark_name, observation_space
-):
-    env.reset(fast_benchmark_name)
-    benchmark(lambda: env.observation[observation_space])
+@pytest.mark.parametrize("args", _args.values(), ids=_args.keys())
+def test_observation(benchmark, args):
+    make_env, observation_space = args
+    with make_env() as env:
+        env.reset()
+        benchmark(lambda: env.observation[observation_space])
 
 
-def test_reward(benchmark, env: CompilerEnv, benchmark_name, reward_space):
-    env.reset(benchmark_name)
-    benchmark(lambda: env.reward[reward_space])
+_args = dict(
+    {
+        f"llvm;{reward}": (
+            lambda: gym.make("llvm-v0", benchmark="cBench-v1/qsort"),
+            reward,
+        )
+        for reward in REWARD_SPACE_NAMES
+    },
+    **{
+        "dummy-cc": (lambda: gym.make("example-cc-v0"), "runtime"),
+        "dummy-py": (lambda: gym.make("example-py-v0"), "runtime"),
+    },
+)
 
 
-def test_fork(benchmark, env: CompilerEnv, benchmark_name):
-    env.reset(benchmark_name)
-    benchmark(lambda: env.fork().close())
+@pytest.mark.parametrize("args", _args.values(), ids=_args.keys())
+def test_reward(benchmark, args):
+    make_env, reward_space = args
+    with make_env() as env:
+        env.reset()
+        benchmark(lambda: env.reward[reward_space])
+
+
+@pytest.mark.parametrize(
+    "make_env",
+    [
+        lambda: gym.make("llvm-autophase-ic-v0", benchmark="cBench-v1/crc32"),
+        lambda: gym.make("llvm-autophase-ic-v0", benchmark="cBench-v1/jpeg-d"),
+        # TODO: Example service does not yet support fork() operator.
+        # lambda: gym.make("example-cc-v0"),
+        # lambda: gym.make("example-py-v0"),
+    ],
+    ids=["llvm;fast-benchmark", "llvm;slow-benchmark"],
+)
+def test_fork(benchmark, make_env):
+    with make_env() as env:
+        env.reset()
+        benchmark(lambda: env.fork().close())
 
 
 if __name__ == "__main__":
@@ -99,6 +209,7 @@ if __name__ == "__main__":
         extra_pytest_args=[
             "--benchmark-storage=/tmp/compiler_gym/pytest_benchmark",
             "--benchmark-save=bench_test",
+            "--benchmark-sort=name",
             "-x",
         ],
         debug_level=0,

--- a/examples/example_compiler_gym_service/BUILD
+++ b/examples/example_compiler_gym_service/BUILD
@@ -11,6 +11,7 @@ py_library(
         "//examples/example_compiler_gym_service/service_cc:compiler_gym-example-service-cc",
         "//examples/example_compiler_gym_service/service_py:compiler_gym-example-service-py",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         "//compiler_gym/util",
     ],

--- a/examples/example_compiler_gym_service/__init__.py
+++ b/examples/example_compiler_gym_service/__init__.py
@@ -3,9 +3,19 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 """This module demonstrates how to """
+from pathlib import Path
+
 from compiler_gym.spaces import Reward
 from compiler_gym.util.registration import register
 from compiler_gym.util.runfiles_path import runfiles_path
+
+EXAMPLE_CC_SERVICE_BINARY: Path = runfiles_path(
+    "examples/example_compiler_gym_service/service_cc/compiler_gym-example-service-cc"
+)
+
+EXAMPLE_PY_SERVICE_BINARY: Path = runfiles_path(
+    "examples/example_compiler_gym_service/service_py/compiler_gym-example-service-py"
+)
 
 
 class RuntimeReward(Reward):
@@ -46,9 +56,7 @@ register(
     id="example-cc-v0",
     entry_point="compiler_gym.envs:CompilerEnv",
     kwargs={
-        "service": runfiles_path(
-            "examples/example_compiler_gym_service/service_cc/compiler_gym-example-service-cc"
-        ),
+        "service": EXAMPLE_CC_SERVICE_BINARY,
         "rewards": [RuntimeReward()],
     },
 )
@@ -57,9 +65,7 @@ register(
     id="example-py-v0",
     entry_point="compiler_gym.envs:CompilerEnv",
     kwargs={
-        "service": runfiles_path(
-            "examples/example_compiler_gym_service/service_py/compiler_gym-example-service-py"
-        ),
+        "service": EXAMPLE_PY_SERVICE_BINARY,
         "rewards": [RuntimeReward()],
     },
 )

--- a/tests/pytest_plugins/llvm.py
+++ b/tests/pytest_plugins/llvm.py
@@ -38,10 +38,9 @@ if bool(os.environ.get("CI")):
         b for b in BENCHMARK_NAMES if b != "benchmark://cBench-v1/ghostscript"
     ]
 
-_env = gym.make("llvm-v0")
-OBSERVATION_SPACE_NAMES = sorted(_env.observation.spaces.keys())
-REWARD_SPACE_NAMES = sorted(_env.reward.spaces.keys())
-_env.close()
+with gym.make("llvm-v0") as env:
+    OBSERVATION_SPACE_NAMES = sorted(env.observation.spaces.keys())
+    REWARD_SPACE_NAMES = sorted(env.reward.spaces.keys())
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
This extends the micro-benchmark script to record and report runtimes
for operations on the example gym service implementations in C++ and
Python. The idea is that this provides a useful reference when
evaluating the measurements of other environments. Since the example
services do no compilation, the benchmark performances are close to
a roofline.

Example output:

```
$ bazel test -c opt --test_output=streamed //benchmarks:bench_test --test_arg=--benchmark-min-rounds=1 --test_arg=--benchmark-max-time=0.1
...
-------------------------------------------------------------------------------------------------- benchmark: 51 tests ---------------------------------------------------------------------------------------------------
Name (time in ms)                                        Min                 Max                Mean            StdDev              Median               IQR            Outliers         OPS            Rounds  Iterations
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_fork[llvm;fast-benchmark]                        4.8040 (45.74)      7.2895 (31.33)      5.3976 (45.78)    0.7821 (inf)        5.0368 (46.11)    0.7366 (inf)           1;1    185.2667 (0.02)         10           1
test_fork[llvm;slow-benchmark]                       86.6110 (824.64)    92.0431 (395.54)    89.3271 (757.70)   3.8411 (inf)       89.3271 (817.81)   5.4321 (inf)           0;0     11.1948 (0.00)          2           1
test_make_local[dummy-cc]                           110.5937 (>1000.0)  110.5937 (475.26)   110.5937 (938.08)   0.0000 (1.0)      110.5937 (>1000.0)  0.0000 (1.0)           0;0      9.0421 (0.00)          1           1
test_make_local[dummy-py]                           561.0691 (>1000.0)  561.0691 (>1000.0)  561.0691 (>1000.0)  0.0000 (1.0)      561.0691 (>1000.0)  0.0000 (1.0)           0;0      1.7823 (0.00)          1           1
test_make_local[llvm]                               114.4065 (>1000.0)  114.4065 (491.65)   114.4065 (970.43)   0.0000 (1.0)      114.4065 (>1000.0)  0.0000 (1.0)           0;0      8.7408 (0.00)          1           1
test_make_service[dummy-cc]                         202.3606 (>1000.0)  202.3606 (869.62)   202.3606 (>1000.0)  0.0000 (1.0)      202.3606 (>1000.0)  0.0000 (1.0)           0;0      4.9417 (0.00)          1           1
test_make_service[dummy-py]                         202.0134 (>1000.0)  202.0134 (868.13)   202.0134 (>1000.0)  0.0000 (1.0)      202.0134 (>1000.0)  0.0000 (1.0)           0;0      4.9502 (0.00)          1           1
test_make_service[llvm]                             202.0408 (>1000.0)  202.0408 (868.25)   202.0408 (>1000.0)  0.0000 (1.0)      202.0408 (>1000.0)  0.0000 (1.0)           0;0      4.9495 (0.00)          1           1
test_observation[dummy-cc]                            0.1161 (1.11)       0.2802 (1.20)       0.1491 (1.26)     0.0330 (inf)        0.1277 (1.17)     0.0478 (inf)          39;3  6,708.7171 (0.79)        314           1
test_observation[dummy-py]                            0.3321 (3.16)       0.4858 (2.09)       0.4207 (3.57)     0.0411 (inf)        0.4301 (3.94)     0.0598 (inf)          61;0  2,376.9078 (0.28)        246           1
test_observation[llvm;AutophaseDict]                  0.5295 (5.04)       0.8450 (3.63)       0.6042 (5.13)     0.0390 (inf)        0.5943 (5.44)     0.0084 (inf)         13;13  1,655.0383 (0.20)        125           1
test_observation[llvm;Autophase]                      0.5553 (5.29)       0.8140 (3.50)       0.5873 (4.98)     0.0557 (inf)        0.5668 (5.19)     0.0125 (inf)         14;15  1,702.5760 (0.20)        114           1
test_observation[llvm;BitcodeFile]                    0.6576 (6.26)       1.3880 (5.96)       0.9525 (8.08)     0.1085 (inf)        0.9646 (8.83)     0.0620 (inf)         10;10  1,049.8633 (0.12)         77           1
test_observation[llvm;CpuInfo]                        0.3088 (2.94)       0.6829 (2.93)       0.4056 (3.44)     0.0576 (inf)        0.3911 (3.58)     0.0117 (inf)         31;31  2,465.1972 (0.29)        159           1
test_observation[llvm;Inst2vecEmbeddingIndices]      20.5965 (196.10)    20.7034 (88.97)     20.6517 (175.17)   0.0510 (inf)       20.6515 (189.07)   0.0994 (inf)           2;0     48.4222 (0.01)          5           1
test_observation[llvm;Inst2vecPreprocessedText]      20.7928 (197.97)    21.0087 (90.28)     20.9007 (177.29)   0.1526 (inf)       20.9007 (191.35)   0.2159 (inf)           0;0     47.8452 (0.01)          2           1
test_observation[llvm;Inst2vec]                      21.3403 (203.19)    21.3403 (91.71)     21.3403 (181.01)   0.0000 (1.0)       21.3403 (195.38)   0.0000 (1.0)           0;0     46.8596 (0.01)          1           1
test_observation[llvm;InstCountDict]                  0.6148 (5.85)       0.9742 (4.19)       0.6704 (5.69)     0.0586 (inf)        0.6640 (6.08)     0.0459 (inf)           8;8  1,491.5903 (0.18)        108           1
test_observation[llvm;InstCountNormDict]              0.6278 (5.98)       0.9438 (4.06)       0.7054 (5.98)     0.0748 (inf)        0.6966 (6.38)     0.1145 (inf)          14;2  1,417.5866 (0.17)        113           1
test_observation[llvm;InstCountNorm]                  0.5899 (5.62)       0.8876 (3.81)       0.6467 (5.49)     0.0733 (inf)        0.6043 (5.53)     0.1092 (inf)          19;1  1,546.3237 (0.18)        105           1
test_observation[llvm;InstCount]                      0.5700 (5.43)       0.8901 (3.82)       0.6102 (5.18)     0.0701 (inf)        0.5824 (5.33)     0.0137 (inf)         16;19  1,638.7047 (0.19)        113           1
test_observation[llvm;IrInstructionCountO0]           0.3584 (3.41)       0.6110 (2.63)       0.3805 (3.23)     0.0329 (inf)        0.3702 (3.39)     0.0103 (inf)         19;23  2,627.8709 (0.31)        187           1
test_observation[llvm;IrInstructionCountO3]           0.3566 (3.40)       0.6392 (2.75)       0.3804 (3.23)     0.0431 (inf)        0.3676 (3.37)     0.0090 (inf)         12;24  2,628.8687 (0.31)        169           1
test_observation[llvm;IrInstructionCountOz]           0.3597 (3.42)       0.5306 (2.28)       0.3826 (3.25)     0.0262 (inf)        0.3739 (3.42)     0.0105 (inf)         23;23  2,613.6874 (0.31)        177           1
test_observation[llvm;IrInstructionCount]             0.3927 (3.74)       0.6217 (2.67)       0.4163 (3.53)     0.0361 (inf)        0.4061 (3.72)     0.0159 (inf)          7;10  2,402.2491 (0.28)        130           1
test_observation[llvm;Ir]                             0.7613 (7.25)       1.1482 (4.93)       0.8078 (6.85)     0.0805 (inf)        0.7738 (7.08)     0.0301 (inf)         10;13  1,237.9911 (0.15)         89           1
test_observation[llvm;ObjectTextSizeBytes]            9.3614 (89.13)     15.6553 (67.28)     14.0959 (119.56)   2.1991 (inf)       14.8689 (136.13)   1.6294 (inf)           1;1     70.9428 (0.01)          7           1
test_observation[llvm;ObjectTextSizeO0]               0.3566 (3.40)       0.5738 (2.47)       0.3781 (3.21)     0.0373 (inf)        0.3664 (3.35)     0.0076 (inf)         16;19  2,644.6269 (0.31)        156           1
test_observation[llvm;ObjectTextSizeO3]               0.3221 (3.07)       0.6166 (2.65)       0.3783 (3.21)     0.0355 (inf)        0.3704 (3.39)     0.0118 (inf)         20;21  2,643.1592 (0.31)        166           1
test_observation[llvm;ObjectTextSizeOz]               0.3761 (3.58)       0.6096 (2.62)       0.4033 (3.42)     0.0412 (inf)        0.3855 (3.53)     0.0119 (inf)         21;34  2,479.6897 (0.29)        164           1
test_observation[llvm;Programl]                      32.0248 (304.91)    39.3018 (168.89)    34.8076 (295.25)   3.9288 (inf)       33.0961 (303.00)   5.4578 (inf)           1;0     28.7294 (0.00)          3           1
test_reset[dummy-cc]                                  0.1805 (1.72)       0.4321 (1.86)       0.2303 (1.95)     0.0496 (inf)        0.1977 (1.81)     0.0774 (inf)          42;1  4,342.4606 (0.51)        352           1
test_reset[dummy-py]                                  0.4649 (4.43)       0.6860 (2.95)       0.5777 (4.90)     0.0408 (inf)        0.5879 (5.38)     0.0096 (inf)         28;31  1,731.0389 (0.20)        171           1
test_reset[llvm;fast-benchmark]                       2.1266 (20.25)      2.3785 (10.22)      2.2526 (19.11)    0.1782 (inf)        2.2526 (20.62)    0.2520 (inf)           0;0    443.9396 (0.05)          2           1
test_reset[llvm;slow-benchmark]                      77.2634 (735.64)    77.2634 (332.03)    77.2634 (655.37)   0.0000 (1.0)       77.2634 (707.37)   0.0000 (1.0)           0;0     12.9427 (0.00)          1           1
test_reward[dummy-cc]                                 0.1183 (1.13)       0.2387 (1.03)       0.1489 (1.26)     0.0281 (inf)        0.1317 (1.21)     0.0406 (inf)          41;2  6,717.1073 (0.79)        301           1
test_reward[dummy-py]                                 0.3001 (2.86)       0.3835 (1.65)       0.3134 (2.66)     0.0128 (inf)        0.3094 (2.83)     0.0077 (inf)         18;17  3,190.4714 (0.38)        213           1
test_reward[llvm;IrInstructionCountNorm]              0.3332 (3.17)       0.5403 (2.32)       0.4017 (3.41)     0.0539 (inf)        0.3850 (3.52)     0.0293 (inf)         22;13  2,489.4771 (0.29)         59           1
test_reward[llvm;IrInstructionCountO3]                0.3014 (2.87)       0.5600 (2.41)       0.4071 (3.45)     0.0637 (inf)        0.3886 (3.56)     0.0308 (inf)         19;19  2,456.5960 (0.29)         52           1
test_reward[llvm;IrInstructionCountOz]                0.3824 (3.64)       0.6053 (2.60)       0.4450 (3.77)     0.0515 (inf)        0.4310 (3.95)     0.0306 (inf)          12;5  2,247.1215 (0.26)         43           1
test_reward[llvm;IrInstructionCount]                  0.3744 (3.56)       0.6485 (2.79)       0.4109 (3.49)     0.0542 (inf)        0.3873 (3.55)     0.0091 (inf)         15;15  2,433.7126 (0.29)         75           1
test_reward[llvm;ObjectTextSizeBytes]                 9.3067 (88.61)     15.7944 (67.87)     14.1646 (120.15)   2.2788 (inf)       15.0950 (138.20)   1.6877 (inf)           1;1     70.5988 (0.01)          7           1
test_reward[llvm;ObjectTextSizeNorm]                  9.8552 (93.83)     15.8185 (67.98)     13.5796 (115.19)   2.2238 (inf)       14.2967 (130.89)   3.8114 (inf)           2;0     73.6399 (0.01)          8           1
test_reward[llvm;ObjectTextSizeO3]                   12.2533 (116.67)    16.1384 (69.35)     14.5087 (123.07)   1.2806 (inf)       14.9500 (136.87)   1.5278 (inf)           2;0     68.9243 (0.01)          7           1
test_reward[llvm;ObjectTextSizeOz]                    9.1199 (86.83)     15.3407 (65.92)     13.0005 (110.27)   2.6913 (inf)       14.3396 (131.28)   4.7893 (inf)           2;0     76.9203 (0.01)          7           1
test_step[dummy-cc]                                   0.1050 (1.0)        0.2327 (1.0)        0.1179 (1.0)      0.0281 (inf)        0.1092 (1.0)      0.0033 (inf)         25;39  8,482.2649 (1.0)         322           1
test_step[dummy-py]                                   0.2904 (2.77)       0.3844 (1.65)       0.3170 (2.69)     0.0148 (inf)        0.3131 (2.87)     0.0101 (inf)         32;23  3,154.6643 (0.37)        225           1
test_step[llvm;fast-benchmark;fast-action]            0.4910 (4.67)       0.7095 (3.05)       0.5682 (4.82)     0.0618 (inf)        0.5423 (4.96)     0.1120 (inf)          21;0  1,760.0245 (0.21)         43           1
test_step[llvm;fast-benchmark;slow-action]            0.7612 (7.25)       1.0620 (4.56)       0.8402 (7.13)     0.0968 (inf)        0.8085 (7.40)     0.0457 (inf)           8;8  1,190.1905 (0.14)         37           1
test_step[llvm;slow-benchmark;fast-action]           14.2512 (135.69)    20.2964 (87.22)     17.2738 (146.52)   4.2746 (inf)       17.2738 (158.15)   6.0452 (inf)           0;0     57.8912 (0.01)          2           1
test_step[llvm;slow-benchmark;slow-action]           80.5652 (767.08)    80.5652 (346.22)    80.5652 (683.38)   0.0000 (1.0)       80.5652 (737.60)   0.0000 (1.0)           0;0     12.4123 (0.00)          1           1
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```