### PR TITLE
[datasets] Add a random_benchmark() method.

### DIFF
--- a/compiler_gym/bin/manual_env.py
+++ b/compiler_gym/bin/manual_env.py
@@ -367,7 +367,7 @@ The 'tutorial' command will give a step by step guide."""
         Use '-' for a random benchmark.
         """
         if arg == "-":
-            arg = self.env.datasets.benchmark().uri
+            arg = self.env.datasets.random_benchmark().uri
             print(f"set_benchmark {arg}")
 
         try:

--- a/compiler_gym/datasets/dataset.py
+++ b/compiler_gym/datasets/dataset.py
@@ -9,6 +9,7 @@ import warnings
 from pathlib import Path
 from typing import Dict, Iterable, Optional, Union
 
+import numpy as np
 from deprecated.sphinx import deprecated as mark_deprecated
 
 from compiler_gym.datasets.benchmark import Benchmark
@@ -355,6 +356,29 @@ class Dataset(object):
             instance.
 
         :raise LookupError: If :code:`uri` is not found.
+        """
+        raise NotImplementedError("abstract class")
+
+    def random_benchmark(
+        self, random_state: Optional[np.random.Generator] = None
+    ) -> Benchmark:
+        """Select a benchmark randomly.
+
+        :param random_state: A random number generator. If not provided, a
+            default :code:`np.random.default_rng()` is used.
+
+        :return: A :class:`Benchmark <compiler_gym.datasets.Benchmark>`
+            instance.
+        """
+        random_state = random_state or np.random.default_rng()
+        return self._random_benchmark(random_state)
+
+    def _random_benchmark(self, random_state: np.random.Generator) -> Benchmark:
+        """Private implementation of the random benchmark getter.
+
+        Subclasses must implement this method so that it selects a benchmark
+        from the available benchmarks with uniform probability, using only
+        :code:`random_state` as a source of randomness.
         """
         raise NotImplementedError("abstract class")
 

--- a/compiler_gym/datasets/files_dataset.py
+++ b/compiler_gym/datasets/files_dataset.py
@@ -6,6 +6,8 @@ import os
 from pathlib import Path
 from typing import Iterable, List
 
+import numpy as np
+
 from compiler_gym.datasets.dataset import Benchmark, Dataset
 from compiler_gym.util.decorators import memoized_property
 
@@ -117,3 +119,6 @@ class FilesDataset(Dataset):
         if not abspath.is_file():
             raise LookupError(f"Benchmark not found: {uri} (file not found: {abspath})")
         return self.benchmark_class.from_file(uri, abspath)
+
+    def _random_benchmark(self, random_state: np.random.Generator) -> Benchmark:
+        return self.benchmark(random_state.choice(list(self.benchmark_uris())))

--- a/compiler_gym/envs/llvm/datasets/csmith.py
+++ b/compiler_gym/envs/llvm/datasets/csmith.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from threading import Lock
 from typing import Iterable, List
 
+import numpy as np
 from fasteners import InterProcessLock
 
 from compiler_gym.datasets import Benchmark, BenchmarkSource, Dataset
@@ -226,6 +227,10 @@ class CsmithDataset(Dataset):
 
     def benchmark(self, uri: str) -> CsmithBenchmark:
         return self.benchmark_from_seed(int(uri.split("/")[-1]))
+
+    def _random_benchmark(self, random_state: np.random.Generator) -> Benchmark:
+        seed = random_state.integers(UINT_MAX)
+        return self.benchmark_from_seed(seed)
 
     def benchmark_from_seed(self, seed: int) -> CsmithBenchmark:
         """Get a benchmark from a uint32 seed.

--- a/compiler_gym/envs/llvm/datasets/llvm_stress.py
+++ b/compiler_gym/envs/llvm/datasets/llvm_stress.py
@@ -6,6 +6,8 @@ import subprocess
 from pathlib import Path
 from typing import Iterable
 
+import numpy as np
+
 from compiler_gym.datasets import Benchmark, Dataset
 from compiler_gym.datasets.benchmark import BenchmarkInitError
 from compiler_gym.third_party import llvm
