### PR TITLE
[env] Add `observations` and `rewards` kwargs to `env.step()`

### DIFF
--- a/compiler_gym/envs/compiler_env.py
+++ b/compiler_gym/envs/compiler_env.py
@@ -262,7 +262,7 @@ class CompilerEnv(gym.Env):
             for space in self.service.action_spaces
         ]
         self.observation = self._observation_view_type(
-            get_observation=lambda req: _wrapped_step(self.service, req),
+            raw_step=self.raw_step,
             spaces=self.service.observation_spaces,
         )
         self.reward = self._reward_view_type(rewards, self.observation)

--- a/compiler_gym/envs/compiler_env.py
+++ b/compiler_gym/envs/compiler_env.py
@@ -43,7 +43,12 @@ from compiler_gym.service.proto import (
 )
 from compiler_gym.spaces import DefaultRewardFromObservation, NamedDiscrete, Reward
 from compiler_gym.util.debug_util import get_logging_level
-from compiler_gym.util.gym_type_hints import ObservationType, RewardType, StepType
+from compiler_gym.util.gym_type_hints import (
+    ActionType,
+    ObservationType,
+    RewardType,
+    StepType,
+)
 from compiler_gym.util.timer import Timer
 from compiler_gym.validation_error import ValidationError
 from compiler_gym.validation_result import ValidationResult
@@ -864,7 +869,7 @@ class CompilerEnv(gym.Env):
 
     def step(
         self,
-        action: Union[int, Iterable[int]],
+        action: Union[ActionType, Iterable[ActionType]],
         observations: Optional[Iterable[Union[str, ObservationSpaceSpec]]] = None,
         rewards: Optional[Iterable[Union[str, Reward]]] = None,
     ) -> StepType:

--- a/compiler_gym/envs/compiler_env.py
+++ b/compiler_gym/envs/compiler_env.py
@@ -80,11 +80,11 @@ class CompilerEnv(gym.Env):
     :doc:`/compiler_gym/service` for more details on connecting to services):
 
     >>> env = CompilerEnv(
-        service="localhost:8080",
-        observation_space="features",
-        reward_space="runtime",
-        rewards=[env_reward_spaces],
-    )
+    ...     service="localhost:8080",
+    ...     observation_space="features",
+    ...     reward_space="runtime",
+    ...     rewards=[env_reward_spaces],
+    ... )
 
     Once constructed, an environment can be used in exactly the same way as a
     regular :code:`gym.Env`, e.g.
@@ -759,6 +759,30 @@ class CompilerEnv(gym.Env):
         observations: Iterable[ObservationSpaceSpec],
         rewards: Iterable[Reward],
     ) -> StepType:
+        """Take a step.
+
+        :param actions: A list of actions to be applied.
+
+        :param observations: A list of observations spaces to compute
+            observations from. These are evaluated after the actions are
+            applied.
+
+        :param rewards: A list of reward spaces to compute rewards from. These
+            are evaluated after the actions are applied.
+
+        :return: A tuple of observations, rewards, done, and info. Observations
+            and rewards are lists.
+
+        :raises SessionNotFound: If :meth:`reset()
+            <compiler_gym.envs.CompilerEnv.reset>` has not been called.
+
+        .. warning::
+
+            Prefer :meth:`step() <compiler_gym.envs.CompilerEnv.step>` to
+            :meth:`raw_step() <compiler_gym.envs.CompilerEnv.step>`.
+            :meth:`step() <compiler_gym.envs.CompilerEnv.step>` has equivalent
+            functionality, and is less likely to change in the future.
+        """
         if not self.in_episode:
             raise SessionNotFound("Must call reset() before step()")
 
@@ -843,7 +867,7 @@ class CompilerEnv(gym.Env):
             for observation_space in user_observation_spaces
         ]
 
