### PR TITLE
Add a module of wrappers for CompilerEnv environments.

### DIFF
--- a/compiler_gym/BUILD
+++ b/compiler_gym/BUILD
@@ -17,6 +17,7 @@ py_library(
         "//compiler_gym/envs",
         "//compiler_gym/leaderboard",
         "//compiler_gym/util",
+        "//compiler_gym/wrappers",
     ],
 )
 

--- a/compiler_gym/datasets/benchmark.py
+++ b/compiler_gym/datasets/benchmark.py
@@ -98,6 +98,9 @@ class Benchmark:
     def __repr__(self) -> str:
         return str(self.uri)
 
+    def __hash__(self) -> int:
+        return hash(self.uri)
+
     @property
     def uri(self) -> str:
         """The URI of the benchmark.

--- a/compiler_gym/wrappers/BUILD
+++ b/compiler_gym/wrappers/BUILD
@@ -1,0 +1,22 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+load("@rules_python//python:defs.bzl", "py_library")
+
+py_library(
+    name = "wrappers",
+    srcs = [
+        "__init__.py",
+        "commandline.py",
+        "core.py",
+        "datasets.py",
+        "time_limit.py",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//compiler_gym/datasets",
+        "//compiler_gym/envs",
+        "//compiler_gym/util",
+    ],
+)

--- a/compiler_gym/wrappers/__init__.py
+++ b/compiler_gym/wrappers/__init__.py
@@ -1,0 +1,28 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""The :code:`compiler_gym.wrappers` module provides.
+"""
+from compiler_gym.wrappers.commandline import (
+    CommandlineWithTerminalAction,
+    ConstrainedCommandline,
+)
+from compiler_gym.wrappers.core import ActionWrapper, CompilerEnvWrapper
+from compiler_gym.wrappers.datasets import (
+    CycleOverBenchmarks,
+    IterateOverBenchmarks,
+    RandomOrderBenchmarks,
+)
+from compiler_gym.wrappers.time_limit import TimeLimit
+
+__all__ = [
+    "ActionWrapper",
+    "CommandlineWithTerminalAction",
+    "CompilerEnvWrapper",
+    "ConstrainedCommandline",
+    "CycleOverBenchmarks",
+    "IterateOverBenchmarks",
+    "RandomOrderBenchmarks",
+    "TimeLimit",
+]

