### PR TITLE
Make wrapper environments compatible with fork()

### DIFF
--- a/compiler_gym/util/BUILD
+++ b/compiler_gym/util/BUILD
@@ -17,6 +17,7 @@ py_library(
         "gym_type_hints.py",
         "logs.py",
         "minimize_trajectory.py",
+        "parallelization.py",
         "registration.py",
         "runfiles_path.py",
         "shell_format.py",

--- a/compiler_gym/util/parallelization.py
+++ b/compiler_gym/util/parallelization.py
@@ -1,0 +1,34 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Utilities for parallelization / threading / concurrency."""
+from itertools import tee
+from threading import Lock
+from typing import Any, Iterable
+
+
+class _ThreadSafeTee:
+    """An extension of :code:`itertools.tee()` that uses a lock to ensure
+    exclusive access to the iterator.
+    """
+
+    def __init__(self, tee_obj, lock):
+        self.tee_obj = tee_obj
+        self.lock = lock
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        with self.lock:
+            return next(self.tee_obj)
+
+    def __copy__(self):
+        return _ThreadSafeTee(self.tee_obj.__copy__(), self.lock)
+
+
+def thread_safe_tee(iterable: Iterable[Any], n: int = 2):
+    """An extension of :code:`itertools.tee()` that yields thread-safe iterators."""
+    lock = Lock()
+    return tuple(_ThreadSafeTee(tee_obj, lock) for tee_obj in tee(iterable, n))

--- a/compiler_gym/wrappers/commandline.py
+++ b/compiler_gym/wrappers/commandline.py
@@ -95,6 +95,7 @@ class ConstrainedCommandline(ActionWrapper):
         :param name: The name of the new action space.
         """
         super().__init__(env)
+        self._flags = flags
 
         if not flags:
             raise TypeError("No flags provided")
@@ -119,7 +120,7 @@ class ConstrainedCommandline(ActionWrapper):
                 )
                 for a in (env.action_space.flags.index(f) for f in flags)
             ],
-            name=f"{type(self).__name__}<{env.action_space.name}, {len(flags)}>",
+            name=f"{type(self).__name__}<{name or env.action_space.name}, {len(flags)}>",
         )
 
     def action(self, action: Union[int, List[int]]):
@@ -136,3 +137,8 @@ class ConstrainedCommandline(ActionWrapper):
     def actions(self) -> List[int]:
         """Reverse-translate actions back into the constrained space."""
         return self.reverse_action(self.env.actions)
+
+    def fork(self) -> "ConstrainedCommandline":
+        return ConstrainedCommandline(
+            env=self.env.fork(), flags=self._flags, name=self.action_space.name
+        )

--- a/compiler_gym/wrappers/datasets.py
+++ b/compiler_gym/wrappers/datasets.py
@@ -9,9 +9,10 @@ import numpy as np
 
 from compiler_gym.datasets import Benchmark
 from compiler_gym.envs import CompilerEnv
+from compiler_gym.util.parallelization import thread_safe_tee
 from compiler_gym.wrappers.core import CompilerEnvWrapper
 
-BenchmarkArg = Union[str, Benchmark]
+BenchmarkLike = Union[str, Benchmark]
 
 
 class IterateOverBenchmarks(CompilerEnvWrapper):
@@ -22,21 +23,53 @@ class IterateOverBenchmarks(CompilerEnvWrapper):
     which will loop over the benchmarks.
     """
 
-    def __init__(self, env: CompilerEnv, benchmarks: Iterable[BenchmarkArg]):
+    def __init__(
+        self,
+        env: CompilerEnv,
+        benchmarks: Iterable[BenchmarkLike],
+        fork_shares_iterator: bool = False,
+    ):
         """Constructor.
 
         :param env: The environment to wrap.
 
         :param benchmarks: An iterable sequence of benchmarks.
