### PR TITLE
Combine all env.step() type hints into a single module.

### DIFF
--- a/compiler_gym/__init__.py
+++ b/compiler_gym/__init__.py
@@ -34,7 +34,7 @@ from compiler_gym.compiler_env_state import (
     CompilerEnvStateReader,
     CompilerEnvStateWriter,
 )
-from compiler_gym.envs import COMPILER_GYM_ENVS, CompilerEnv, observation_t, step_t
+from compiler_gym.envs import COMPILER_GYM_ENVS, CompilerEnv
 from compiler_gym.random_search import random_search
 from compiler_gym.util.debug_util import (
     get_debug_level,
@@ -63,11 +63,9 @@ __all__ = [
     "download",
     "get_debug_level",
     "get_logging_level",
-    "observation_t",
     "random_search",
     "set_debug_level",
     "site_data_path",
-    "step_t",
     "transient_cache_path",
     "validate_states",
     "ValidationError",

--- a/compiler_gym/envs/__init__.py
+++ b/compiler_gym/envs/__init__.py
@@ -2,15 +2,12 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-from compiler_gym.envs.compiler_env import CompilerEnv, info_t, observation_t, step_t
+from compiler_gym.envs.compiler_env import CompilerEnv
 from compiler_gym.envs.llvm.llvm_env import LlvmEnv
 from compiler_gym.util.registration import COMPILER_GYM_ENVS
 
 __all__ = [
     "CompilerEnv",
     "LlvmEnv",
-    "observation_t",
-    "info_t",
-    "step_t",
     "COMPILER_GYM_ENVS",
 ]

--- a/compiler_gym/envs/compiler_env.py
+++ b/compiler_gym/envs/compiler_env.py
@@ -11,7 +11,7 @@ from copy import deepcopy
 from math import isclose
 from pathlib import Path
 from time import time
-from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
+from typing import Callable, Dict, Iterable, List, Optional, Tuple, Union
 
 import gym
 import numpy as np
@@ -43,14 +43,11 @@ from compiler_gym.service.proto import (
 )
 from compiler_gym.spaces import DefaultRewardFromObservation, NamedDiscrete, Reward
 from compiler_gym.util.debug_util import get_logging_level
+from compiler_gym.util.gym_type_hints import StepType
 from compiler_gym.util.timer import Timer
 from compiler_gym.validation_error import ValidationError
 from compiler_gym.validation_result import ValidationResult
 from compiler_gym.views import ObservationSpaceSpec, ObservationView, RewardView
-
-# Type hints.
-info_t = Dict[str, Any]
-step_t = Tuple[Optional[observation_t], Optional[float], bool, info_t]
 
 
 def _wrapped_step(
@@ -751,7 +748,7 @@ class CompilerEnv(gym.Env):
                 reply.observation[0]
             )
 
-    def step(self, action: Union[int, Iterable[int]]) -> step_t:
+    def step(self, action: Union[int, Iterable[int]]) -> StepType:
         """Take a step.
 
         :param action: An action, or a sequence of actions. When multiple

--- a/compiler_gym/envs/llvm/BUILD
+++ b/compiler_gym/envs/llvm/BUILD
@@ -57,6 +57,7 @@ py_library(
     deps = [
         "//compiler_gym/service",
         "//compiler_gym/spaces",
+        "//compiler_gym/util",
         "//compiler_gym/views",
     ],
 )

--- a/compiler_gym/envs/llvm/llvm_rewards.py
+++ b/compiler_gym/envs/llvm/llvm_rewards.py
@@ -8,6 +8,7 @@ from typing import List, Optional
 from compiler_gym.datasets import Benchmark
 from compiler_gym.service import observation_t
 from compiler_gym.spaces.reward import Reward
+from compiler_gym.util.gym_type_hints import RewardType
 from compiler_gym.views.observation import ObservationView
 
 
@@ -46,12 +47,12 @@ class CostFunctionReward(Reward):
         action: int,
         observations: List[observation_t],
         observation_view: ObservationView,
-    ) -> float:
+    ) -> RewardType:
         """Called on env.step(). Compute and return new reward."""
-        cost: float = observations[0]
+        cost: RewardType = observations[0]
         if self.previous_cost is None:
             self.previous_cost = observation_view[self.init_cost_function]
-        reward = float(self.previous_cost - cost)
+        reward = RewardType(self.previous_cost - cost)
         self.previous_cost = cost
         return reward
 
@@ -82,13 +83,13 @@ class NormalizedReward(CostFunctionReward):
         action: int,
         observations: List[observation_t],
         observation_view: ObservationView,
-    ) -> float:
+    ) -> RewardType:
         """Called on env.step(). Compute and return new reward."""
         if self.cost_norm is None:
             self.cost_norm = self.get_cost_norm(observation_view)
         return super().update(action, observations, observation_view) / self.cost_norm
 
-    def get_cost_norm(self, observation_view: ObservationView) -> float:
+    def get_cost_norm(self, observation_view: ObservationView) -> RewardType:
         """Return the value used to normalize costs."""
         return observation_view[self.init_cost_function]
 
@@ -104,7 +105,7 @@ class BaselineImprovementNormalizedReward(NormalizedReward):
         super().__init__(**kwargs)
         self.baseline_cost_function: str = baseline_cost_function
 
-    def get_cost_norm(self, observation_view: ObservationView) -> float:
+    def get_cost_norm(self, observation_view: ObservationView) -> RewardType:
         """Return the value used to normalize costs."""
         init_cost = observation_view[self.init_cost_function]
         baseline_cost = observation_view[self.baseline_cost_function]

--- a/compiler_gym/spaces/BUILD
+++ b/compiler_gym/spaces/BUILD
@@ -38,6 +38,7 @@ py_library(
     deps = [
         ":scalar",
         "//compiler_gym/service",
+        "//compiler_gym/util",
     ],
 )
 

--- a/compiler_gym/spaces/__init__.py
+++ b/compiler_gym/spaces/__init__.py
@@ -9,11 +9,11 @@ from compiler_gym.spaces.scalar import Scalar
 from compiler_gym.spaces.sequence import Sequence
 
 __all__ = [
-    "DefaultRewardFromObservation",
-    "Scalar",
-    "Sequence",
-    "NamedDiscrete",
     "Commandline",
     "CommandlineFlag",
+    "DefaultRewardFromObservation",
+    "NamedDiscrete",
     "Reward",
+    "Scalar",
+    "Sequence",
 ]

--- a/compiler_gym/spaces/reward.py
+++ b/compiler_gym/spaces/reward.py
@@ -8,6 +8,7 @@ import numpy as np
 
 from compiler_gym.service import observation_t
 from compiler_gym.spaces.scalar import Scalar
+from compiler_gym.util.gym_type_hints import RewardType
 
 
 class Reward(Scalar):
@@ -39,11 +40,11 @@ class Reward(Scalar):
         self,
         id: str,
         observation_spaces: Optional[List[str]] = None,
-        default_value: float = 0,
-        min: Optional[float] = None,
-        max: Optional[float] = None,
+        default_value: RewardType = 0,
+        min: Optional[RewardType] = None,
+        max: Optional[RewardType] = None,
         default_negates_returns: bool = False,
-        success_threshold: Optional[float] = None,
+        success_threshold: Optional[RewardType] = None,
         deterministic: bool = False,
         platform_dependent: bool = True,
     ):
@@ -82,7 +83,7 @@ class Reward(Scalar):
         )
         self.id = id
         self.observation_spaces = observation_spaces or []
-        self.default_value: float = default_value
+        self.default_value: RewardType = default_value
         self.default_negates_returns: bool = default_negates_returns
         self.success_threshold = success_threshold
         self.deterministic = deterministic
@@ -102,7 +103,7 @@ class Reward(Scalar):
         action: int,
         observations: List[observation_t],
         observation_view: "compiler_gym.views.ObservationView",  # noqa: F821
-    ) -> float:
+    ) -> RewardType:
         """Calculate a reward for the given action.
 
         :param action: The action performed.
@@ -114,7 +115,7 @@ class Reward(Scalar):
         """
         raise NotImplementedError("abstract class")
 
-    def reward_on_error(self, episode_reward: float) -> float:
+    def reward_on_error(self, episode_reward: RewardType) -> RewardType:
         """Return the reward value for an error condition.
 
         This method should be used to produce the reward value that should be
@@ -130,7 +131,7 @@ class Reward(Scalar):
             return self.default_value
 
     @property
-    def range(self) -> Tuple[float, float]:
+    def range(self) -> Tuple[RewardType, RewardType]:
         """The lower and upper bounds of the reward."""
         return (self.min, self.max)
 
@@ -155,13 +156,13 @@ class DefaultRewardFromObservation(Reward):
         action: int,
         observations: List[observation_t],
         observation_view: "compiler_gym.views.ObservationView",  # noqa: F821
-    ) -> float:
+    ) -> RewardType:
         """Called on env.step(). Compute and return new reward."""
         del action  # unused
         del observation_view  # unused
