### PR TITLE
[README] Tweak example usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,12 +175,14 @@ In Python, import `compiler_gym` to use the environments:
 
 ```py
 >>> import gym
->>> import compiler_gym                     # imports the CompilerGym environments
->>> env = gym.make("llvm-autophase-ic-v0")  # starts a new environment
->>> env.benchmark = "benchmark://cbench-v1/qsort"  # select a program to compile
->>> env.reset()                             # starts a new compilation session
->>> env.render()                            # prints the IR of the program
->>> env.step(env.action_space.sample())     # applies a random optimization, updates state/reward/actions
+>>> import compiler_gym                     # import the CompilerGym environments
+>>> env = gym.make(                         # create a new environment
+...     "llvm-autophase-ic-v0"              # select the compiler optimization task
+...     benchmark="cbench-v1/qsort"         # select the program to compile
+... )
+>>> env.reset()                             # start a new compilation session
+>>> env.render()                            # print the IR of the program
+>>> env.step(env.action_space.sample())     # apply a random optimization, update state/reward/actions
 ```
 
 See the [documentation website](http://facebookresearch.github.io/CompilerGym/)


### PR DESCRIPTION
Don't use the `env.benchmark` attribute, and use active writing style.