--- a/compiler_gym/wrappers/commandline.py
+++ b/compiler_gym/wrappers/commandline.py
@@ -1,0 +1,138 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+from collections.abc import Iterable as IterableType
+from typing import Dict, Iterable, List, Optional, Union
+
+from compiler_gym.envs import CompilerEnv
+from compiler_gym.spaces import Commandline, CommandlineFlag
+from compiler_gym.util.gym_type_hints import StepType
+from compiler_gym.wrappers.core import ActionWrapper, CompilerEnvWrapper
+
+
+class CommandlineWithTerminalAction(CompilerEnvWrapper):
+    """Creates a new action space with a special "end of episode" terminal
+    action at the start. If step() is called with it, the "done" flag is set.
+    """
+
+    def __init__(
+        self,
+        env: CompilerEnv,
+        terminal=CommandlineFlag(
+            name="end-of-episode",
+            flag="# end-of-episode",
+            description="End the episode",
+        ),
+    ):
+        """Constructor.
+
+        :param env: The environment to wrap.
+
+        :param terminal: The flag to use as the terminal action. Optional.
+        """
+        super().__init__(env)
+
+        if not isinstance(env.action_space, Commandline):
+            raise TypeError(
+                f"Unsupported action space: {type(env.action_space).__name__}"
+            )
+
+        # Redefine the action space, inserting the terminal action at the start.
+        self.action_space = Commandline(
+            items=[terminal]
+            + [
+                CommandlineFlag(
+                    name=name,
+                    flag=flag,
+                    description=description,
+                )
+                for name, flag, description in zip(
+                    env.action_space.names,
+                    env.action_space.flags,
+                    env.action_space.descriptions,
+                )
+            ],
+            name=f"{type(self).__name__}<{env.action_space.name}>",
+        )
+
+    def step(self, action: int) -> StepType:
+        if isinstance(action, int):
+            end_of_episode = action == 0
+            action = [] if end_of_episode else action - 1
+        else:
+            try:
+                index = action.index(0)
+                end_of_episode = True
+            except ValueError:
+                index = len(action)
+                end_of_episode = False
+            action = [a - 1 for a in action[:index]]
+
+        observation, reward, done, info = self.env.step(action)
+        if end_of_episode and not done:
+            done = True
+            info["terminal_action"] = True
+
+        return observation, reward, done, info
+
+
+class ConstrainedCommandline(ActionWrapper):
+    """Constrains a Commandline action space to a subset of the original space's
+    flags.
+    """
+
+    def __init__(
+        self, env: CompilerEnv, flags: Iterable[str], name: Optional[str] = None
+    ):
+        """Constructor.
+
+        :param env: The environment to wrap.
+
+        :param flags: A list of entries from :code:`env.action_space.flags`
+            denoting flags that are available in this wrapped environment.
+
+        :param name: The name of the new action space.
+        """
+        super().__init__(env)
+
+        if not flags:
+            raise TypeError("No flags provided")
+        if not isinstance(env.action_space, Commandline):
+            raise TypeError(
+                "Can only wrap Commandline action space. "
+                f"Received: {type(env.action_space).__name__}"
+            )
+
+        self._forward_translation: List[int] = [self.action_space[f] for f in flags]
+        self._reverse_translation: Dict[int, int] = {
+            v: i for i, v in enumerate(self._forward_translation)
+        }
+
+        # Redefine the action space using this smaller set of flags.
+        self.action_space = Commandline(
+            items=[
+                CommandlineFlag(
+                    name=env.action_space.names[a],
+                    flag=env.action_space.flags[a],
+                    description=env.action_space.descriptions[a],
+                )
+                for a in (env.action_space.flags.index(f) for f in flags)
+            ],
+            name=f"{type(self).__name__}<{env.action_space.name}, {len(flags)}>",
+        )
+
+    def action(self, action: Union[int, List[int]]):
+        if isinstance(action, IterableType):
+            return [self._forward_translation[a] for a in action]
+        return self._forward_translation[action]
+
+    def reverse_action(self, action: Union[int, List[int]]):
+        if isinstance(action, IterableType):
+            return [self._reverse_translation[a] for a in action]
+        return self._reverse_translation[action]
+
+    @property
+    def actions(self) -> List[int]:
+        """Reverse-translate actions back into the constrained space."""
+        return self.reverse_action(self.env.actions)

--- a/compiler_gym/wrappers/core.py
+++ b/compiler_gym/wrappers/core.py
@@ -1,0 +1,58 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+from typing import Iterable, Union
+
+import gym
+
+from compiler_gym.envs import CompilerEnv
+from compiler_gym.util.gym_type_hints import ObservationType, StepType
+
+
+class CompilerEnvWrapper(gym.Wrapper):
+    """Wraps a :class:`CompilerEnv <compiler_gym.envs.CompilerEnv>` environment
+    to allow a modular transformation.
+
+    This class is the base class for all wrappers. This class must be used
+    rather than :code:`gym.Wrapper` to support the CompilerGym API extensions
+    such as the :code:`fork()` method.
+    """
+
+    def __init__(self, env: CompilerEnv):
+        """Constructor.
+
+        :param env: The environment to wrap.
+
+        :raises TypeError: If :code:`env` is not a :class:`CompilerEnv
+            <compiler_gym.envs.CompilerEnv>`.
+        """
+        super().__init__(env)
+        if not isinstance(env, CompilerEnv):
+            raise TypeError(
+                "Only a CompilerEnv instance can be wrapped, not "
+                f"an instance of type: '{type(env).__name__}'"
+            )
+
+    def reset(self, *args, **kwargs) -> ObservationType:
+        return self.env.reset(*args, **kwargs)
+
+    def fork(self) -> CompilerEnv:
+        return type(self)(env=self.env.fork())
+
+
+class ActionWrapper(CompilerEnvWrapper):
+    """Wraps a :class:`CompilerEnv <compiler_gym.envs.CompilerEnv>` environment
+    to allow an action space transformation.
+    """
+
+    def step(self, action: Union[int, Iterable[int]]) -> StepType:
+        return self.env.step(self.action(action))
+
+    def action(self, action):
+        """Translate the action to the new space."""
+        raise NotImplementedError
+
+    def reverse_action(self, action):
+        """Translate an action from the new space to the wrapped space."""
+        raise NotImplementedError