-        # Update and compue the rewards.
+        # Update and compute the rewards.
         rewards: List[RewardType] = []
         for reward_space in reward_spaces:
             reward_observations = [
@@ -891,9 +915,7 @@ class CompilerEnv(gym.Env):
             :code:`env.reward_space` is not returned.
 
         :return: A tuple of observation, reward, done, and info. Observation and
-            reward are None if default observation/reward is not set. If done is
-            True, observation and reward may also be None (e.g. because the
-            service failed).
+            reward are None if default observation/reward is not set.
 
         :raises SessionNotFound: If :meth:`reset()
             <compiler_gym.envs.CompilerEnv.reset>` has not been called.

--- a/compiler_gym/envs/llvm/llvm_rewards.py
+++ b/compiler_gym/envs/llvm/llvm_rewards.py
@@ -43,11 +43,12 @@ class CostFunctionReward(Reward):
 
     def update(
         self,
-        action: int,
+        actions: List[int],
         observations: List[ObservationType],
         observation_view: ObservationView,
     ) -> RewardType:
         """Called on env.step(). Compute and return new reward."""
+        del actions
         cost: RewardType = observations[0]
         if self.previous_cost is None:
             self.previous_cost = observation_view[self.init_cost_function]
@@ -79,14 +80,14 @@ class NormalizedReward(CostFunctionReward):
 
     def update(
         self,
-        action: int,
+        actions: List[int],
         observations: List[ObservationType],
         observation_view: ObservationView,
     ) -> RewardType:
         """Called on env.step(). Compute and return new reward."""
         if self.cost_norm is None:
             self.cost_norm = self.get_cost_norm(observation_view)
-        return super().update(action, observations, observation_view) / self.cost_norm
+        return super().update(actions, observations, observation_view) / self.cost_norm
 
     def get_cost_norm(self, observation_view: ObservationView) -> RewardType:
         """Return the value used to normalize costs."""

--- a/compiler_gym/envs/llvm/llvm_rewards.py
+++ b/compiler_gym/envs/llvm/llvm_rewards.py
@@ -48,7 +48,7 @@ class CostFunctionReward(Reward):
         observation_view: ObservationView,
     ) -> RewardType:
         """Called on env.step(). Compute and return new reward."""
-        del actions
+        del actions  # unused
         cost: RewardType = observations[0]
         if self.previous_cost is None:
             self.previous_cost = observation_view[self.init_cost_function]

--- a/compiler_gym/envs/llvm/make_specs.py
+++ b/compiler_gym/envs/llvm/make_specs.py
@@ -18,8 +18,7 @@ def main(argv):
     assert len(argv) == 3, "Usage: make_specs.py <service_binary> <output_path>"
     service_path, output_path = argv[1:]
 
-    env = LlvmEnv(Path(service_path))
-    try:
+    with LlvmEnv(Path(service_path)) as env:
         with open(output_path, "w") as f:
             print("from enum import Enum", file=f)
             print(file=f)
@@ -30,8 +29,6 @@ def main(argv):
             print("class reward_spaces(Enum):", file=f)
             for name in env.reward.spaces:
                 print(f'    {name} = "{name}"', file=f)
-    finally:
-        env.close()
 
 
 if __name__ == "__main__":

--- a/compiler_gym/spaces/reward.py
+++ b/compiler_gym/spaces/reward.py
@@ -99,7 +99,7 @@ class Reward(Scalar):
 
     def update(
         self,
-        action: int,
+        actions: List[int],
         observations: List[ObservationType],
         observation_view: "compiler_gym.views.ObservationView",  # noqa: F821
     ) -> RewardType:

--- a/compiler_gym/util/gym_type_hints.py
+++ b/compiler_gym/util/gym_type_hints.py
@@ -2,7 +2,7 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-from typing import Any, Dict, Optional, Tuple, TypeVar
+from typing import Any, Dict, List, Optional, Tuple, TypeVar, Union
 
 # A JSON dictionary.
 JsonDictType = Dict[str, Any]
@@ -12,4 +12,9 @@ ObservationType = TypeVar("ObservationType")
 RewardType = float
 DoneType = bool
 InfoType = JsonDictType
-StepType = Tuple[Optional[ObservationType], Optional[RewardType], DoneType, InfoType]
+StepType = Tuple[
+    Optional[Union[ObservationType, List[ObservationType]]],
+    Optional[Union[RewardType, List[RewardType]]],
+    DoneType,
+    InfoType,
+]

--- a/compiler_gym/util/gym_type_hints.py
+++ b/compiler_gym/util/gym_type_hints.py
@@ -9,6 +9,7 @@ JsonDictType = Dict[str, Any]
 
 # Type hints for the values returned by gym.Env.step().
 ObservationType = TypeVar("ObservationType")
+ActionType = int
 RewardType = float
 DoneType = bool
 InfoType = JsonDictType