+
+        :param fork_shares_iterator: If :code:`True`, the :code:`benchmarks`
+            iterator will bet shared by a forked environment created by
+            :meth:`env.fork() <compiler_gym.envs.CompilerEnv.fork>`. This means
+            that calling :meth:`env.reset()
+            <compiler_gym.envs.CompilerEnv.reset>` with one environment will
+            advance the iterator in the other. If :code:`False`, forked
+            environments will use :code:`itertools.tee()` to create a copy of
+            the iterator so that each iterator may advance independently.
+            However, this requires shared buffers between the environments which
+            can lead to memory overheads if :meth:`env.reset()
+            <compiler_gym.envs.CompilerEnv.reset>` is called many times more in
+            one environment than the other.
         """
         super().__init__(env)
         self.benchmarks = iter(benchmarks)
+        self.fork_shares_iterator = fork_shares_iterator
 
-    def reset(self, benchmark: Optional[BenchmarkArg] = None, **kwargs):
+    def reset(self, benchmark: Optional[BenchmarkLike] = None, **kwargs):
         if benchmark is not None:
             raise TypeError("Benchmark passed toIterateOverBenchmarks.reset()")
-        benchmark: BenchmarkArg = next(self.benchmarks)
+        benchmark: BenchmarkLike = next(self.benchmarks)
         return self.env.reset(benchmark=benchmark)
+
+    def fork(self) -> "IterateOverBenchmarks":
+        if self.fork_shares_iterator:
+            other_benchmarks_iterator = self.benchmarks
+        else:
+            self.benchmarks, other_benchmarks_iterator = thread_safe_tee(
+                self.benchmarks
+            )
+        return IterateOverBenchmarks(
+            env=self.env.fork(),
+            benchmarks=other_benchmarks_iterator,
+            fork_shares_iterator=self.fork_shares_iterator,
+        )
 
 
 class CycleOverBenchmarks(IterateOverBenchmarks):
@@ -49,37 +82,74 @@ class CycleOverBenchmarks(IterateOverBenchmarks):
     def __init__(
         self,
         env: CompilerEnv,
-        benchmarks: Iterable[BenchmarkArg],
+        benchmarks: Iterable[BenchmarkLike],
+        fork_shares_iterator: bool = False,
     ):
         """Constructor.
 
         :param env: The environment to wrap.
 
         :param benchmarks: An iterable sequence of benchmarks.
+
+        :param fork_shares_iterator: If :code:`True`, the :code:`benchmarks`
+            iterator will bet shared by a forked environment created by
+            :meth:`env.fork() <compiler_gym.envs.CompilerEnv.fork>`. This means
+            that calling :meth:`env.reset()
+            <compiler_gym.envs.CompilerEnv.reset>` with one environment will
+            advance the iterator in the other. If :code:`False`, forked
+            environments will use :code:`itertools.tee()` to create a copy of
+            the iterator so that each iterator may advance independently.
+            However, this requires shared buffers between the environments which
+            can lead to memory overheads if :meth:`env.reset()
+            <compiler_gym.envs.CompilerEnv.reset>` is called many times more in
+            one environment than the other.
         """
-        super().__init__(env, benchmarks=cycle(benchmarks))
+        super().__init__(
+            env, benchmarks=cycle(benchmarks), fork_shares_iterator=fork_shares_iterator
+        )
 
 
 class RandomOrderBenchmarks(IterateOverBenchmarks):
     """Select randomly from a list of benchmarks on each call to :meth:`reset()
     <compiler_gym.envs.CompilerEnv.reset>`.
+
+    .. note::
+
+        Uniform random selection is provided by evaluating the input benchmarks
+        iterator into a list and sampling randomly from the list. This will not
+        work for random iteration over infinite or very large iterables of
+        benchmarks.
     """
 
     def __init__(
         self,
         env: CompilerEnv,
-        benchmarks: Iterable[BenchmarkArg],
+        benchmarks: Iterable[BenchmarkLike],
         rng: Optional[np.random.Generator] = None,
     ):
         """Constructor.
 
         :param env: The environment to wrap.
 
-        :param benchmarks: An iterable sequence of benchmarks.
+        :param benchmarks: An iterable sequence of benchmarks. The entirety of
+            this input iterator is evaluated during construction.
 
         :param rng: A random number generator to use for random benchmark
             selection.
         """
-        benchmarks = list(benchmarks)
+        self._all_benchmarks = list(benchmarks)
         rng = rng or np.random.default_rng()
-        super().__init__(env, benchmarks=(rng.choice(benchmarks) for _ in iter(int, 1)))
+        super().__init__(
+            env,
+            benchmarks=(rng.choice(self._all_benchmarks) for _ in iter(int, 1)),
+            fork_shares_iterator=True,
+        )
+
+    def fork(self) -> "IterateOverBenchmarks":
+        """Fork the random order benchmark wrapper.
+
+        Note that RNG state is not copied to forked environments.
+        """
+        return IterateOverBenchmarks(
+            env=self.env.fork(), benchmarks=self._all_benchmarks
+        )

--- a/compiler_gym/wrappers/time_limit.py
+++ b/compiler_gym/wrappers/time_limit.py
@@ -20,3 +20,13 @@ class TimeLimit(gym.wrappers.TimeLimit, CompilerEnvWrapper):
         >>> done
         True
     """
+
+    def fork(self) -> "TimeLimit":
+        """Fork the wrapped environment.
+
+        The time limit state of the forked environment is the same as the source
+        state.
+        """
+        fkd = type(self)(env=self.env.fork(), max_episode_steps=self._max_episode_steps)
+        fkd._elapsed_steps = self._elapsed_steps  # pylint: disable=protected-access
+        return fkd