@@ -55,6 +57,10 @@ class LlvmStressDataset(Dataset):
 
     def benchmark(self, uri: str) -> Benchmark:
         return self.benchmark_from_seed(int(uri.split("/")[-1]))
+
+    def _random_benchmark(self, random_state: np.random.Generator) -> Benchmark:
+        seed = random_state.integers(UINT_MAX)
+        return self.benchmark_from_seed(seed)
 
     def benchmark_from_seed(self, seed: int) -> Benchmark:
         """Get a benchmark from a uint32 seed.

--- a/tests/datasets/files_dataset_test.py
+++ b/tests/datasets/files_dataset_test.py
@@ -6,6 +6,7 @@
 import tempfile
 from pathlib import Path
 
+import numpy as np
 import pytest
 
 from compiler_gym.datasets import FilesDataset
@@ -109,6 +110,18 @@ def test_populated_dataset_with_file_extension_filter(populated_dataset: FilesDa
         "benchmark://test-v0/b/d",
     ]
     assert populated_dataset.size == 2
+
+
+def test_populated_dataset_random_benchmark(populated_dataset: FilesDataset):
+    num_benchmarks = 3
+    rng = np.random.default_rng(0)
+    random_benchmarks = {
+        b.uri
+        for b in (
+            populated_dataset.random_benchmark(rng) for _ in range(num_benchmarks)
+        )
+    }
+    assert len(random_benchmarks) == num_benchmarks
 
 
 if __name__ == "__main__":

--- a/tests/llvm/datasets/csmith_test.py
+++ b/tests/llvm/datasets/csmith_test.py
@@ -7,6 +7,7 @@ from itertools import islice
 from pathlib import Path
 
 import gym
+import numpy as np
 import pytest
 
 import compiler_gym.envs.llvm  # noqa register environments
@@ -45,6 +46,17 @@ def test_csmith_random_select(
     assert benchmark.source
     benchmark.write_sources_to_directory(tmpwd)
     assert (tmpwd / "source.c").is_file()
+
+
+@skip_on_ci
+def test_random_benchmark(csmith_dataset: CsmithDataset):
+    num_benchmarks = 5
+    rng = np.random.default_rng(0)
+    random_benchmarks = {
+        b.uri
+        for b in (csmith_dataset.random_benchmark(rng) for _ in range(num_benchmarks))
+    }
+    assert len(random_benchmarks) == num_benchmarks
 
 
 if __name__ == "__main__":

--- a/tests/llvm/datasets/llvm_stress_test.py
+++ b/tests/llvm/datasets/llvm_stress_test.py
@@ -7,6 +7,7 @@ import sys
 from itertools import islice
 
 import gym
+import numpy as np
 import pytest
 
 import compiler_gym.envs.llvm  # noqa register environments
@@ -57,6 +58,19 @@ def test_llvm_stress_random_select(
         instcount = env.reset(benchmark=benchmark)
         print(env.ir)  # For debugging in case of error.
         assert instcount["TotalInstsCount"] > 0
+
+
+@skip_on_ci
+def test_random_benchmark(llvm_stress_dataset: LlvmStressDataset):
+    num_benchmarks = 5
+    rng = np.random.default_rng(0)
+    random_benchmarks = {
+        b.uri
+        for b in (
+            llvm_stress_dataset.random_benchmark(rng) for _ in range(num_benchmarks)
+        )
+    }
+    assert len(random_benchmarks) == num_benchmarks
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The v0.1.8 release removed the random benchmark selection from
CompilerGym environments when no benchmark was specified. If the user
wishes for random benchmark selection, they were required to roll
their own implementation. Randomly sampling from
env.dataset.benchmark_uris() is not always easy as the generator may
be infinite. For some datasets, e.g. Csmith, it is trivial to select
random benchmarks by generating random numbers within the range of
numeric seed values, but this is not obvious and the user shouldn't
have to figure this out for the simple case of uniform random
selection.

This adds a `random_benchmark()` method to the `Dataset` class which
allows uniform random benchmark selection, and a `random_benchmark()`
method to the `Datasets` class for sampling across datasets.

Fixes #240.