--- a/compiler_gym/views/observation_space_spec.py
+++ b/compiler_gym/views/observation_space_spec.py
@@ -79,8 +79,17 @@ class ObservationSpaceSpec:
 
     def __hash__(self) -> int:
         # Quickly hash observation spaces by comparing the index into the list
-        # of spaces returned by the environment. This means that hashing across
-        # different environments is _not_ safe.
+        # of spaces returned by the environment. This means that you should not
+        # hash between observation spaces from different environments as this
+        # will cause collisions, e.g.
+        #
+        #     # not okay:
+        #     >>> obs = set(env.observation.spaces).union(
+        #         other_env.observation.spaces
+        #     )
+        #
+        # If you want to hash between environments, consider using the string id
+        # to identify the observation spaces.
         return self.index
 
     def __repr__(self) -> str:

--- a/compiler_gym/views/observation_space_spec.py
+++ b/compiler_gym/views/observation_space_spec.py
@@ -77,6 +77,12 @@ class ObservationSpaceSpec:
         self.translate = translate
         self.to_string = to_string
 
+    def __hash__(self) -> int:
+        # Quickly hash observation spaces by comparing the index into the list
+        # of spaces returned by the environment. This means that hashing across
+        # different environments is _not_ safe.
+        return self.index
+
     def __repr__(self) -> str:
         return f"ObservationSpaceSpec({self.id})"
 

--- a/examples/example_compiler_gym_service/env_tests.py
+++ b/examples/example_compiler_gym_service/env_tests.py
@@ -66,22 +66,20 @@ def test_reward_spaces(env: CompilerEnv):
 
 def test_step_before_reset(env: CompilerEnv):
     """Taking a step() before reset() is illegal."""
-    with pytest.raises(Exception):
+    with pytest.raises(SessionNotFound, match=r"Must call reset\(\) before step\(\)"):
         env.step(0)
 
 
 def test_observation_before_reset(env: CompilerEnv):
     """Taking an observation before reset() is illegal."""
-    with pytest.raises(SessionNotFound) as ctx:
+    with pytest.raises(SessionNotFound, match=r"Must call reset\(\) before step\(\)"):
         _ = env.observation["ir"]
-    assert str(ctx.value).startswith("Session not found")
 
 
 def test_reward_before_reset(env: CompilerEnv):
     """Taking a reward before reset() is illegal."""
-    with pytest.raises(SessionNotFound) as ctx:
+    with pytest.raises(SessionNotFound, match=r"Must call reset\(\) before step\(\)"):
         _ = env.reward["runtime"]
-    assert str(ctx.value).startswith("Session not found")
 
 
 def test_reset_invalid_benchmark(env: CompilerEnv):

--- a/tests/llvm/observation_spaces_test.py
+++ b/tests/llvm/observation_spaces_test.py
@@ -1151,5 +1151,24 @@ def test_object_text_size_observation_spaces(env: LlvmEnv):
     assert value == crc32_code_sizes[sys.platform][2]
 
 
+def test_add_derived_space(env: LlvmEnv):
+    env.reset()
+    env.observation.add_derived_space(
+        id="IrLen",
+        base_id="Ir",
+        space=Box(low=0, high=float("inf"), shape=(1,), dtype=int),
+        translate=lambda base: [15],
+    )
+
+    value = env.observation["IrLen"]
+    assert isinstance(value, list)
+    assert value == [15]
+
+    # Repeat the above test using the generated bound method.
+    value = env.observation.IrLen()
+    assert isinstance(value, list)
+    assert value == [15]
+
+
 if __name__ == "__main__":
     main()

--- a/tests/views/observation_test.py
+++ b/tests/views/observation_test.py
@@ -5,25 +5,15 @@
 """Unit tests for //compiler_gym/views."""
 import numpy as np
 import pytest
-from gym.spaces import Box
 
 from compiler_gym.service.proto import (
-    DoubleList,
-    Int64List,
-    Observation,
     ObservationSpace,
     ScalarLimit,
     ScalarRange,
     ScalarRangeList,
-    StepRequest,
 )
 from compiler_gym.views import ObservationView
 from tests.test_main import main
-
-
-class MockGetObservationReply:
-    def __init__(self, value):
-        self.observation = [value]
 
 
 class MockGetObservation:
@@ -31,45 +21,22 @@ class MockGetObservation:
 
     def __init__(self, ret=None):
         self.called_observation_spaces = []
-        self.ret = list(reversed(ret or []))
+        self.ret = list(reversed(ret or [None]))
 
-    def __call__(self, request: StepRequest):
-        self.called_observation_spaces.append(request.observation_space[0])
+    def __call__(self, actions, observations, rewards):
+        assert not actions
+        assert len(observations) == 1
+        assert not rewards
+        self.called_observation_spaces.append(observations[0].id)
         ret = self.ret[-1]
         del self.ret[-1]
-        return MockGetObservationReply(ret)
+        return [ret], [], False, {}
 
 
 def test_empty_space():
     with pytest.raises(ValueError) as ctx:
         ObservationView(MockGetObservation(), [])
     assert str(ctx.value) == "No observation spaces"
-
-
-def test_invalid_observation_name():
-    spaces = [
-        ObservationSpace(
-            name="ir",
-            string_size_range=ScalarRange(min=ScalarLimit(value=0)),
-        )
-    ]
-    observation = ObservationView(MockGetObservation(), spaces)
-    with pytest.raises(KeyError) as ctx:
-        _ = observation["invalid"]
-
-    assert str(ctx.value) == "'invalid'"
-
-
-def test_invalid_observation_index():
-    spaces = [
-        ObservationSpace(
-            name="ir",
-            string_size_range=ScalarRange(min=ScalarLimit(value=0)),
-        )
-    ]
-    observation = ObservationView(MockGetObservation(), spaces)
-    with pytest.raises(KeyError):
-        _ = observation[100]
 
 
 def test_observed_value_types():
@@ -108,14 +75,14 @@ def test_observed_value_types():
     ]
     mock = MockGetObservation(
         ret=[
-            Observation(string_value="Hello, IR"),
-            Observation(double_list=DoubleList(value=[1.0, 2.0])),
-            Observation(int64_list=Int64List(value=[-5, 15])),
-            Observation(binary_value=b"Hello, bytes\0"),
-            Observation(string_value="Hello, IR"),
-            Observation(double_list=DoubleList(value=[1.0, 2.0])),
-            Observation(int64_list=Int64List(value=[-5, 15])),
-            Observation(binary_value=b"Hello, bytes\0"),
+            "Hello, IR",
+            [1.0, 2.0],
+            [-5, 15],
+            b"Hello, bytes\0",
+            "Hello, IR",
+            [1.0, 2.0],
+            [-5, 15],
+            b"Hello, bytes\0",
         ]
     )
     observation = ObservationView(mock, spaces)
@@ -126,17 +93,15 @@ def test_observed_value_types():
 
     value = observation["dfeat"]
     np.testing.assert_array_almost_equal(value, [1.0, 2.0])
-    assert value.dtype == np.float64
 
     value = observation["features"]
     np.testing.assert_array_equal(value, [-5, 15])
-    assert value.dtype == np.int64
 
     value = observation["binary"]
     assert value == b"Hello, bytes\0"
 
     # Check that the correct observation_space_list indices were used.
-    assert mock.called_observation_spaces == [0, 2, 1, 3]
+    assert mock.called_observation_spaces == ["ir", "dfeat", "features", "binary"]
     mock.called_observation_spaces = []
 
     # Repeat the above tests using the generated bound methods.
@@ -146,54 +111,15 @@ def test_observed_value_types():
 
     value = observation.dfeat()
     np.testing.assert_array_almost_equal(value, [1.0, 2.0])
-    assert value.dtype == np.float64
 
     value = observation.features()
     np.testing.assert_array_equal(value, [-5, 15])
-    assert value.dtype == np.int64
 
     value = observation.binary()
     assert value == b"Hello, bytes\0"
 
     # Check that the correct observation_space_list indices were used.
