### PR TITLE
[util] Catch errors raised by requests library

### DIFF
--- a/compiler_gym/util/download.py
+++ b/compiler_gym/util/download.py
@@ -15,7 +15,7 @@ from compiler_gym.util.runfiles_path import cache_path
 from compiler_gym.util.truncate import truncate
 
 
-class DownloadFailed(OSError):
+class DownloadFailed(IOError):
     """Error thrown if a download fails."""
 
 
@@ -109,7 +109,7 @@ def download(
 
     :return: The contents of the downloaded file.
 
-    :raises OSError: If the download fails, or if the downloaded content does
+    :raises IOError: If the download fails, or if the downloaded content does
         match the expected :code:`sha256` checksum.
     """
     # Convert a singular string into a list of strings.

--- a/compiler_gym/util/download.py
+++ b/compiler_gym/util/download.py
@@ -24,7 +24,12 @@ class TooManyRequests(DownloadFailed):
 
 
 def _get_url_data(url: str) -> bytes:
-    req = requests.get(url)
+    try:
+        req = requests.get(url)
+    except IOError as e:
+        # Re-cast an error raised by requests library to DownloadFailed type.
+        raise DownloadFailed(str(e)) from e
+
     try:
         if req.status_code == 429:
             raise TooManyRequests("429 Too Many Requests")


### PR DESCRIPTION
If `requests.get()` fails, catch it and recast it as a `DownloadFailed` error so that the download can be retried.