### PR TITLE
Service patch set

### DIFF
--- a/compiler_gym/service/connection.py
+++ b/compiler_gym/service/connection.py
@@ -309,6 +309,9 @@ class ManagedConnection(Connection):
         env = os.environ.copy()
         env["COMPILER_GYM_RUNFILES"] = str(runfiles_path("."))
         env["COMPILER_GYM_SITE_DATA"] = str(site_data_path("."))
+        # Set the pythonpath so that executable python scripts can use absolute
+        # import paths like `from compiler_gym.envs.foo import bar`.
+        env["PYTHONPATH"] = env["COMPILER_GYM_RUNFILES"]
 
         # Set the verbosity of the service. The logging level of the service is
         # the debug level - 1, so that COMPILER_GYM_DEBUG=3 will cause VLOG(2)

--- a/compiler_gym/service/connection.py
+++ b/compiler_gym/service/connection.py
@@ -327,7 +327,7 @@ class ManagedConnection(Connection):
             # don't override any existing value so that the user may debug the
             # gRPC backend by setting GRPC_VERBOSITY to ERROR, INFO, or DEBUG.
             if not os.environ.get("GRPC_VERBOSITY"):
-                os.environ["GRPC_VERBOSITY"] = "NONE"
+                env["GRPC_VERBOSITY"] = "NONE"
 
         # Set environment variable COMPILER_GYM_SERVICE_ARGS to pass
         # additional arguments to the service.

--- a/compiler_gym/service/runtime/compiler_gym_service.py
+++ b/compiler_gym/service/runtime/compiler_gym_service.py
@@ -55,6 +55,8 @@ def exception_to_grpc_status(context):  # pragma: no cover
         handle_exception_as(e, StatusCode.FAILED_PRECONDITION)
     except TimeoutError as e:
         handle_exception_as(e, StatusCode.DEADLINE_EXCEEDED)
+    except Exception as e:  # pylint: disable=broad-except
+        handle_exception_as(e, StatusCode.INTERNAL)
 
 
 class CompilerGymService(CompilerGymServiceServicerStub):  # pragma: no cover

--- a/compiler_gym/service/runtime/compiler_gym_service.py
+++ b/compiler_gym/service/runtime/compiler_gym_service.py
@@ -105,7 +105,7 @@ class CompilerGymService(CompilerGymServiceServicerStub):  # pragma: no cover
 
         with self.sessions_lock, exception_to_grpc_status(context):
             # If a benchmark definition was provided, add it.
-            if request.benchmark.program:
+            if request.benchmark.HasField("program"):
                 self.benchmarks[request.benchmark.uri] = request.benchmark
 
             # Lookup the requested benchmark.

--- a/compiler_gym/service/runtime/compiler_gym_service.py
+++ b/compiler_gym/service/runtime/compiler_gym_service.py
@@ -95,7 +95,7 @@ class CompilerGymService(CompilerGymServiceServicerStub):  # pragma: no cover
         logging.debug(
             "StartSession(id=%d, benchmark=%s), %d active sessions",
             self.next_session_id,
-            request.benchmark,
+            request.benchmark.uri,
             len(self.sessions) + 1,
         )
         reply = StartSessionReply()


### PR DESCRIPTION
This PR contains numerous small fixes for the service implementation:

* Sets $PYTHONPATH so that python scripts can be used as services.
* Fixes a logging message format.
* Fixes the benchmark cache hit detector in pyhon.