-    assert mock.called_observation_spaces == [0, 2, 1, 3]
-
-
-def test_add_derived_space():
-    spaces = [
-        ObservationSpace(
-            name="ir",
-            string_size_range=ScalarRange(min=ScalarLimit(value=0)),
-        ),
-    ]
-    mock = MockGetObservation(
-        ret=[
-            Observation(string_value="Hello, world!"),
-            Observation(string_value="Hello, world!"),
-        ],
-    )
-    observation = ObservationView(mock, spaces)
-    observation.add_derived_space(
-        id="ir_len",
-        base_id="ir",
-        space=Box(low=0, high=float("inf"), shape=(1,), dtype=int),
-        translate=lambda base: [
-            len(base),
-        ],
-    )
-
-    value = observation["ir_len"]
-    assert isinstance(value, list)
-    assert value == [
-        len("Hello, world!"),
-    ]
-
-    # Repeat the above test using the generated bound method.
-    value = observation.ir_len()
-    assert isinstance(value, list)
-    assert value == [
-        len("Hello, world!"),
-    ]
+    assert mock.called_observation_spaces == ["ir", "dfeat", "features", "binary"]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This extends `env.step()` to support `observations` and `rewards` keyword arguments. When provided with a list of strings, these indicate a list of observation spaces and/or reward spaces to be computed and returned in place of the normal default values. For example, suppose we have an environment which uses the `Autophase` observation space and `IrInstructionCount` rewards:

```py
>>> env = gym.make("llvm-v0", observation_space="Autophase", reward_space="IrInstructionCount")
>>> env.reset()
>>> env.step(0)
(array([  0,   4,  54,  39,  12,  46,  23,   6,  12,  31,   2,   4,   0,
         81,   4,  77,  13,  15, 108, 106,  75,  51,  71,  46,  15,   0,
          9,  46,   0,  13,  72,  51,  77,  81,  39,  31,   0, 163,   2,
          0,   4,   6,  13,   1,   0,  73,   8,   1,   0,  15,  85, 638,
        402,  16,  10, 298]),
 0.0,
 False,
 {'action_had_no_effect': True, 'new_action_space': False})
```

Now if we pass a list of observation spaces to `env.step()`, those will be returned in place of the usual observation:

```py
>>> env.step(0, observations=["IrInstructionCount", "BitcodeFile", "InstCount"])
([638,
  '/dev/shm/compiler_gym/s/0517T162105-203078-571b/module-71cf624f.bc',
  array([638,  85,  16,   6,  77,   0,   0,   0,   0,   2,   0,   0,   0,
           0,   0,   9,   2,   8,   0,   2,   0,   1,   2,   0,   0,   0,
           0,   0,   0,   0,   0,   0,   0,  46, 163,  73,  39,   0,   0,
           0,   1,  15,  13,   0,   0,   0,   3,   0,   0,   6,   0,  51,
           0,   0,   0,  31,   2,   4,  81,   1,   0,   0,   0,   0,   0,
           0,   0,   0,   0,   0])],
 0.0,
 False,
 {'action_had_no_effect': True, 'new_action_space': False})
```

Note that specifying an `observations` list _replaces_ the default observation space. If you would like that observation too, request it.

The same approach can be used to update and return multiple rewards in a single step:

```py
env.step(0, rewards=["IrInstructionCount", "ObjectTextSizeBytes"])
Out[8]: 
(array([  0,   4,  54,  39,  12,  46,  23,   6,  12,  31,   2,   4,   0,
         81,   4,  77,  13,  15, 108, 106,  75,  51,  71,  46,  15,   0,
          9,  46,   0,  13,  72,  51,  77,  81,  39,  31,   0, 163,   2,
          0,   4,   6,  13,   1,   0,  73,   8,   1,   0,  15,  85, 638,
        402,  16,  10, 298]),
 [0.0, 0.0],
 False,
 {'action_had_no_effect': True, 'new_action_space': False})
```

## Motivation

Each interaction with the environment incurs an overhead of an RPC round trip to the backend service. By enabling multiple observations and rewards to be computed in a single round trip, this enables more efficient usage in cases where you may want to explore rewards, or compose an observation space from multiple observations etc.


## Downsides of this approach

There are two drawbacks of this approach:

1. The added complexity and python code in the `env.step()` implementation.
2. Deviating from the base gym API should be done sparingly as all other code for gym environments assumes a single `action` argument.

To mitigate these, the actual multi-action, multi-observation, multi-reward step implementation is exposed through a new `env.raw_step()` method. Internally, `env.step()` calls this method after wrangling the arguments into the expected types.


## Performance Impact

Comparison of micro benchmarks between current `development` branch and this PR shows a 1-3% regression in median step time:

