### PR TITLE
[docs] Use conda install install patchelf.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -31,7 +31,7 @@ Now proceed to [All platforms](#all-platforms) below.
 On debian-based linux systems, install the required toolchain using:
 
 ```sh
-sudo apt install clang-9 libtinfo5 libjpeg-dev patchelf
+sudo apt install clang-9 libtinfo5 libjpeg-dev
 wget https://github.com/bazelbuild/bazelisk/releases/download/v1.7.5/bazelisk-linux-amd64 -O bazel
 chmod +x bazel && mkdir -p ~/.local/bin && mv -v bazel ~/.local/bin
 export PATH="$HOME/.local/bin:$PATH"
@@ -46,7 +46,7 @@ We recommend using
 to manage the remaining build dependencies. First create a conda environment
 with the required dependencies:
 
-    conda create -n compiler_gym python=3.9 cmake pandoc
+    conda create -n compiler_gym python=3.9 cmake pandoc patchelf
     conda activate compiler_gym
 
 Then clone the CompilerGym source code using:


### PR DESCRIPTION
Prefer recommending that users install patchelf through conda rather
than requiring a system-wide apt install.