--- a/compiler_gym/wrappers/datasets.py
+++ b/compiler_gym/wrappers/datasets.py
@@ -1,0 +1,85 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+from itertools import cycle
+from typing import Iterable, Optional, Union
+
+import numpy as np
+
+from compiler_gym.datasets import Benchmark
+from compiler_gym.envs import CompilerEnv
+from compiler_gym.wrappers.core import CompilerEnvWrapper
+
+BenchmarkArg = Union[str, Benchmark]
+
+
+class IterateOverBenchmarks(CompilerEnvWrapper):
+    """Iterate over a (possibly finite) sequence of benchmarks on each call to
+    reset(). Will raise :code:`StopIteration` on :meth:`reset()
+    <compiler_gym.envs.CompilerEnv.reset>` once the iterator is exhausted. Use
+    :class:`CycleOverBenchmarks` or :class:`RandomOrderBenchmarks` for wrappers
+    which will loop over the benchmarks.
+    """
+
+    def __init__(self, env: CompilerEnv, benchmarks: Iterable[BenchmarkArg]):
+        """Constructor.
+
+        :param env: The environment to wrap.
+
+        :param benchmarks: An iterable sequence of benchmarks.
+        """
+        super().__init__(env)
+        self.benchmarks = iter(benchmarks)
+
+    def reset(self, benchmark: Optional[BenchmarkArg] = None, **kwargs):
+        if benchmark is not None:
+            raise TypeError("Benchmark passed toIterateOverBenchmarks.reset()")
+        benchmark: BenchmarkArg = next(self.benchmarks)
+        return self.env.reset(benchmark=benchmark)
+
+
+class CycleOverBenchmarks(IterateOverBenchmarks):
+    """Cycle through a list of benchmarks on each call to :meth:`reset()
+    <compiler_gym.envs.CompilerEnv.reset>`. Same as
+    :class:`IterateOverBenchmarks` except the list of benchmarks repeats once
+    exhausted.
+    """
+
+    def __init__(
+        self,
+        env: CompilerEnv,
+        benchmarks: Iterable[BenchmarkArg],
+    ):
+        """Constructor.
+
+        :param env: The environment to wrap.
+
+        :param benchmarks: An iterable sequence of benchmarks.
+        """
+        super().__init__(env, benchmarks=cycle(benchmarks))
+
+
+class RandomOrderBenchmarks(IterateOverBenchmarks):
+    """Select randomly from a list of benchmarks on each call to :meth:`reset()
+    <compiler_gym.envs.CompilerEnv.reset>`.
+    """
+
+    def __init__(
+        self,
+        env: CompilerEnv,
+        benchmarks: Iterable[BenchmarkArg],
+        rng: Optional[np.random.Generator] = None,
+    ):
+        """Constructor.
+
+        :param env: The environment to wrap.
+
+        :param benchmarks: An iterable sequence of benchmarks.
+
+        :param rng: A random number generator to use for random benchmark
+            selection.
+        """
+        benchmarks = list(benchmarks)
+        rng = rng or np.random.default_rng()
+        super().__init__(env, benchmarks=(rng.choice(benchmarks) for _ in iter(int, 1)))

--- a/compiler_gym/wrappers/time_limit.py
+++ b/compiler_gym/wrappers/time_limit.py
@@ -1,0 +1,22 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+import gym
+
+from compiler_gym.wrappers.core import CompilerEnvWrapper
+
+
+class TimeLimit(gym.wrappers.TimeLimit, CompilerEnvWrapper):
+    """A step-limited wrapper that is compatible with CompilerGym.
+
+    Example usage:
+
+        >>> env = TimeLimit(env, max_episode_steps=3)
+        >>> env.reset()
+        >>> _, _, done, _ = env.step(0)
+        >>> _, _, done, _ = env.step(0)
+        >>> _, _, done, _ = env.step(0)
+        >>> done
+        True
+    """

