### PR TITLE
Overhaul the README.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ We actively welcome your pull requests.
 1. Fork [the repo](https://github.com/facebookresearch/CompilerGym) and create
    your branch from `development`.
 2. Follow the instructions for
-   [building from source](https://github.com/facebookresearch/CompilerGym#building-from-source)
+   [building from source](https://github.com/facebookresearch/CompilerGym/blob/development/INSTALL.md)
    to set up your environment.
 3. If you've added code that should be tested, add tests.
 4. If you've changed APIs, update the [documentation](/docs/source).

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,83 @@
+# Installation
+
+Install the latest CompilerGym release using:
+
+    pip install -U compiler_gym
+
+CompilerGym requires Python >= 3.6. The binary works on macOS and Linux (on
+Ubuntu 18.04, Fedora 28, Debian 10 or newer equivalents).
+
+## Building from Source
+
+If you prefer, you may build from source. This requires a modern C++ toolchain
+and bazel.
+
+### macOS
+
+On macOS the required dependencies can be installed using
+[homebrew](https://docs.brew.sh/Installation):
+
+```sh
+brew install bazelisk zlib
+export LDFLAGS="-L/usr/local/opt/zlib/lib"
+export CPPFLAGS="-I/usr/local/opt/zlib/include"
+export PKG_CONFIG_PATH="/usr/local/opt/zlib/lib/pkgconfig"
+```
+
+Now proceed to [All platforms](#all-platforms) below.
+
+### Linux
+
+On debian-based linux systems, install the required toolchain using:
+
+```sh
+sudo apt install clang-9 libtinfo5 libjpeg-dev patchelf
+wget https://github.com/bazelbuild/bazelisk/releases/download/v1.7.5/bazelisk-linux-amd64 -O bazel
+chmod +x bazel && mkdir -p ~/.local/bin && mv -v bazel ~/.local/bin
+export PATH="$HOME/.local/bin:$PATH"
+export CC=clang
+export CXX=clang++
+```
+
+### All platforms
+
+We recommend using
+[conda](https://docs.conda.io/projects/conda/en/latest/user-guide/install/)
+to manage the remaining build dependencies. First create a conda environment
+with the required dependencies:
+
+    conda create -n compiler_gym python=3.9 cmake pandoc
+    conda activate compiler_gym
+
+Then clone the CompilerGym source code using:
+
+    git clone https://github.com/facebookresearch/CompilerGym.git
+    cd CompilerGym
+
+There are two primary git branches: `stable` tracks the latest release;
+`development` is for bleeding edge features that may not yet be mature. Checkout
+your preferred branch and install the python development dependencies using:
+
+    git checkout stable
+    make init
+
+The `make init` target only needs to be run once on initial setup, or when
+pulling remote changes to the CompilerGym repository.
+
+Run the test suite to confirm that everything is working:
+
+    make test
+
+To build and install the `compiler_gym` python package, run:
+
+    make install
+
+**NOTE:** To use the `compiler_gym` package that is installed by `make install`
+you must leave the root directory of this repository. Attempting to import
+`compiler_gym` while in the root of this repository will cause import errors.
+
+When you are finished, you can deactivate and delete the conda
+environment using:
+
+    conda deactivate
+    conda env remove -n compiler_gym

--- a/Makefile
+++ b/Makefile
@@ -189,14 +189,9 @@ docs/source/contributing.rst: CONTRIBUTING.md
 	echo "..\n  Generated from $<. Do not edit!\n" > $@
 	$(PANDOC) --from=markdown --to=rst $< >> $@
 
-docs/source/installation.rst: README.md
-	echo "..\n  Generated from $<. Do not edit!\n" > $@
-	sed -n '/^## Installation/,$$p' $< | sed -n '/^### Building/q;p' | $(PANDOC) --from=markdown --to=rst >> $@
-
 GENERATED_DOCS := \
 	docs/source/changelog.rst \
 	docs/source/contributing.rst \
-	docs/source/installation.rst \
 	$(NULL)
 
 gendocs: $(GENERATED_DOCS)

--- a/README.md
+++ b/README.md
@@ -1,170 +1,78 @@
 ![CompilerGym](https://github.com/facebookresearch/CompilerGym/raw/development/docs/source/_static/img/logo.png)
 
----
+<p align="center">
+  <!-- PyPi Version -->
+  <a href="https://pypi.org/project/compiler-gym/">
+      <img src="https://badge.fury.io/py/compiler-gym.svg" alt="PyPI version" height="20">
+  </a>
+  <!-- Downloads counter -->
+  <a href="https://pypi.org/project/compiler-gym/">
+      <img src="https://pepy.tech/badge/compiler-gym" alt="PyPi Downloads" height="20">
+  </a>
+  <!-- license -->
+  <a href="https://tldrlegal.com/license/mit-license">
+      <img src="https://img.shields.io/pypi/l/compiler-gym" alt="License" height="20">
+  </a>
+  <!-- CI status -->
+  <a href="https://github.com/facebookresearch/CompilerGym/actions?query=workflow%3ACI+branch%3Adevelopment">
+      <img src="https://github.com/facebookresearch/CompilerGym/workflows/CI/badge.svg?branch=development" alt="CI status" height="20">
+  </a>
+  <!-- Getting started colab -->
+  <a href="https://colab.research.google.com/github/facebookresearch/CompilerGym/blob/stable/examples/getting-started.ipynb">
+      <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Colab" height="20">
+  </a>
+</p>
 
-<!-- Documentation -->
-<a href="http://facebookresearch.github.io/CompilerGym/">
-    <img src="https://img.shields.io/badge/documentation-latest-blue.svg" alt="Documentation" height="20">
-</a>
-<!-- PyPi Version -->
-<a href="https://pypi.org/project/compiler-gym/">
-    <img src="https://badge.fury.io/py/compiler-gym.svg" alt="PyPI version" height="20">
-</a>
-<!-- CI status -->
-<a href="https://github.com/facebookresearch/CompilerGym/actions?query=workflow%3ACI+branch%3Adevelopment">
-    <img src="https://github.com/facebookresearch/CompilerGym/workflows/CI/badge.svg?branch=development" alt="CI status" height="20">
-</a>
-<!-- Downloads counter -->
-<a href="https://pypi.org/project/compiler-gym/">
-    <img src="https://pepy.tech/badge/compiler-gym" alt="PyPi Downloads" height="20">
-</a>
-<!-- license -->
-<a href="https://tldrlegal.com/license/mit-license">
-    <img src="https://img.shields.io/pypi/l/compiler-gym" alt="License" height="20">
-</a>
-<!-- Getting started colab -->
-<a href="https://colab.research.google.com/github/facebookresearch/CompilerGym/blob/stable/examples/getting-started.ipynb">
-    <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Colab" height="20">
-</a>
-
-CompilerGym is a toolkit for exposing compiler optimization problems
-for reinforcement learning. It allows machine learning researchers to
-experiment with program optimization techniques without requiring any
-experience in compilers, and provides a framework for compiler
-developers to expose new optimization problems for AI.
-
-
-**Table of Contents**
-
-- [Features](#features)
-- [Installation](#installation)
-  - [Building from Source](#building-from-source)
-- [Usage](#usage)
-- [Leaderboards](#leaderboards)
-  - [LLVM Instruction Count](#llvm-instruction-count)
-- [Contributing](#contributing)
-- [Citation](#citation)
+<p align="center">
+  <i>Reinforcement learning environments for compiler optimization tasks.</i>
+</p>
+<p align="center">
+  <i>
+    Check
+    <a href="http://facebookresearch.github.io/CompilerGym/">the website</a>
+    for more information.
+  </i>
+</p>
 
 
-# Features
+## Introduction
 
-With CompilerGym, building ML models for compiler research problems is as easy
-as building ML models to play video games. Here are some highlights of key
-features:
+CompilerGym is a library of easy to use and performant reinforcement learning
+environments for compiler tasks. It allows ML researchers to interact with
+important compiler optimization problems in a language and vocabulary with which
+they are comfortable, and provides a toolkit for systems developers to expose
+new compiler tasks for ML research. We aim to act as a catalyst for making
+compilers faster using ML. Key features include:
 
-* **API:** uses the popular [Gym](https://gym.openai.com/) interface from OpenAI
-  — use Python to write your agent.
+* **Ease of use:** built on the the popular [Gym](https://gym.openai.com/)
+  interface - use Python to write your agent. With CompilerGym, building ML
+  models for compiler research problems is as easy as building ML models to play
+  video games.
 
-* **Datasets:** wraps real world programs (C++ programs, TensorFlow programs,
-  programs from Github, etc.) and a mainstream compiler
-  ([LLVM](https://llvm.org/)), providing millions of programs for training.
+* **Batteries included:** includes everything required to get started. Wraps
+  real world programs and compilers to provide millions of instances for
+  training. Provides multiple kinds of pre-computed program representations: you
+  can focus on end-to-end deep learning or features + boosted trees, all the way
+  up to graph models. Appropriate reward functions and loss functions for
+  optimization targets are provided out of the box.
 
-* **Tasks and Actions:** interfaces the [LLVM](https://llvm.org/) compiler for
-  one compiler research problem:  phase ordering (more to come). It has a large
-  discrete action space.
-
-* **Representations:** provides raw representations of programs, as well as
-  multiple kinds of pre-computed features: you can focus on end-to-end deep
-  learning or features + boosted trees, all the way up to graph models.
-
-* **Rewards:** provides appropriate reward functions and loss functions out of
-  the box.
-
-* **Testing:** provides a validation process for correctness of results.
-
-* **Baselines:** provides some baselines and reports their performance.
-
-* **Competition:** provides [leaderboards](#leaderboards) for you to submit your
-  results.
+* **Reproducible:** provides validation for correctness of results, common
+  baselines, and [leaderboards](#leaderboards) for you to submit your results.
 
 For a glimpse of what's to come, check out [our
 roadmap](https://github.com/facebookresearch/CompilerGym/projects/1).
 
-# Installation
+
+## Installation
 
 Install the latest CompilerGym release using:
 
     pip install -U compiler_gym
 
-The binary works on macOS and Linux (on Ubuntu 18.04, Fedora 28, Debian 10 or
-newer equivalents).
+See [INSTALL.md](INSTALL.md) for further details.
 
-## Building from Source
 
-If you prefer, you may build from source. This requires a modern C++ toolchain
-and bazel.
-
-### macOS  <!-- omit in toc -->
-
-On macOS the required dependencies can be installed using
-[homebrew](https://docs.brew.sh/Installation):
-
-```sh
-brew install bazelisk zlib
-export LDFLAGS="-L/usr/local/opt/zlib/lib"
-export CPPFLAGS="-I/usr/local/opt/zlib/include"
-export PKG_CONFIG_PATH="/usr/local/opt/zlib/lib/pkgconfig"
-```
-
-Now proceed to [All platforms](#all-platforms) below.
-
-### Linux  <!-- omit in toc -->
-
-On debian-based linux systems, install the required toolchain using:
-
-```sh
-sudo apt install clang-9 libtinfo5 libjpeg-dev patchelf
-wget https://github.com/bazelbuild/bazelisk/releases/download/v1.7.5/bazelisk-linux-amd64 -O bazel
-chmod +x bazel && mkdir -p ~/.local/bin && mv -v bazel ~/.local/bin
-export PATH="$HOME/.local/bin:$PATH"
-export CC=clang
-export CXX=clang++
-```
-
-### All platforms  <!-- omit in toc -->
-
-We recommend using
-[conda](https://docs.conda.io/projects/conda/en/latest/user-guide/install/)
-to manage the remaining build dependencies. First create a conda environment
-with the required dependencies:
-
-    conda create -n compiler_gym python=3.9 cmake pandoc
-    conda activate compiler_gym
-
-Then clone the CompilerGym source code using:
-
-    git clone https://github.com/facebookresearch/CompilerGym.git
-    cd CompilerGym
-
-There are two primary git branches: `stable` tracks the latest release;
-`development` is for bleeding edge features that may not yet be mature. Checkout
-your preferred branch and install the python development dependencies using:
-
-    git checkout stable
-    make init
-
-The `make init` target only needs to be run once on initial setup, or when
-pulling remote changes to the CompilerGym repository.
-
-Run the test suite to confirm that everything is working:
-
-    make test
-
-To build and install the `compiler_gym` python package, run:
-
-    make install
-
-**NOTE:** To use the `compiler_gym` package that is installed by `make install`
-you must leave the root directory of this repository. Attempting to import
-`compiler_gym` while in the root of this repository will cause import errors.
-
-When you are finished, you can deactivate and delete the conda
-environment using:
-
-    conda deactivate
-    conda env remove -n compiler_gym
-
-# Usage
+## Usage
 
 Starting with CompilerGym is simple. If you not already familiar with the gym
 interface, refer to the [getting started
@@ -188,21 +96,18 @@ In Python, import `compiler_gym` to use the environments:
 ```
 
 See the [documentation website](http://facebookresearch.github.io/CompilerGym/)
-for tutorials, further details, and API reference. Our
-[roadmap](https://facebookresearch.github.io/CompilerGym/about.html#roadmap) of
-planned features is public, and the
-[changelog](https://github.com/facebookresearch/CompilerGym/blob/development/CHANGELOG.md)
-summarizes shipped features.
+for tutorials, further details, and API reference. See the [examples](/examples)
+directory for pytorch integration, agent implementations, etc.
 
 
-# Leaderboards
+## Leaderboards
 
 These leaderboards track the performance of user-submitted algorithms for
 CompilerGym tasks. To submit a result please see
 [this document](https://github.com/facebookresearch/CompilerGym/blob/development/CONTRIBUTING.md#leaderboard-submissions).
 
 
-## LLVM Instruction Count
+### LLVM Instruction Count
 
 LLVM is a popular open source compiler used widely in industry and research. The
 `llvm-ic-v0` environment exposes LLVM's optimizing passes as a set of actions
@@ -227,13 +132,13 @@ environment on the 23 benchmarks in the `cbench-v1` dataset.
 | Jiadong Guo | Tabular Q (N=2000, H=5) | [write-up](leaderboard/llvm_instcount/tabular_q/README.md), [results](leaderboard/llvm_instcount/tabular_q/results-H5-N2000.csv) | 2021-04 | 694.105 | 0.988× |
 
 
-# Contributing
+## Contributing
 
 We welcome contributions to CompilerGym. If you are interested in contributing please see
 [this document](https://github.com/facebookresearch/CompilerGym/blob/development/CONTRIBUTING.md).
 
 
-# Citation
+## Citation
 
 If you use CompilerGym in any of your work, please cite:
 

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -50,9 +50,9 @@ cumulative reward from these environments so as to produce the best programs.
 
 .. include:: installation.rst
 
-See `the Readme file
-<https://github.com/facebookresearch/CompilerGym#building-from-source>`_ for
-alternative installation methods.
+See `INSTALL.md
+<https://github.com/facebookresearch/CompilerGym/blob/development/INSTALL.md>`_
+for alternative installation methods.
 
 
 Using CompilerGym

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -47,8 +47,11 @@ A single instance of this "agent-environment loop" represents the compilation of
 a particular program. The goal is to develop an agent that maximises the
 cumulative reward from these environments so as to produce the best programs.
 
+Install the latest CompilerGym release using:
 
-.. include:: installation.rst
+.. code-block::
+
+   pip install -U compiler_gym
 
 See `INSTALL.md
 <https://github.com/facebookresearch/CompilerGym/blob/development/INSTALL.md>`_

--- a/examples/getting-started.ipynb
+++ b/examples/getting-started.ipynb
@@ -82,7 +82,7 @@
     "id": "CaRZ_tt-Uqrx"
    },
    "source": [
-    "See [Building from Source](https://github.com/facebookresearch/CompilerGym#building-from-source) for alternative installation methods."
+    "See [INSTALL.md](https://github.com/facebookresearch/CompilerGym/blob/development/INSTALL.md) for alternative installation methods."
    ]
   },
   {


### PR DESCRIPTION
Split the build instructions into an INSTALL.md document, and include some more features in the README.