### PR TITLE
Add automated deprecation warnings to the Dataset class.

### DIFF
--- a/compiler_gym/datasets/datasets.py
+++ b/compiler_gym/datasets/datasets.py
@@ -79,7 +79,7 @@ class Datasets(object):
     ):
         self._datasets: Dict[str, Dataset] = {d.name: d for d in datasets}
         self._visible_datasets: Set[str] = set(
-            name for name, dataset in self._datasets.items() if not dataset.hidden
+            name for name, dataset in self._datasets.items() if not dataset.deprecated
         )
 
     def datasets(self, with_deprecated: bool = False) -> Iterable[Dataset]:
@@ -95,7 +95,7 @@ class Datasets(object):
         """
         datasets = self._datasets.values()
         if not with_deprecated:
-            datasets = (d for d in datasets if not d.hidden)
+            datasets = (d for d in datasets if not d.deprecated)
         yield from sorted(datasets, key=lambda d: (d.sort_order, d.name))
 
     def __iter__(self) -> Iterable[Dataset]:
@@ -147,7 +147,7 @@ class Datasets(object):
         dataset_name = resolve_uri_protocol(key)
 
         self._datasets[dataset_name] = dataset
-        if not dataset.hidden:
+        if not dataset.deprecated:
             self._visible_datasets.add(dataset_name)
 
     def __delitem__(self, dataset: str):

--- a/compiler_gym/datasets/tar_dataset.py
+++ b/compiler_gym/datasets/tar_dataset.py
@@ -73,6 +73,8 @@ class TarDataset(FilesDataset):
         return self._installed
 
     def install(self) -> None:
+        super().install()
+
         if self.installed:
             return
 

--- a/compiler_gym/envs/llvm/datasets/__init__.py
+++ b/compiler_gym/envs/llvm/datasets/__init__.py
@@ -213,7 +213,10 @@ def get_llvm_datasets(site_data_base: Optional[Path] = None) -> Iterable[Dataset
     yield CBenchDataset(
         site_data_base=site_data_base,
         name="benchmark://cBench-v1",
-        hidden=True,
+        deprecated=(
+            "Please use 'benchmark://cbench-v1' (note the lowercase name). "
+            "The dataset is the same, only the name has changed"
+        ),
         manifest_url="https://dl.fbaipublicfiles.com/compiler_gym/llvm_bitcodes-10.0.0-cBench-v1-manifest.bz2",
         manifest_sha256="635b94eeb2784dfedb3b53fd8f84517c3b4b95d851ddb662d4c1058c72dc81e0",
         sort_order=100,

--- a/compiler_gym/envs/llvm/datasets/cbench.py
+++ b/compiler_gym/envs/llvm/datasets/cbench.py
@@ -18,7 +18,6 @@ from threading import Lock
 from typing import Callable, Dict, List, NamedTuple, Optional
 
 import fasteners
-from deprecated.sphinx import deprecated
 
 from compiler_gym.datasets import Benchmark, TarDatasetWithManifest
 from compiler_gym.third_party import llvm
@@ -506,7 +505,7 @@ class CBenchDataset(TarDatasetWithManifest):
         name="benchmark://cbench-v1",
         manifest_url="https://dl.fbaipublicfiles.com/compiler_gym/llvm_bitcodes-10.0.0-cbench-v1-manifest.bz2",
         manifest_sha256="eeffd7593aeb696a160fd22e6b0c382198a65d0918b8440253ea458cfe927741",
-        hidden=False,
+        deprecated=None,
     ):
         platform = {"darwin": "macos"}.get(sys.platform, sys.platform)
         url, sha256 = _CBENCH_TARS[platform]
@@ -527,7 +526,7 @@ class CBenchDataset(TarDatasetWithManifest):
             site_data_base=site_data_base,
             sort_order=sort_order,
             benchmark_class=CBenchBenchmark,
-            hidden=hidden,
+            deprecated=deprecated,
             validatable="Partially",
         )
 
@@ -575,15 +574,8 @@ class CBenchLegacyDataset(TarDatasetWithManifest):
             strip_prefix="cBench-v0",
             benchmark_file_suffix=".bc",
             site_data_base=site_data_base,
-            hidden=True,  # Hidden because it is deprecated.
+            deprecated="Please use 'benchmark://cbench-v1'",
         )
-
-    @deprecated(
-        version="0.1.4",
-        reason=("Dataset 'cBench-v0' is deprecated, please use 'cbench-v1'"),
-    )
-    def install(self) -> None:
-        super().install()
 
 
 # ===============================

--- a/compiler_gym/envs/llvm/datasets/csmith.py
+++ b/compiler_gym/envs/llvm/datasets/csmith.py
@@ -129,6 +129,8 @@ class CsmithDataset(Dataset):
 
     def install(self) -> None:
         """Download and build the Csmith binary."""
+        super().install()
+
         if self.installed:
             return
 

--- a/compiler_gym/envs/llvm/datasets/poj104.py
+++ b/compiler_gym/envs/llvm/datasets/poj104.py
@@ -8,8 +8,6 @@ from concurrent.futures import as_completed
 from pathlib import Path
 from typing import Optional
 
-from deprecated.sphinx import deprecated
-
 from compiler_gym.datasets import Benchmark, BenchmarkInitError, TarDatasetWithManifest
 from compiler_gym.datasets.benchmark import BenchmarkWithSource
 from compiler_gym.envs.llvm.llvm_benchmark import ClangInvocation
@@ -191,12 +189,5 @@ class POJ104LegacyDataset(TarDatasetWithManifest):
             benchmark_file_suffix=".bc",
             site_data_base=site_data_base,
             sort_order=sort_order,
-            hidden=True,
+            deprecated="Please update to benchmark://poj104-v1.",
         )
-
-    @deprecated(
-        version="0.1.8",
-        reason=("Dataset 'poj104-v0' is deprecated, please use 'poj104-v1'"),
-    )
-    def install(self) -> None:
-        super().install()

--- a/tests/datasets/dataset_test.py
+++ b/tests/datasets/dataset_test.py
@@ -60,7 +60,7 @@ def test_dataset_optional_properties():
     )
 
     assert dataset.references == {}  # Default value.
-    assert not dataset.hidden
+    assert not dataset.deprecated
     assert dataset.sort_order == 0
     assert dataset.validatable == "No"
 
@@ -73,7 +73,7 @@ def test_dataset_optional_properties_explicit_values():
         license="MIT",
         site_data_base="test",
         references={"GitHub": "https://github.com/facebookresearch/CompilerGym"},
-        hidden=True,
+        deprecated="Deprecation message",
         sort_order=10,
         validatable="Yes",
     )
@@ -81,7 +81,7 @@ def test_dataset_optional_properties_explicit_values():
     assert dataset.references == {
         "GitHub": "https://github.com/facebookresearch/CompilerGym"
     }
-    assert dataset.hidden
+    assert dataset.deprecated
     assert dataset.sort_order == 10
     assert dataset.validatable == "Yes"
 
@@ -132,6 +132,20 @@ def test_dataset_site_data_directory(tmpwd: Path):
         str(tmpwd / "test" / "benchmark" / "test-v0")
     )
     assert not dataset.site_data_path.is_dir()  # Dir is not created until needed.
+
+
+def test_dataset_deprecation_message(tmpwd: Path):
+    """Test that a deprecation warning is emitted on install()."""
+    dataset = Dataset(
+        name="benchmark://test-v0",
+        description="A test dataset",
+        license="MIT",
+        site_data_base="test",
+        deprecated="The cat sat on the mat",
+    )
+
+    with pytest.warns(DeprecationWarning, match="The cat sat on the mat"):
+        dataset.install()
 
 
 class TestDataset(Dataset):

--- a/tests/datasets/datasets_test.py
+++ b/tests/datasets/datasets_test.py
@@ -17,7 +17,7 @@ class MockDataset:
     def __init__(self, name):
         self.name = name
         self.installed = False
-        self.hidden = False
+        self.deprecated = False
         self.benchmark_values = []
         self.sort_order = 0
 
@@ -52,7 +52,7 @@ class MockBenchmark:
         self.uri = uri
 
     def __repr__(self):
-        return str(self.name)
+        return str(self.uri)
 
 
 def test_enumerate_datasets_empty():
@@ -78,20 +78,20 @@ def test_enumerate_datasets_with_custom_sort_order():
     assert list(datasets) == [db, da]
 
 
-def test_enumerate_hidden_datasets():
+def test_enumerate_deprecated_datasets():
     da = MockDataset("benchmark://a")
     db = MockDataset("benchmark://b")
     datasets = Datasets((da, db))
 
-    db.hidden = True
+    db.deprecated = True
     assert list(datasets) == [da]
     assert list(datasets.datasets(with_deprecated=True)) == [da, db]
 
 
-def test_enumerate_datasets_hidden_at_construction_time():
+def test_enumerate_datasets_deprecated_at_construction_time():
     da = MockDataset("benchmark://a")
     db = MockDataset("benchmark://b")
-    db.hidden = True
+    db.deprecated = True
     datasets = Datasets((da, db))
 
     assert list(datasets) == [da]
@@ -107,11 +107,11 @@ def test_datasets_add_dataset():
     assert list(datasets) == [da]
 
 
-def test_datasets_add_hidden_dataset():
+def test_datasets_add_deprecated_dataset():
     datasets = Datasets([])
 
     da = MockDataset("benchmark://a")
-    da.hidden = True
+    da.deprecated = True
     datasets["benchmark://foo-v0"] = da
 
     assert list(datasets) == []
@@ -213,7 +213,7 @@ def test_benchmark_uris_order():
 def test_benchmarks_iter_deprecated():
     da = MockDataset("benchmark://foo-v0")
     db = MockDataset("benchmark://bar-v0")
-    db.hidden = True
+    db.deprecated = True
     ba = MockBenchmark(uri="benchmark://foo-v0/abc")
     bb = MockBenchmark(uri="benchmark://foo-v0/123")
     bc = MockBenchmark(uri="benchmark://bar-v0/abc")

--- a/tests/llvm/datasets/cbench_test.py
+++ b/tests/llvm/datasets/cbench_test.py
@@ -68,15 +68,20 @@ def test_validate_sha_output_invalid():
 
 def test_cbench_v0_deprecation(env: LlvmEnv):
     """Test that cBench-v0 emits a deprecation warning when used."""
-    with pytest.deprecated_call(
-        match="Dataset 'cBench-v0' is deprecated, please use 'cbench-v1'"
-    ):
+    with pytest.deprecated_call(match="Please use 'benchmark://cbench-v1'"):
         env.datasets["cBench-v0"].install()
 
-    with pytest.deprecated_call(
-        match="Dataset 'cBench-v0' is deprecated, please use 'cbench-v1'"
-    ):
+    with pytest.deprecated_call(match="Please use 'benchmark://cbench-v1'"):
         env.datasets.benchmark("benchmark://cBench-v0/crc32")
+
+
+def test_cbench_v1_deprecation(env: LlvmEnv):
+    """Test that cBench-v1 emits a deprecation warning when used."""
+    with pytest.deprecated_call(match="Please use 'benchmark://cbench-v1'"):
+        env.datasets["cBench-v1"].install()
+
+    with pytest.deprecated_call(match="Please use 'benchmark://cbench-v1'"):
+        env.datasets.benchmark("benchmark://cBench-v1/crc32")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This replaces the boolean `hidden` value with a `deprecated` message,                                                                                                                                                         
which is emitted automatically on a call to `install()`.  

Issue #45. Fixes #219.