### PR TITLE
[llvm] Add the -early-cse pass to the action space.

### DIFF
--- a/compiler_gym/envs/llvm/service/passes/config.py
+++ b/compiler_gym/envs/llvm/service/passes/config.py
@@ -47,7 +47,8 @@ CREATE_PASS_NAME_MAP = {
     "DeadInstElimination": "DeadInstEliminationPass",
     "DivRemPairsLegacyPass": "DivRemPairsPass",
     "DSELegacyPass": "DeadStoreEliminationPass",
-    "EarlyCSEMemSSALegacyPass": "EarlyCSEPass",
+    "EarlyCSELegacyPass": "EarlyCSEPass",
+    "EarlyCSEMemSSALegacyPass": "EarlyCSEMemSSAPass",
     "EliminateAvailableExternallyLegacyPass": "EliminateAvailableExternallyPass",
     "EntryExitInstrumenter": "EntryExitInstrumenterPass",
     "Float2IntLegacyPass": "Float2IntPass",
@@ -174,7 +175,6 @@ _EXCLUDED_PASSES = {
     "WholeProgramDevirt",
     "MakeGuardsExplicitLegacyPass",
     "LowerTypeTests",
-    "EarlyCSELegacyPass",
     # Unneeded debugging passes.
     "WriteThinLTOBitcode",
     "PredicateInfoPrinterLegacyPass",

--- a/compiler_gym/envs/llvm/service/passes/make_action_space_genfiles.py
+++ b/compiler_gym/envs/llvm/service/passes/make_action_space_genfiles.py
@@ -154,6 +154,19 @@ def make_action_sources(pass_iterator, outpath: Path):
         print("#pragma once", file=f)
         for header in sorted(headers):
             print(f'#include "{header}"', file=f)
+
+        # Inject an ad-hoc workaround for the non-standard constructor of the
+        # EarlyCSEMemSSAPass.
+        print(
+            """
+namespace llvm {
+FunctionPass* createEarlyCSEMemSSAPass() {
+  return createEarlyCSEPass(/*UseMemorySSA=*/true);
+}
+} // namespace llvm
+""",
+            file=f,
+        )
     logging.debug("Generated %s", include_path.name)
 
     with open(actions_path, "w") as f:


### PR DESCRIPTION
This adds the -early-cse pass to the action space by injecting an
ad-hoc constructor definition into the generated headers.