--- a/tests/util/BUILD
+++ b/tests/util/BUILD
@@ -66,6 +66,16 @@ py_test(
 )
 
 py_test(
+    name = "parallelization_test",
+    timeout = "short",
+    srcs = ["parallelization_test.py"],
+    deps = [
+        "//compiler_gym/util",
+        "//tests:test_main",
+    ],
+)
+
+py_test(
     name = "statistics_test",
     timeout = "short",
     srcs = ["statistics_test.py"],

--- a/tests/util/parallelization_test.py
+++ b/tests/util/parallelization_test.py
@@ -1,0 +1,17 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Unit tests for //compiler_gym/util:parallelization."""
+from compiler_gym.util import parallelization
+from tests.test_main import main
+
+
+def test_thread_safe_tee():
+    a, b = parallelization.thread_safe_tee(range(100))
+    assert next(a) == 0
+    assert next(b) == 0
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/wrappers/commandline_wrappers_test.py
+++ b/tests/wrappers/commandline_wrappers_test.py
@@ -10,25 +10,6 @@ from tests.test_main import main
 pytest_plugins = ["tests.pytest_plugins.llvm"]
 
 
-def test_constrained_action_space(env: LlvmEnv):
-    mem2reg_index = env.action_space["-mem2reg"]
-    reg2mem_index = env.action_space["-reg2mem"]
-
-    env = ConstrainedCommandline(env=env, flags=["-mem2reg", "-reg2mem"])
-
-    assert env.action_space.n == 2
-    assert env.action_space.flags == ["-mem2reg", "-reg2mem"]
-
-    assert env.action(0) == mem2reg_index
-    assert env.action([0, 1]) == [mem2reg_index, reg2mem_index]
-
-    env.reset()
-    env.step(0)
-    env.step([1, 1])
-
-    assert env.actions == [0, 1, 1]
-
-
 def test_commandline_with_terminal_action(env: LlvmEnv):
     mem2reg_unwrapped_index = env.action_space["-mem2reg"]
 
@@ -50,6 +31,64 @@ def test_commandline_with_terminal_action(env: LlvmEnv):
     _, _, done, info = env.step(0)
     assert done
     assert "terminal_action" in info
+
+
+def test_commandline_with_terminal_action_fork(env: LlvmEnv):
+    env = CommandlineWithTerminalAction(env)
+    assert env.unwrapped.action_space != env.action_space  # Sanity check.
+    fkd = env.fork()
+    try:
+        assert fkd.action_space == env.action_space
+
+        _, _, done, info = env.step(0)
+        assert done
+
+        _, _, done, info = fkd.step(0)
+        assert done
+    finally:
+        fkd.close()
+
+
+def test_constrained_action_space(env: LlvmEnv):
+    mem2reg_index = env.action_space["-mem2reg"]
+    reg2mem_index = env.action_space["-reg2mem"]
+
+    env = ConstrainedCommandline(env=env, flags=["-mem2reg", "-reg2mem"])
+
+    assert env.action_space.n == 2
+    assert env.action_space.flags == ["-mem2reg", "-reg2mem"]
+
+    assert env.action(0) == mem2reg_index
+    assert env.action([0, 1]) == [mem2reg_index, reg2mem_index]
+
+    env.reset()
+    env.step(0)
+    env.step([1, 1])
+
+    assert env.actions == [0, 1, 1]
+
+
+def test_constrained_action_space_fork(env: LlvmEnv):
+    mem2reg_index = env.action_space["-mem2reg"]
+    reg2mem_index = env.action_space["-reg2mem"]
+
+    env = ConstrainedCommandline(env=env, flags=["-mem2reg", "-reg2mem"])
+
+    fkd = env.fork()
+    try:
+        assert fkd.action_space.n == 2
+        assert fkd.action_space.flags == ["-mem2reg", "-reg2mem"]
+
+        assert fkd.action(0) == mem2reg_index
+        assert fkd.action([0, 1]) == [mem2reg_index, reg2mem_index]
+
+        fkd.reset()
+        fkd.step(0)
+        fkd.step([1, 1])
+
+        assert fkd.actions == [0, 1, 1]
+    finally:
+        fkd.close()
 
 
 if __name__ == "__main__":

--- a/tests/wrappers/time_limit_wrappers_test.py
+++ b/tests/wrappers/time_limit_wrappers_test.py
@@ -53,5 +53,28 @@ def test_time_limit_reached(env: LlvmEnv):
     assert info["TimeLimit.truncated"], info
 
 
+def test_time_limit_fork(env: LlvmEnv):
+    """Check that the time limit state is copied on fork()."""
+    env = TimeLimit(env, max_episode_steps=3)
+
+    env.reset()
+    _, _, done, info = env.step(0)  # 1st step
+    assert not done, info
+
+    fkd = env.fork()
+    try:
+        _, _, done, info = env.step(0)  # 2nd step
+        assert not done, info
+        _, _, done, info = fkd.step(0)  # 2nd step
+        assert not done, info
+
+        _, _, done, info = env.step(0)  # 3rd step
+        assert done, info
+        _, _, done, info = fkd.step(0)  # 3rd step
+        assert done, info
+    finally:
+        fkd.close()
+
+
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This PR makes all of the environment wrappers defined in `compiler_gym.wrappers` compatible with the `fork()` operator.

Fixes #291.