--- a/docs/source/compiler_gym/wrappers.rst
+++ b/docs/source/compiler_gym/wrappers.rst
@@ -1,0 +1,58 @@
+compiler_gym.wrappers
+=====================
+
+.. automodule:: compiler_gym.wrappers
+
+.. contents:: Document contents:
+    :local:
+
+.. currentmodule:: compiler_gym.wrappers
+
+
+Base wrappers
+-------------
+
+.. autoclass:: CompilerEnvWrapper
+
+    .. automethod:: __init__
+
+
+.. autoclass:: ActionWrapper
+
+    .. automethod:: action
+
+    .. automethod:: reverse_action
+
+
+Action space wrappers
+---------------------
+
+.. autoclass:: CommandlineWithTerminalAction
+
+    .. automethod:: __init__
+
+
+.. autoclass:: ConstrainedCommandline
+
+    .. automethod:: __init__
+
+
+.. autoclass:: TimeLimit
+
+
+Datasets wrappers
+-----------------
+
+.. autoclass:: IterateOverBenchmarks
+
+    .. automethod:: __init__
+
+
+.. autoclass:: CycleOverBenchmarks
+
+    .. automethod:: __init__
+
+
+.. autoclass:: RandomOrderBenchmarks
+
+    .. automethod:: __init__

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -35,6 +35,7 @@ for applying reinforcement learning to compiler optimizations.
    compiler_gym/service
    compiler_gym/spaces
    compiler_gym/views
