### PR TITLE
[examples] Update Actor Critic to use the new wrappers classes.

### DIFF
--- a/compiler_gym/wrappers/core.py
+++ b/compiler_gym/wrappers/core.py
@@ -28,11 +28,6 @@ class CompilerEnvWrapper(gym.Wrapper):
             <compiler_gym.envs.CompilerEnv>`.
         """
         super().__init__(env)
-        if not isinstance(env, CompilerEnv):
-            raise TypeError(
-                "Only a CompilerEnv instance can be wrapped, not "
-                f"an instance of type: '{type(env).__name__}'"
-            )
 
     def reset(self, *args, **kwargs) -> ObservationType:
         return self.env.reset(*args, **kwargs)


### PR DESCRIPTION
There are a new set of wrappers classes that negate the need for a `CustomEnv` in the actor critic example by allowing each of the required transforms to be described by their own wrapper class.