### PR TITLE
Remove `object` subclasses from Python classes.

### DIFF
--- a/compiler_gym/datasets/benchmark.py
+++ b/compiler_gym/datasets/benchmark.py
@@ -38,7 +38,7 @@ class BenchmarkSource(NamedTuple):
         return str(self.filename)
 
 
-class Benchmark(object):
+class Benchmark:
     """A benchmark represents a particular program that is being compiled.
 
     A benchmark is a program that can be used by a :class:`CompilerEnv

--- a/compiler_gym/datasets/dataset.py
+++ b/compiler_gym/datasets/dataset.py
@@ -17,7 +17,7 @@ from compiler_gym.datasets.uri import DATASET_NAME_RE
 from compiler_gym.util.debug_util import get_logging_level
 
 
-class Dataset(object):
+class Dataset:
     """A dataset is a collection of benchmarks.
 
     The Dataset class has methods for installing and managing groups of

--- a/compiler_gym/datasets/datasets.py
+++ b/compiler_gym/datasets/datasets.py
@@ -33,7 +33,7 @@ def round_robin_iterables(iters: Iterable[Iterable[T]]) -> Iterable[T]:
         yield from iters.popleft()
 
 
-class Datasets(object):
+class Datasets:
     """A collection of datasets.
 
     This class provides a dictionary-like interface for indexing and iterating

--- a/compiler_gym/envs/llvm/llvm_benchmark.py
+++ b/compiler_gym/envs/llvm/llvm_benchmark.py
@@ -107,7 +107,7 @@ def get_system_includes() -> List[Path]:
     return _SYSTEM_INCLUDES
 
 
-class ClangInvocation(object):
+class ClangInvocation:
     """Class to represent a single invocation of the clang compiler."""
 
     def __init__(

--- a/compiler_gym/service/connection.py
+++ b/compiler_gym/service/connection.py
@@ -134,7 +134,7 @@ else:
     StubMethod = Callable[[Request], Reply]
 
 
-class Connection(object):
+class Connection:
     """Base class for service connections."""
 
     def __init__(self, channel, url: str, logger: logging.Logger):
@@ -477,7 +477,7 @@ class UnmanagedConnection(Connection):
         return self.url
 
 
-class CompilerGymServiceConnection(object):
+class CompilerGymServiceConnection:
     """A connection to a compiler gym service.
 
     There are two types of service connections: managed and unmanaged. The type

--- a/compiler_gym/third_party/inst2vec/__init__.py
+++ b/compiler_gym/third_party/inst2vec/__init__.py
@@ -15,7 +15,7 @@ _PICKLED_EMBEDDINGS = runfiles_path(
 )
 
 
-class Inst2vecEncoder(object):
+class Inst2vecEncoder:
     """An LLVM encoder for inst2vec."""
 
     def __init__(self):

--- a/compiler_gym/util/shell_format.py
+++ b/compiler_gym/util/shell_format.py
@@ -5,7 +5,7 @@
 from typing import Any
 
 
-class ShellFormatCodes(object):
+class ShellFormatCodes:
     """Shell escape codes for pretty-printing."""
 
     PURPLE = "\033[95m"

--- a/compiler_gym/util/timer.py
+++ b/compiler_gym/util/timer.py
@@ -29,7 +29,7 @@ def humanize_duration_hms(seconds: float) -> str:
     return f"{seconds // 3600}:{(seconds % 3600) // 60:02d}:{seconds % 60:02d}"
 
 
-class Timer(object):
+class Timer:
     """A very simple scoped timer.
 
     Example:

--- a/compiler_gym/views/observation.py
+++ b/compiler_gym/views/observation.py
@@ -9,7 +9,7 @@ from compiler_gym.service.proto import ObservationSpace, StepReply, StepRequest
 from compiler_gym.views.observation_space_spec import ObservationSpaceSpec
 
 
-class ObservationView(object):
+class ObservationView:
     """A view into the available observation spaces of a service.
 
     Example usage:

--- a/compiler_gym/views/observation_space_spec.py
+++ b/compiler_gym/views/observation_space_spec.py
@@ -22,7 +22,7 @@ def _json2nx(observation):
     )
 
 
-class ObservationSpaceSpec(object):
+class ObservationSpaceSpec:
     """Specification of an observation space.
 
     :ivar id: The name of the observation space.

--- a/compiler_gym/views/reward.py
+++ b/compiler_gym/views/reward.py
@@ -10,7 +10,7 @@ from compiler_gym.spaces.reward import Reward
 from compiler_gym.views.observation import ObservationView
 
 
-class RewardView(object):
+class RewardView:
     """A view into a set of reward spaces.
 
     Example usage:

--- a/examples/example_compiler_gym_service/service_py/example_service.py
+++ b/examples/example_compiler_gym_service/service_py/example_service.py
@@ -86,7 +86,7 @@ OBSERVATION_SPACES = [
 ]
 
 
-class CompilationSession(object):
+class CompilationSession:
     """Represents an instance of an interactive compilation session."""
 
     def __init__(self, benchmark: str):

--- a/tests/util/minimize_trajectory_test.py
+++ b/tests/util/minimize_trajectory_test.py
@@ -18,14 +18,14 @@ pytest_plugins = ["tests.pytest_plugins.llvm"]
 logging.basicConfig(level=logging.DEBUG)
 
 
-class MockActionSpace(object):
+class MockActionSpace:
     """A mock action space for use by MockEnv."""
 
     def __init__(self, actions):
         self.flags = {a: str(a) for a in set(actions)}
 
 
-class MockValidationResult(object):
+class MockValidationResult:
     """A mock validation result for use by MockEnv."""
 
     def __init__(self, okay):
@@ -35,7 +35,7 @@ class MockValidationResult(object):
         return self._okay
 
 
-class MockEnv(object):
+class MockEnv:
     """A mock environment for testing trajectory minimization."""
 
     def __init__(self, actions: List[int], validate=lambda env: True):

--- a/tests/views/observation_test.py
+++ b/tests/views/observation_test.py
@@ -21,12 +21,12 @@ from compiler_gym.views import ObservationView
 from tests.test_main import main
 
 
-class MockGetObservationReply(object):
+class MockGetObservationReply:
     def __init__(self, value):
         self.observation = [value]
 
 
-class MockGetObservation(object):
+class MockGetObservation:
     """Mock for the get_observation callack of ObservationView."""
 
     def __init__(self, ret=None):

--- a/tests/views/reward_test.py
+++ b/tests/views/reward_test.py
@@ -9,7 +9,7 @@ from compiler_gym.views import RewardView
 from tests.test_main import main
 
 
-class MockReward(object):
+class MockReward:
     def __init__(self, id, ret=None):
         self.id = id
         self.ret = list(reversed(ret or []))
@@ -21,7 +21,7 @@ class MockReward(object):
         return ret
 
 
-class MockObservationView(object):
+class MockObservationView:
     pass
 
 


### PR DESCRIPTION
The minimum supported Python version for CompilerGym is
3.6. Subclassing from object is only required for Python versions < 3.