-        value: float = observations[0]
+        value: RewardType = observations[0]
         if self.previous_value is None:
             self.previous_value = 0
-        reward = float(value - self.previous_value)
+        reward = RewardType(value - self.previous_value)
         self.previous_value = value
         return reward

--- a/compiler_gym/util/BUILD
+++ b/compiler_gym/util/BUILD
@@ -14,6 +14,7 @@ py_library(
         "decorators.py",
         "download.py",
         "filesystem.py",
+        "gym_type_hints.py",
         "logs.py",
         "minimize_trajectory.py",
         "registration.py",

--- a/compiler_gym/util/gym_type_hints.py
+++ b/compiler_gym/util/gym_type_hints.py
@@ -1,0 +1,15 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+from typing import Any, Dict, Optional, Tuple, TypeVar
+
+# A JSON dictionary.
+JsonDictType = Dict[str, Any]
+
+# Type hints for the values returned by gym.Env.step().
+ObservationType = TypeVar("ObservationType")
+RewardType = float
+DoneType = bool
+InfoType = JsonDictType
+StepType = Tuple[Optional[ObservationType], Optional[RewardType], DoneType, InfoType]


### PR DESCRIPTION
This adds a compiler_gym.util.gym_type_hints module that contains the
type hints for gym.Env return types. Previously they were scattered
across several files.