### PR TITLE
[Makefile] Run `bazel fetch` in a retry loop before build.

### DIFF
--- a/.github/actions/install-build-dependencies/action.yml
+++ b/.github/actions/install-build-dependencies/action.yml
@@ -1,5 +1,5 @@
 ---
-name: Install the Linux dependencies
+name: Install build dependencies
 description: Install build dependencies
 runs:
     using: composite

--- a/Makefile
+++ b/Makefile
@@ -253,10 +253,10 @@ TEST_TARGET ?=
 # Extra command line arguments for pytest.
 PYTEST_ARGS ?=
 
-test:
+test: bazel-fetch
 	$(BAZEL) $(BAZEL_OPTS) test $(BAZEL_TEST_OPTS) $(if $(TEST_TARGET),$(TEST_TARGET),//...)
 
-itest:
+itest: bazel-fetch
 	$(IBAZEL) $(BAZEL_OPTS) test $(BAZEL_TEST_OPTS) $(if $(TEST_TARGET),$(TEST_TARGET),//...)
 
 # Since we can't run compiler_gym from the project root we need to jump through


### PR DESCRIPTION
CI jobs will infrequently fail due to an error during the fetch stage
of bazel. This patch makes the bazel fetch run as a standalone build
step prior to the main package build. It uses a retry loop so that
flaky CI build failures should be less likely.
