### PR TITLE
[ci] Split the dependency install rules into a reusable action.

### DIFF
--- a/.github/actions/install-build-dependencies/action.yml
+++ b/.github/actions/install-build-dependencies/action.yml
@@ -1,0 +1,28 @@
+---
+name: Install the Linux dependencies
+description: Install build dependencies
+runs:
+    using: composite
+    steps:
+        - name: Install dependencies (linux)
+          run: |
+              if [ "$(uname)" != "Darwin" ]; then
+                  curl -L "https://github.com/bazelbuild/bazelisk/releases/download/v1.6.1/bazelisk-linux-amd64" > bazel
+                  chmod +x bazel
+                  sudo mv bazel /usr/local/bin/bazel
+                  sudo apt-get install clang-9 patchelf
+                  python -m pip install -r compiler_gym/requirements.txt -r examples/requirements.txt -r tests/requirements.txt
+              fi
+          shell: bash
+
+        - name: Install dependencies (macos)
+          run: |
+              if [ "$(uname)" = "Darwin" ]; then
+                  brew install bazelisk zlib
+                  python -m pip install -r compiler_gym/requirements.txt -r examples/requirements.txt -r tests/requirements.txt
+              fi
+          shell: bash
+          env:
+              LDFLAGS: -L/usr/local/opt/zlib/lib
+              CPPFLAGS: -I/usr/local/opt/zlib/include
+              PKG_CONFIG_PATH: /usr/local/opt/zlib/lib/pkgconfig

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,24 +28,8 @@ jobs:
               with:
                   python-version: ${{ matrix.python }}
 
-            - name: Install dependencies (linux)
-              run: |
-                  curl -L "https://github.com/bazelbuild/bazelisk/releases/download/v1.6.1/bazelisk-linux-amd64" > bazel
-                  chmod +x bazel
-                  sudo mv bazel /usr/local/bin/bazel
-                  sudo apt install clang-9 patchelf
-                  python -m pip install -r compiler_gym/requirements.txt -r examples/requirements.txt -r tests/requirements.txt
-              if: matrix.os == 'ubuntu-latest'
-
-            - name: Install dependencies (macOS)
-              run: |
-                  brew install bazelisk zlib
-                  python -m pip install -r compiler_gym/requirements.txt -r examples/requirements.txt -r tests/requirements.txt
-              env:
-                  LDFLAGS: -L/usr/local/opt/zlib/lib
-                  CPPFLAGS: -I/usr/local/opt/zlib/include
-                  PKG_CONFIG_PATH: /usr/local/opt/zlib/lib/pkgconfig
-              if: matrix.os == 'macos-latest'
+            - name: Install build dependencies
+              uses: ./.github/actions/install-build-dependencies
 
             - name: Test
               run: make test
@@ -54,7 +38,6 @@ jobs:
                   CXX: clang++
                   BAZEL_OPTS: --batch
                   BAZEL_TEST_OPTS: --config=ci --test_timeout=300,900,1800,7200
-
 
     install_test:
         runs-on: ${{ matrix.os }}
@@ -73,24 +56,8 @@ jobs:
               with:
                   python-version: ${{ matrix.python }}
 
-            - name: Install dependencies (linux)
-              run: |
-                  curl -L "https://github.com/bazelbuild/bazelisk/releases/download/v1.6.1/bazelisk-linux-amd64" > bazel
-                  chmod +x bazel
-                  sudo mv bazel /usr/local/bin/bazel
-                  sudo apt install clang-9 patchelf
-                  python -m pip install -r compiler_gym/requirements.txt -r examples/requirements.txt -r tests/requirements.txt
-              if: matrix.os == 'ubuntu-latest'
-
-            - name: Install dependencies (macos)
-              run: |
-                  brew install bazelisk zlib
-                  python -m pip install -r compiler_gym/requirements.txt -r examples/requirements.txt -r tests/requirements.txt
-              env:
-                  LDFLAGS: -L/usr/local/opt/zlib/lib
-                  CPPFLAGS: -I/usr/local/opt/zlib/include
-                  PKG_CONFIG_PATH: /usr/local/opt/zlib/lib/pkgconfig
-              if: matrix.os == 'macos-latest'
+            - name: Install build dependencies
+              uses: ./.github/actions/install-build-dependencies
 
             - name: Install
               run: make install

--- a/.github/workflows/fuzz.yaml
+++ b/.github/workflows/fuzz.yaml
@@ -30,20 +30,8 @@ jobs:
               with:
                   python-version: ${{ matrix.python }}
 
-            - name: Install build dependencies (linux)
-              run: |
-                  curl -L "https://github.com/bazelbuild/bazelisk/releases/download/v1.6.1/bazelisk-linux-amd64" > bazel.tmp
-                  sudo mv bazel.tmp /usr/local/bin/bazel
-                  chmod +x /usr/local/bin/bazel
-                  sudo apt install clang-9 patchelf
-                  python -m pip install -r compiler_gym/requirements.txt -r tests/requirements.txt
-              if: matrix.os == 'ubuntu-latest'
-
-            - name: Install build dependencies (macOS)
-              run: |
-                  brew install bazelisk
-                  python -m pip install -r compiler_gym/requirements.txt -r tests/requirements.txt
-              if: matrix.os == 'macos-latest'
+            - name: Install build dependencies
+              uses: ./.github/actions/install-build-dependencies
 
             - name: Install
               run: make install

--- a/.github/workflows/release_test.yaml
+++ b/.github/workflows/release_test.yaml
@@ -26,7 +26,7 @@ jobs:
               with:
                   python-version: ${{ matrix.python }}
 
-            - name: Install dependencies (macos)
+            - name: Install runtime dependencies (macos)
               run: brew install zlib
               if: matrix.os == 'macos-latest'
 


### PR DESCRIPTION
Define a single "install dependencies" action that can be reused by all GitHub Actions workflows.