```
----------------------------------------------------------- benchmark 'test_step[dummy-cc]': 2 tests ----------------------------------------------------------
Name (time in us)                           Min              Median                 Max                Mean            StdDev            OPS (Kops/s)          
---------------------------------------------------------------------------------------------------------------------------------------------------------------
test_step[dummy-cc] (development-)     112.4243 (1.0)      119.0580 (1.0)      141.3160 (1.0)      122.0013 (1.0)      8.7393 (1.40)           8.1966 (1.0)    
test_step[dummy-cc] (pr-271)           118.5739 (1.05)     121.0123 (1.02)     146.1692 (1.03)     122.8557 (1.01)     6.2366 (1.0)            8.1396 (0.99)   
---------------------------------------------------------------------------------------------------------------------------------------------------------------

----------------------------------------------------------- benchmark 'test_step[dummy-py]': 2 tests ----------------------------------------------------------
Name (time in us)                           Min              Median                 Max                Mean            StdDev            OPS (Kops/s)          
---------------------------------------------------------------------------------------------------------------------------------------------------------------
test_step[dummy-py] (development-)     219.7951 (1.0)      231.4836 (1.0)      294.3157 (1.17)     231.2456 (1.0)      9.3071 (2.46)           4.3244 (1.0)    
test_step[dummy-py] (pr-271)           232.9921 (1.06)     239.0078 (1.03)     251.3048 (1.0)      239.4990 (1.04)     3.7885 (1.0)            4.1754 (0.97)   
---------------------------------------------------------------------------------------------------------------------------------------------------------------

----------------------------------------------------------- benchmark 'test_step[llvm;fast-benchmark;fast-action]': 2 tests -----------------------------------------------------------
Name (time in us)                                                  Min              Median                 Max                Mean             StdDev            OPS (Kops/s)          
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_step[llvm;fast-benchmark;fast-action] (development-)     273.0205 (1.0)      282.8132 (1.0)      296.0783 (1.0)      282.9571 (1.0)       4.4848 (1.0)            3.5341 (1.0)    
test_step[llvm;fast-benchmark;fast-action] (pr-271)           280.3617 (1.03)     285.7240 (1.01)     360.0664 (1.22)     290.3162 (1.03)     16.0257 (3.57)           3.4445 (0.97)   
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

---------------------------------------------------------- benchmark 'test_step[llvm;fast-benchmark;slow-action]': 2 tests -----------------------------------------------------------
Name (time in us)                                                  Min              Median                 Max                Mean            StdDev            OPS (Kops/s)          
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_step[llvm;fast-benchmark;slow-action] (development-)     534.6683 (1.0)      551.9865 (1.0)      565.9248 (1.0)      551.3697 (1.0)      5.9387 (1.0)            1.8137 (1.0)    
test_step[llvm;fast-benchmark;slow-action] (pr-271)           545.0963 (1.02)     563.9269 (1.02)     583.3211 (1.03)     564.8474 (1.02)     8.7242 (1.47)           1.7704 (0.98)   
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

------------------------------------------------------ benchmark 'test_step[llvm;slow-benchmark;fast-action]': 2 tests ------------------------------------------------------
Name (time in ms)                                                 Min             Median                Max               Mean            StdDev                OPS          
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_step[llvm;slow-benchmark;fast-action] (development-)     19.1860 (1.0)      20.1969 (1.0)      21.5074 (1.0)      20.2000 (1.0)      0.4335 (1.03)     49.5049 (1.0)    
test_step[llvm;slow-benchmark;fast-action] (pr-271)           19.3978 (1.01)     20.5750 (1.02)     22.0242 (1.02)     20.6662 (1.02)     0.4206 (1.0)      48.3882 (0.98)   
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------

------------------------------------------------------ benchmark 'test_step[llvm;slow-benchmark;slow-action]': 2 tests -------------------------------------------------------
Name (time in ms)                                                 Min             Median                 Max               Mean            StdDev                OPS          
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_step[llvm;slow-benchmark;slow-action] (development-)     90.0628 (1.0)      93.5737 (1.0)      109.2660 (1.0)      93.8676 (1.0)      2.3871 (1.18)     10.6533 (1.0)    
test_step[llvm;slow-benchmark;slow-action] (pr-271)           90.6975 (1.01)     95.9317 (1.03)     110.5762 (1.01)     96.0721 (1.02)     2.0239 (1.0)      10.4089 (0.98)   
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```