+   compiler_gym/wrappers
 
 ..
    TODO(github.com/facebookresearch/CompilerGym/issues/4): Add LLVM Service docs.

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ setuptools.setup(
         "compiler_gym.util.flags",
         "compiler_gym.util",
         "compiler_gym.views",
+        "compiler_gym.wrappers",
         "compiler_gym",
     ],
     package_dir={

--- a/tests/wrappers/BUILD
+++ b/tests/wrappers/BUILD
@@ -1,0 +1,49 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+load("@rules_python//python:defs.bzl", "py_test")
+
+py_test(
+    name = "commandline_wrappers_test",
+    timeout = "short",
+    srcs = ["commandline_wrappers_test.py"],
+    deps = [
+        "//compiler_gym/wrappers",
+        "//tests:test_main",
+        "//tests/pytest_plugins:llvm",
+    ],
+)
+
+py_test(
+    name = "core_wrappers_test",
+    timeout = "short",
+    srcs = ["core_wrappers_test.py"],
+    deps = [
+        "//compiler_gym/wrappers",
+        "//tests:test_main",
+        "//tests/pytest_plugins:llvm",
+    ],
+)
+
+py_test(
+    name = "datasets_wrappers_test",
+    timeout = "short",
+    srcs = ["datasets_wrappers_test.py"],
+    deps = [
+        "//compiler_gym/wrappers",
+        "//tests:test_main",
+        "//tests/pytest_plugins:llvm",
+    ],
+)
+
+py_test(
+    name = "time_limit_wrappers_test",
+    timeout = "short",
+    srcs = ["time_limit_wrappers_test.py"],
+    deps = [
+        "//compiler_gym/wrappers",
+        "//tests:test_main",
+        "//tests/pytest_plugins:llvm",
+    ],
+)

--- a/tests/wrappers/commandline_wrappers_test.py
+++ b/tests/wrappers/commandline_wrappers_test.py
@@ -1,0 +1,56 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Unit tests for //compiler_gym/wrappers."""
+from compiler_gym.envs.llvm import LlvmEnv
+from compiler_gym.wrappers import CommandlineWithTerminalAction, ConstrainedCommandline
+from tests.test_main import main
+
+pytest_plugins = ["tests.pytest_plugins.llvm"]
+
+
+def test_constrained_action_space(env: LlvmEnv):
+    mem2reg_index = env.action_space["-mem2reg"]
+    reg2mem_index = env.action_space["-reg2mem"]
+
+    env = ConstrainedCommandline(env=env, flags=["-mem2reg", "-reg2mem"])
+
+    assert env.action_space.n == 2
+    assert env.action_space.flags == ["-mem2reg", "-reg2mem"]
+
+    assert env.action(0) == mem2reg_index
+    assert env.action([0, 1]) == [mem2reg_index, reg2mem_index]
+
+    env.reset()
+    env.step(0)
+    env.step([1, 1])
+
+    assert env.actions == [0, 1, 1]
+
+
+def test_commandline_with_terminal_action(env: LlvmEnv):
+    mem2reg_unwrapped_index = env.action_space["-mem2reg"]
+
+    env = CommandlineWithTerminalAction(env)
+
+    mem2reg_index = env.action_space["-mem2reg"]
+    reg2mem_index = env.action_space["-reg2mem"]
+
+    assert mem2reg_index == mem2reg_unwrapped_index + 1
+
+    env.reset()
+    _, _, done, info = env.step(mem2reg_index + 1)
+    assert not done, info
+    _, _, done, info = env.step([reg2mem_index + 1, reg2mem_index + 1])
+    assert not done, info
+
+    assert env.actions == [mem2reg_index, reg2mem_index, reg2mem_index]
+
+    _, _, done, info = env.step(0)
+    assert done
+    assert "terminal_action" in info
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/wrappers/core_wrappers_test.py
+++ b/tests/wrappers/core_wrappers_test.py
@@ -1,0 +1,99 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Unit tests for //compiler_gym/wrappers."""
+from compiler_gym.datasets import Datasets
+from compiler_gym.envs.llvm import LlvmEnv
+from compiler_gym.wrappers import ActionWrapper, CompilerEnvWrapper
+from tests.test_main import main
+
+pytest_plugins = ["tests.pytest_plugins.llvm"]
+
+
+def test_wrapped_close(env: LlvmEnv):
+    env = CompilerEnvWrapper(env)
+    env.close()
+    assert env.service is None
+
+
+def test_wrapped_properties(env: LlvmEnv):
+    """Test accessing the non-standard properties."""
+    assert env.actions == []
+    assert env.benchmark
+    assert isinstance(env.datasets, Datasets)
+
+
+def test_wrapped_fork_type(env: LlvmEnv):
+    """Test forking a wrapper."""
+
+    env = CompilerEnvWrapper(env)
+    fkd = env.fork()
+    try:
+        assert isinstance(fkd, CompilerEnvWrapper)
+    finally:
+        fkd.close()
+
+
+def test_wrapped_fork_subtype(env: LlvmEnv):
+    """Test forking a wrapper subtype."""
+
+    class MyWrapper(CompilerEnvWrapper):
+        def __init__(self, env):
+            super().__init__(env)
+
+    env = MyWrapper(env)
+    fkd = env.fork()
+    try:
+        assert isinstance(fkd, MyWrapper)
+    finally:
+        fkd.close()
+
+
+def test_wrapped_fork_subtype_custom_constructor(env: LlvmEnv):
+    """Test forking a wrapper with a custom constructor. This requires a custom
+    fork() implementation."""
+
+    class MyWrapper(CompilerEnvWrapper):
+        def __init__(self, env, foo):
+            super().__init__(env)
+            self.foo = foo
+
+        def fork(self):
+            return MyWrapper(self.env.fork(), foo=self.foo)
+
+    env = MyWrapper(env, foo=1)
+    fkd = env.fork()
+    try:
+        assert isinstance(fkd, MyWrapper)
+        assert fkd.foo == 1
+    finally:
+        fkd.close()
+
+
+def test_wrapped_step_multi_step(env: LlvmEnv):
+    env.reset(benchmark="benchmark://cbench-v1/dijkstra")
+    env.step([0, 0, 0])
+
+    assert env.benchmark == "benchmark://cbench-v1/dijkstra"
+    assert env.actions == [0, 0, 0]
+
+
+def test_wrapped_action(env: LlvmEnv):
+    class MyWrapper(ActionWrapper):
+        def action(self, action):
+            return action - 1
+
+        def reverse_action(self, action):
+            return action + 1
+
+    env = MyWrapper(env)
+    env.reset()
+    env.step(1)
+    env.step(2)
+
+    assert env.actions == [0, 1]
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/wrappers/datasets_wrappers_test.py
+++ b/tests/wrappers/datasets_wrappers_test.py
@@ -1,0 +1,87 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Unit tests for //compiler_gym/wrappers."""
+import pytest
+
+from compiler_gym.envs.llvm import LlvmEnv
+from compiler_gym.wrappers import (
+    CycleOverBenchmarks,
+    IterateOverBenchmarks,
+    RandomOrderBenchmarks,
+)
+from tests.test_main import main
+
+pytest_plugins = ["tests.pytest_plugins.llvm"]
+
+
+def test_iterate_over_benchmarks(env: LlvmEnv):
+    env = IterateOverBenchmarks(
+        env=env,
+        benchmarks=[
+            "benchmark://cbench-v1/crc32",
+            "benchmark://cbench-v1/qsort",
+            "benchmark://cbench-v1/dijkstra",
+        ],
+    )
+
+    env.reset()
+    assert env.benchmark == "benchmark://cbench-v1/crc32"
+    env.reset()
+    assert env.benchmark == "benchmark://cbench-v1/qsort"
+    env.reset()
+    assert env.benchmark == "benchmark://cbench-v1/dijkstra"
+
+    with pytest.raises(StopIteration):
+        env.reset()
+
+
+def test_cycle_over_benchmarks(env: LlvmEnv):
+    env = CycleOverBenchmarks(
+        env=env,
+        benchmarks=[
+            "benchmark://cbench-v1/crc32",
+            "benchmark://cbench-v1/qsort",
+        ],
+    )
+
+    env.reset()
+    assert env.benchmark == "benchmark://cbench-v1/crc32"
+    env.reset()
+    assert env.benchmark == "benchmark://cbench-v1/qsort"
+    env.reset()
+    assert env.benchmark == "benchmark://cbench-v1/crc32"
+    env.reset()
+    assert env.benchmark == "benchmark://cbench-v1/qsort"
+    env.reset()
+    assert env.benchmark == "benchmark://cbench-v1/crc32"
+
+
+def test_random_order_benchmarks(env: LlvmEnv):
+    env = RandomOrderBenchmarks(
+        env=env,
+        benchmarks=[
+            "benchmark://cbench-v1/crc32",
+            "benchmark://cbench-v1/qsort",
+        ],
+    )
+    env.reset()
+    assert env.benchmark in {
+        "benchmark://cbench-v1/crc32",
+        "benchmark://cbench-v1/qsort",
+    }
+    env.reset()
+    assert env.benchmark in {
+        "benchmark://cbench-v1/crc32",
+        "benchmark://cbench-v1/qsort",
+    }
+    env.reset()
+    assert env.benchmark in {
+        "benchmark://cbench-v1/crc32",
+        "benchmark://cbench-v1/qsort",
+    }
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/wrappers/time_limit_wrappers_test.py
+++ b/tests/wrappers/time_limit_wrappers_test.py
@@ -1,0 +1,57 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Unit tests for //compiler_gym/wrappers."""
+from compiler_gym.envs.llvm import LlvmEnv
+from compiler_gym.wrappers import TimeLimit
+
+# from gym.wrappers import TimeLimit
+from tests.test_main import main
+
+pytest_plugins = ["tests.pytest_plugins.llvm"]
+
+
+def test_wrapped_close(env: LlvmEnv):
+    env = TimeLimit(env, max_episode_steps=5)
+    env.close()
+    assert env.service is None
+
+
+def test_wrapped_fork_type(env: LlvmEnv):
+    env = TimeLimit(env, max_episode_steps=5)
+    fkd = env.fork()
+    try:
+        assert isinstance(fkd, TimeLimit)
+    finally:
+        fkd.close()
+
+
+def test_wrapped_step_multi_step(env: LlvmEnv):
+    env = TimeLimit(env, max_episode_steps=5)
+    env.reset(benchmark="benchmark://cbench-v1/dijkstra")
+    env.step([0, 0, 0])
+
+    assert env.benchmark == "benchmark://cbench-v1/dijkstra"
+    assert env.actions == [0, 0, 0]
+
+
+def test_time_limit_reached(env: LlvmEnv):
+    env = TimeLimit(env, max_episode_steps=3)
+
+    env.reset()
+    _, _, done, info = env.step(0)
+    assert not done, info
+    _, _, done, info = env.step(0)
+    assert not done, info
+    _, _, done, info = env.step(0)
+    assert done, info
+    assert info["TimeLimit.truncated"], info
+
+    _, _, done, info = env.step(0)
+    assert done, info
+    assert info["TimeLimit.truncated"], info
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This adds a series of helper wrappers under a new
`compiler_gym.warppers` module that makes it easier to modify the
behavior of CompilerEnv environments without having to change the
underlying implementation.

New classes are:

* `CompilerEnvWrapper` an extension to `gym.Wrapper` to support the
  custom compiler_gym API calls.
* `ActionWrapper` compatibility with `gym.ActionWrapper`.
* `CommandlineWithTerminalAction` adds an "end of episode" action to a
  commandline space.
* `ConstrainedCommandline` allows a subset of commandline flags to be
  selected for use.
* `CycleOverBenchmarks` loop over a list of benchamrks on `reset()`.
* `IterateOverBenchmarks` same as above but the iterator is
  exhaustible.
* `RandomOrderBenchmarks` same as above but the order is random and
  non-terminating.
