### PR TITLE
Reduce size of in-memory benchmark caches

### DIFF
--- a/compiler_gym/envs/compiler_env.py
+++ b/compiler_gym/envs/compiler_env.py
@@ -28,9 +28,9 @@ from compiler_gym.service import (
     ServiceTransportError,
     SessionNotFound,
 )
+from compiler_gym.service.proto import Action, AddBenchmarkRequest
+from compiler_gym.service.proto import Benchmark as BenchmarkProto
 from compiler_gym.service.proto import (
-    Action,
-    AddBenchmarkRequest,
     EndSessionReply,
     EndSessionRequest,
     ForkSessionReply,
@@ -236,6 +236,7 @@ class CompilerEnv(gym.Env):
         # the gap between the user setting the env.benchmark property while in
         # an episode and the next call to env.reset().
         self._benchmark_in_use: Optional[Benchmark] = None
+        self._benchmark_in_use_proto: BenchmarkProto = BenchmarkProto()
         self._next_benchmark: Optional[Benchmark] = None
         # Normally when the benchmark is changed the updated value is not
         # reflected until the next call to reset(). We make an exception for the
@@ -710,8 +711,20 @@ class CompilerEnv(gym.Env):
             self.benchmark = benchmark
         self._benchmark_in_use = self._next_benchmark
 
+        # When always_send_benchmark_on_reset option is enabled, the entire
+        # benchmark program is sent with every StartEpisode request. Otherwise
+        # only the URI of the benchmark is sent. In cases where benchmarks are
+        # reused between calls to reset(), sending the URI is more efficient as
+        # the service can cache the benchmark. In cases where reset() is always
+        # called with a different benchmark, this causes unnecessary roundtrips
+        # as every StartEpisodeRequest receives a FileNotFound response.
+        if self.service.opts.always_send_benchmark_on_reset:
+            self._benchmark_in_use_proto = self._benchmark_in_use.proto
+        else:
+            self._benchmark_in_use_proto.uri = self._benchmark_in_use.uri
+
         start_session_request = StartSessionRequest(
-            benchmark=self._benchmark_in_use.uri,
+            benchmark=self._benchmark_in_use_proto,
             action_space=(
                 [a.name for a in self.action_spaces].index(self.action_space_name)
                 if self.action_space_name

--- a/compiler_gym/envs/compiler_env.py
+++ b/compiler_gym/envs/compiler_env.py
@@ -698,6 +698,7 @@ class CompilerEnv(gym.Env):
 
         # Stop an existing episode.
         if self.in_episode:
+            self.logger.debug("Ending session %d", self._session_id)
             self.service(
                 self.service.stub.EndSession,
                 EndSessionRequest(session_id=self._session_id),

--- a/compiler_gym/envs/llvm/service/Benchmark.cc
+++ b/compiler_gym/envs/llvm/service/Benchmark.cc
@@ -111,17 +111,15 @@ Benchmark::Benchmark(const std::string& name, const Bitcode& bitcode,
     : context_(std::make_unique<llvm::LLVMContext>()),
       module_(makeModuleOrDie(*context_, bitcode, name)),
       baselineCosts_(baselineCosts),
-      name_(name),
-      bitcodeSize_(bitcode.size()) {}
+      name_(name) {}
 
 Benchmark::Benchmark(const std::string& name, std::unique_ptr<llvm::LLVMContext> context,
-                     std::unique_ptr<llvm::Module> module, size_t bitcodeSize,
-                     const fs::path& workingDirectory, const BaselineCosts& baselineCosts)
+                     std::unique_ptr<llvm::Module> module, const fs::path& workingDirectory,
+                     const BaselineCosts& baselineCosts)
     : context_(std::move(context)),
       module_(std::move(module)),
       baselineCosts_(baselineCosts),
-      name_(name),
-      bitcodeSize_(bitcodeSize) {}
+      name_(name) {}
 
 std::unique_ptr<Benchmark> Benchmark::clone(const fs::path& workingDirectory) const {
   Bitcode bitcode;

--- a/compiler_gym/envs/llvm/service/Benchmark.h
+++ b/compiler_gym/envs/llvm/service/Benchmark.h
@@ -71,8 +71,8 @@ class Benchmark {
    * Construct a benchmark from an LLVM module.
    */
   Benchmark(const std::string& name, std::unique_ptr<llvm::LLVMContext> context,
-            std::unique_ptr<llvm::Module> module, size_t bitcodeSize,
-            const boost::filesystem::path& workingDirectory, const BaselineCosts& baselineCosts);
+            std::unique_ptr<llvm::Module> module, const boost::filesystem::path& workingDirectory,
+            const BaselineCosts& baselineCosts);
 
   /**
    * Make a copy of the benchmark.
@@ -101,11 +101,6 @@ class Benchmark {
    * The name of the benchmark.
    */
   inline const std::string& name() const { return name_; }
-
-  /**
-   * The size of the bitcode that was parsed to produce the initial benchmark.
-   */
-  inline const size_t bitcodeSize() const { return bitcodeSize_; }
 
   /**
    * The underlying LLVM module.
@@ -159,8 +154,6 @@ class Benchmark {
   std::unique_ptr<llvm::Module> module_;
   const BaselineCosts baselineCosts_;
   const std::string name_;
-  // The length of the bitcode string for this benchmark.
-  const size_t bitcodeSize_;
 };
 
 }  // namespace compiler_gym::llvm_service

--- a/compiler_gym/envs/llvm/service/BenchmarkFactory.cc
+++ b/compiler_gym/envs/llvm/service/BenchmarkFactory.cc
@@ -106,8 +106,8 @@ Status BenchmarkFactory::addBitcode(const std::string& uri, const Bitcode& bitco
       benchmarks_.erase(iterator);
     }
 
-    VLOG(3) << "Evicted " << evicted << " benchmarks. Bitcode cache size now "
-            << loadedBenchmarksSize_ << ", " << benchmarks_.size() << " bitcodes";
+    VLOG(3) << "Evicted " << evicted << " benchmarks. LLVM cache size now " << loadedBenchmarksSize_
+            << ", " << benchmarks_.size() << " bitcodes";
   }
 
   BaselineCosts baselineCosts;

--- a/compiler_gym/envs/llvm/service/BenchmarkFactory.cc
+++ b/compiler_gym/envs/llvm/service/BenchmarkFactory.cc
@@ -43,7 +43,6 @@ Status BenchmarkFactory::getBenchmark(const BenchmarkProto& benchmarkMessage,
   auto loaded = benchmarks_.find(benchmarkMessage.uri());
   if (loaded != benchmarks_.end()) {
     VLOG(3) << "LLVM benchmark cache hit: " << benchmarkMessage.uri();
-    ;
     *benchmark = loaded->second.clone(workingDirectory_);
     return Status::OK;
   }
@@ -117,6 +116,10 @@ Status BenchmarkFactory::addBitcode(const std::string& uri, const Bitcode& bitco
   benchmarks_.insert({uri, Benchmark(uri, std::move(context), std::move(module), bitcodeSize,
                                      workingDirectory_, baselineCosts)});
   loadedBenchmarksSize_ += bitcodeSize;
+
+  VLOG(2) << "Cached LLVM benchmark " << uri << " (" << bitcodeSize
+          << " bytes). Cache size = " << loadedBenchmarksSize_ << " bytes, " << benchmarks_.size()
+          << " items";
 
   return Status::OK;
 }

--- a/compiler_gym/envs/llvm/service/BenchmarkFactory.h
+++ b/compiler_gym/envs/llvm/service/BenchmarkFactory.h
@@ -30,7 +30,7 @@ namespace compiler_gym::llvm_service {
  * bytes. Once this size is reached, benchmarks are offloaded so that they must
  * be re-read from disk.
  */
-constexpr size_t kMaxLoadedBenchmarkSize = 512 * 1024 * 1024;
+constexpr size_t kMaxLoadedBenchmarkSize = 32 * 1024 * 1024;
 
 /**
  * A factory object for instantiating LLVM modules for use in optimization

--- a/compiler_gym/envs/llvm/service/LlvmSession.cc
+++ b/compiler_gym/envs/llvm/service/LlvmSession.cc
@@ -57,47 +57,6 @@ llvm::TargetLibraryInfoImpl getTargetLibraryInfo(llvm::Module& module) {
   return llvm::TargetLibraryInfoImpl(triple);
 }
 
-void initLlvm() {
-  llvm::InitializeAllTargets();
-  llvm::InitializeAllTargetMCs();
-  llvm::InitializeAllAsmPrinters();
-  llvm::InitializeAllAsmParsers();
-
-  // Initialize passes.
-  llvm::PassRegistry& Registry = *llvm::PassRegistry::getPassRegistry();
-  llvm::initializeCore(Registry);
-  llvm::initializeCoroutines(Registry);
-  llvm::initializeScalarOpts(Registry);
-  llvm::initializeObjCARCOpts(Registry);
-  llvm::initializeVectorization(Registry);
-  llvm::initializeIPO(Registry);
-  llvm::initializeAnalysis(Registry);
-  llvm::initializeTransformUtils(Registry);
-  llvm::initializeInstCombine(Registry);
-  llvm::initializeAggressiveInstCombine(Registry);
-  llvm::initializeInstrumentation(Registry);
-  llvm::initializeTarget(Registry);
-  llvm::initializeExpandMemCmpPassPass(Registry);
-  llvm::initializeScalarizeMaskedMemIntrinPass(Registry);
-  llvm::initializeCodeGenPreparePass(Registry);
-  llvm::initializeAtomicExpandPass(Registry);
-  llvm::initializeRewriteSymbolsLegacyPassPass(Registry);
-  llvm::initializeWinEHPreparePass(Registry);
-  llvm::initializeDwarfEHPreparePass(Registry);
-  llvm::initializeSafeStackLegacyPassPass(Registry);
-  llvm::initializeSjLjEHPreparePass(Registry);
-  llvm::initializePreISelIntrinsicLoweringLegacyPassPass(Registry);
-  llvm::initializeGlobalMergePass(Registry);
-  llvm::initializeIndirectBrExpandPassPass(Registry);
-  llvm::initializeInterleavedAccessPass(Registry);
-  llvm::initializeEntryExitInstrumenterPass(Registry);
-  llvm::initializePostInlineEntryExitInstrumenterPass(Registry);
-  llvm::initializeUnreachableBlockElimLegacyPassPass(Registry);
-  llvm::initializeExpandReductionsPass(Registry);
-  llvm::initializeWasmEHPreparePass(Registry);
-  llvm::initializeWriteBitcodePassPass(Registry);
-}
-
 Status writeBitcodeToFile(const llvm::Module& module, const fs::path& path) {
   std::error_code error;
   llvm::raw_fd_ostream outfile(path.string(), error);
@@ -126,7 +85,6 @@ std::vector<ObservationSpace> LlvmSession::getObservationSpaces() const {
 LlvmSession::LlvmSession(const boost::filesystem::path& workingDirectory)
     : CompilationSession(workingDirectory),
       observationSpaceNames_(util::createPascalCaseToEnumLookupTable<LlvmObservationSpace>()) {
-  initLlvm();
   cpuinfo_initialize();
 }
 

--- a/compiler_gym/envs/llvm/service/RunService.cc
+++ b/compiler_gym/envs/llvm/service/RunService.cc
@@ -4,10 +4,60 @@
 // LICENSE file in the root directory of this source tree.
 #include "compiler_gym/envs/llvm/service/LlvmSession.h"
 #include "compiler_gym/service/runtime/Runtime.h"
+#include "llvm/InitializePasses.h"
+#include "llvm/Support/TargetSelect.h"
 
 const char* usage = R"(LLVM CompilerGym service)";
 
 using namespace compiler_gym::runtime;
 using namespace compiler_gym::llvm_service;
 
-int main(int argc, char** argv) { createAndRunCompilerGymService<LlvmSession>(argc, argv, usage); }
+namespace {
+
+void initLlvm() {
+  llvm::InitializeAllTargets();
+  llvm::InitializeAllTargetMCs();
+  llvm::InitializeAllAsmPrinters();
+  llvm::InitializeAllAsmParsers();
+
+  // Initialize passes.
+  llvm::PassRegistry& Registry = *llvm::PassRegistry::getPassRegistry();
+  llvm::initializeCore(Registry);
+  llvm::initializeCoroutines(Registry);
+  llvm::initializeScalarOpts(Registry);
+  llvm::initializeObjCARCOpts(Registry);
+  llvm::initializeVectorization(Registry);
+  llvm::initializeIPO(Registry);
+  llvm::initializeAnalysis(Registry);
+  llvm::initializeTransformUtils(Registry);
+  llvm::initializeInstCombine(Registry);
+  llvm::initializeAggressiveInstCombine(Registry);
+  llvm::initializeInstrumentation(Registry);
+  llvm::initializeTarget(Registry);
+  llvm::initializeExpandMemCmpPassPass(Registry);
+  llvm::initializeScalarizeMaskedMemIntrinPass(Registry);
+  llvm::initializeCodeGenPreparePass(Registry);
+  llvm::initializeAtomicExpandPass(Registry);
+  llvm::initializeRewriteSymbolsLegacyPassPass(Registry);
+  llvm::initializeWinEHPreparePass(Registry);
+  llvm::initializeDwarfEHPreparePass(Registry);
+  llvm::initializeSafeStackLegacyPassPass(Registry);
+  llvm::initializeSjLjEHPreparePass(Registry);
+  llvm::initializePreISelIntrinsicLoweringLegacyPassPass(Registry);
+  llvm::initializeGlobalMergePass(Registry);
+  llvm::initializeIndirectBrExpandPassPass(Registry);
+  llvm::initializeInterleavedAccessPass(Registry);
+  llvm::initializeEntryExitInstrumenterPass(Registry);
+  llvm::initializePostInlineEntryExitInstrumenterPass(Registry);
+  llvm::initializeUnreachableBlockElimLegacyPassPass(Registry);
+  llvm::initializeExpandReductionsPass(Registry);
+  llvm::initializeWasmEHPreparePass(Registry);
+  llvm::initializeWriteBitcodePassPass(Registry);
+}
+
+}  // anonymous namespace
+
+int main(int argc, char** argv) {
+  initLlvm();
+  createAndRunCompilerGymService<LlvmSession>(argc, argv, usage);
+}

--- a/compiler_gym/service/connection.py
+++ b/compiler_gym/service/connection.py
@@ -82,6 +82,14 @@ class ConnectionOpts(BaseModel):
     rpc_init_max_seconds: float = 3
     """The maximum number of seconds to wait for an RPC connection to establish."""
 
+    always_send_benchmark_on_reset: bool = False
+    """Send the full benchmark program data to the compiler service on ever call
+    to :meth:`env.reset() <compiler_gym.envs.CompilerEnv.reset>`. This is more
+    efficient in cases where the majority of calls to
+    :meth:`env.reset() <compiler_gym.envs.CompilerEnv.reset>` uses a different
+    benchmark. In case of benchmark re-use, leave this :code:`False`.
+    """
+
 
 class ServiceError(Exception):
     """Error raised from the service."""

--- a/compiler_gym/service/proto/compiler_gym_service.proto
+++ b/compiler_gym/service/proto/compiler_gym_service.proto
@@ -59,9 +59,9 @@ message GetVersionReply {
 
 // A StartSession() request.
 message StartSessionRequest {
-  // The name of the benchmark to use for this session. If not provided, a
-  // benchmark is chosen randomly by the service.
-  string benchmark = 1;
+  reserved 1;
+  // The benchmark to use.
+  Benchmark benchmark = 4;
   // An index into the GetSpacesReply.action_space_list selecting the action
   // space that is to be used for this session. Once set, the action space
   // cannot be changed for the duration of the session.
@@ -72,11 +72,10 @@ message StartSessionRequest {
 
 // A StartSession() reply.
 message StartSessionReply {
+  reserved 2;
   // The ID that has been assigned to the session. The client must use this ID
   // in all subsequent interactions with the service for this session.
   int64 session_id = 1;
-  // The name of the benchmark.
-  string benchmark = 2;
   // A new action space. This is set only if, after initializing the session,
   // the action space has changed from the default action space returned by
   // GetSpaces(). If set, the environment should discard the previous action

--- a/compiler_gym/service/runtime/BenchmarkCache.h
+++ b/compiler_gym/service/runtime/BenchmarkCache.h
@@ -16,7 +16,7 @@
 
 namespace compiler_gym::runtime {
 
-constexpr size_t kEvictionSizeInBytes = 512 * 1024 * 1024;
+constexpr size_t kEvictionSizeInBytes = 256 * 1024 * 1024;
 
 /**
  * A cache of Benchmark protocol messages.

--- a/compiler_gym/service/runtime/CompilerGymServiceImpl.h
+++ b/compiler_gym/service/runtime/CompilerGymServiceImpl.h
@@ -57,8 +57,8 @@ grpc::Status CompilerGymService<CompilationSessionType>::StartSession(
   }
 
   const std::lock_guard<std::mutex> lock(sessionsMutex_);
-  VLOG(1) << "StartSession(" << request->benchmark() << "), " << sessionCount()
-          << " active sessions";
+  VLOG(1) << "StartSession(id=" << nextSessionId_ << ", benchmark=" << request->benchmark() << "), "
+          << (sessionCount() + 1) << " active sessions";
 
   const Benchmark* benchmark = benchmarks().get(request->benchmark());
   if (!benchmark) {
@@ -111,7 +111,7 @@ grpc::Status CompilerGymService<CompilationSessionType>::ForkSession(
 template <typename CompilationSessionType>
 grpc::Status CompilerGymService<CompilationSessionType>::EndSession(
     grpc::ServerContext* context, const EndSessionRequest* request, EndSessionReply* reply) {
-  VLOG(1) << "EndSession(" << request->session_id() << "), " << sessionCount() - 1
+  VLOG(1) << "EndSession(id=" << request->session_id() << "), " << sessionCount() - 1
           << " sessions remaining";
 
   const std::lock_guard<std::mutex> lock(sessionsMutex_);

--- a/compiler_gym/service/runtime/compiler_gym_service.py
+++ b/compiler_gym/service/runtime/compiler_gym_service.py
@@ -100,7 +100,12 @@ class CompilerGymService(CompilerGymServiceServicerStub):
             return reply
 
         with self.sessions_lock, exception_to_grpc_status(context):
-            if request.benchmark not in self.benchmarks:
+            # If a benchmark definition was provided, add it.
+            if request.benchmark.program:
+                self.benchmarks[request.benchmark.uri] = request.benchmark
+
+            # Lookup the requested benchmark.
+            if request.benchmark.uri not in self.benchmarks:
                 context.set_code(StatusCode.NOT_FOUND)
                 context.set_details("Benchmark not found")
                 return reply
@@ -108,7 +113,7 @@ class CompilerGymService(CompilerGymServiceServicerStub):
             session = self.compilation_session_type(
                 working_directory=self.working_directory,
                 action_space=self.action_spaces[request.action_space],
-                benchmark=self.benchmarks[request.benchmark],
+                benchmark=self.benchmarks[request.benchmark.uri],
             )
 
             # Generate the initial observations.

--- a/compiler_gym/service/runtime/compiler_gym_service.py
+++ b/compiler_gym/service/runtime/compiler_gym_service.py
@@ -90,8 +90,8 @@ class CompilerGymService(CompilerGymServiceServicerStub):
             "StartSession(id=%d, benchmark=%s), %d active sessions",
             self.next_session_id,
             request.benchmark,
-            len(self.sessions),
-        ) + 1
+            len(self.sessions) + 1,
+        )
         reply = StartSessionReply()
 
         if not request.benchmark:

--- a/compiler_gym/service/runtime/compiler_gym_service.py
+++ b/compiler_gym/service/runtime/compiler_gym_service.py
@@ -86,7 +86,12 @@ class CompilerGymService(CompilerGymServiceServicerStub):
 
     def StartSession(self, request: StartSessionRequest, context) -> StartSessionReply:
         """Create a new compilation session."""
-        logging.debug("StartSession(%s), [%d]", request.benchmark, self.next_session_id)
+        logging.debug(
+            "StartSession(id=%d, benchmark=%s), %d active sessions",
+            self.next_session_id,
+            request.benchmark,
+            len(self.sessions),
+        ) + 1
         reply = StartSessionReply()
 
         if not request.benchmark:
@@ -123,7 +128,7 @@ class CompilerGymService(CompilerGymServiceServicerStub):
     def EndSession(self, request: EndSessionRequest, context) -> EndSessionReply:
         del context  # Unused
         logging.debug(
-            "EndSession(%d), %d sessions remaining",
+            "EndSession(id=%d), %d sessions remaining",
             request.session_id,
             len(self.sessions) - 1,
         )


### PR DESCRIPTION
- Limit the size of the LLVM benchmark cache at 128 items, with random eviction.
- Reduce the size of the in-memory Benchmark protocol buffer cache from 512MB to 256MB.
- Change the type of the `StartSessionRequest.benchmark` field from a string to a Benchmark message.
- Add an `always_send_benchmark_on_reset` option to ConnectionSettings that forces the environment to always send the full Benchmark data to the backend service on every `reset()`. This is useful for cases where benchmarks are rarely repeated, e.g. for training loops with very large datasets.
- Only run LLVM initialization once.
- Some small improvements to service logging.