### PR TITLE
Update Flask API to v2

### DIFF
--- a/www/demo_api.py
+++ b/www/demo_api.py
@@ -121,8 +121,8 @@ class StateToVisualize(BaseModel):
     # Observations that we would like to visualize. This list will grow over
     # time to include graphs and 2-D matrices:
     ir: str
-    instcount: List[int]
-    autophase: List[int]
+    instcount: Dict[str, int]
+    autophase: Dict[str, int]
 
     # The reward signal measures how "good" the previous action was. Over time
     # the sequence of actions that produces the highest cumulative reward is the
@@ -137,18 +137,17 @@ def compute_state(env: CompilerEnv, actions: List[int]) -> StateToVisualize:
         actions=actions,
         observations=[
             env.observation.spaces["Ir"],
-            env.observation.spaces["InstCount"],
-            env.observation.spaces["Autophase"],
+            env.observation.spaces["InstCountDict"],
+            env.observation.spaces["AutophaseDict"],
         ],
         rewards=[env.reward.spaces["IrInstructionCountOz"]],
     )
     return StateToVisualize(
         commandline=env.commandline(),
         done=done,
-        # For the
-        ir=ir[:80],
-        instcount=instcount.tolist()[:5],
-        autophase=autophase.tolist()[:5],
+        ir=ir,
+        instcount=instcount,
+        autophase=autophase,
         codesize_reward=codesize_reward,
     )
 

--- a/www/demo_api.py
+++ b/www/demo_api.py
@@ -1,20 +1,28 @@
 """Demonstration of wrapping CompilerGym in a simple Flask app.
 
-This exposes an API with three operations:
+This exposes an API with four operations:
 
-   1. start() -> session_id, state   (/api/v1/start)
+   1. describe() -> dict  (/api/v2/describe)
+
+        Describe the CompilerGym interface. This generates a list of action
+        names and their numeric values, a list of benchmark datasets and the
+        benchmarks within them, and a list of reward spaces.
+
+   2. start(reward, benchmark) -> session_id, state
+        (/api/v2/start/<reward>/<benchmark>)
 
         Start a session. This would happen when the user navigates to the page
-        in their web browser. One tab = one session. Returns a numeric session
-        ID (this probably isn't the right way of doing things but I don't know
-        any better :-) ). Also returns a state, which is the set of things we
-        want to visualize to represent the current environment state.
+        in their web browser. One tab = one session. Takes a reward space name
+        and a benchmark URI as inputs. Returns a numeric session ID (this
+        probably isn't the right way of doing things but I don't know any better
+        :-) ). Also returns a state, which is the set of things we want to
+        visualize to represent the current environment state.
 
-   2. step(session_id, action) -> state  (/api/v1/<session_id>/<action>)
+   3. step(session_id, action) -> state  (/api/v2/<session_id>/<action>)
 
         Run an action and produce a new state, replacing the old one.
 
-   3. stop(session_id)  (/api/v1/stop/<session_id>)
+   4. stop(session_id)  (/api/v2/stop/<session_id>)
 
         End a session. This would be when the user closes the tab / disconnects.
 
@@ -26,70 +34,99 @@ Then launch it by running, in this directory:
 
     FLASK_APP=demo_api.py flask run
 
-Interact with the API through GET requests. E.g. using curl start a session,
-producing an initial state and a new session ID:
+Interact with the API through GET requests, such as using curl. A "describe"
+endpoint provides details on teh available actions, benchmarks, and rewards.:
 
-    $ curl -s localhost:5000/api/v1/start | jq
+    $ curl -s localhost:5000/api/v2/describe | jq
+    {
+        "actions": {
+            "-adce": 1,
+            ...
+            "-tailcallelim": 122
+        },
+        "benchmarks": {
+            "benchmark://anghabench-v1": [
+                "8cc/extr_buffer.c_buf_append",
+                ...
+                "8cc/extr_buffer.c_quote_cstring_len"
+            ],
+            "benchmark://blas-v0": [
+                ...
+            ],
+            "benchmark://cbench-v1": [
+                "adpcm",
+                ...
+                "jpeg-c"
+            ],
+            ...
+        },
+        "rewards": [
+            "IrInstructionCount",
+            ...
+            "ObjectTextSizeOz"
+        ]
+    }
+
+To start a session, specify a reward space and a benchmark. Note that this
+requires URL-encoding the benchmark name as it contains slashes. e.g. to start a
+new session using reward IrInstructionCountOz and benchmark
+"benchmark://cbench-v1/qsort":
+
+    $ curl -s localhost:5000/api/v2/start/IrInstructionCountOz/benchmark%3A%2F%2Fcbench-v1%2Fqsort | jq
     {
         "session_id": 0,
         "state": {
-            "autophase": [
-                0,
-                4,
-                54,
-                39,
-            12
-            ],
-            "codesize_reward": 0,
+            "autophase": {
+                "ArgsPhi": 10,
+                ...
+                "twoSuccessor": 31
+            },
             "commandline": "opt  input.bc -o output.bc",
             "done": false,
-            "instcount": [
-                638,
-                85,
-                16,
-                6,
-                77
-            ],
-            "ir": "; ModuleID = '-'\nsource_filename = \"-\"\ntarget datalayout = \"e-m:o-p270:32:32-p27"
+            "instcount": {
+                "AShrCount": 0,
+                "AddCount": 9,
+                ...
+                "ZExtCount": 15
+            },
+            "ir": "; ModuleID = '-'\nsource_filename = \"-\"\ntarget ...",
+            "reward": 0
         }
     }
 
 That "state" dict contains the things that we would want to visualize in the
 GUI. Our session ID is 0, lets take a step in this session using action "10":
 
-    $ curl -s localhost:5000/api/v1/step/0/10 | jq
+    $ curl -s localhost:5000/api/v2/step/0/10 | jq
     {
         "state": {
-            "autophase": [
-                0,
-                1,
-                38,
-                26,
-                9
-            ],
-            "codesize_reward": 0.06501547987616099,
+            "autophase": {
+                "ArgsPhi": 2,
+                ..,
+                "twoSuccessor": 29
+            },
             "commandline": "opt -simplifycfg input.bc -o output.bc",
             "done": false,
-            "instcount": [
-                617,
-                67,
-                16,
-                6,
-                59
-            ],
-            "ir": "; ModuleID = '-'\nsource_filename = \"-\"\ntarget datalayout = \"e-m:o-p270:32:32-p27"
+            "instcount": {
+                "AShrCount": 0,
+                ...
+                "ZExtCount": 15
+            },
+            "ir": "; ModuleID = '-'\nsource_filename = \"-\"\ntarget ...",
+            "reward": 0.06501547987616099
         }
     }
 
 Notice that the state dict has changed. Some of the numbers in the "autophase"
-and "instcount" vectors have changed, there is a codesize_reward value, and the
-commandline now includes the flag needed to run action "10" (which turned out to
-be the "-simplifycfg" flag).
+and "instcount" feature dictionary have changed, there is a reward value, and
+the commandline now includes the flag needed to run action "10" (which turned
+out to be the "-simplifycfg" flag).
 
 We could carry on taking steps, or just end the session:
 
-    $ curl -s localhost:5000/api/v1/stop/0
+    $ curl -s localhost:5000/api/v2/stop/0
 """
+from itertools import islice
 from typing import Dict, List
 
 from flask import Flask, jsonify
@@ -127,13 +164,14 @@ class StateToVisualize(BaseModel):
     # The reward signal measures how "good" the previous action was. Over time
     # the sequence of actions that produces the highest cumulative reward is the
     # best:
-    codesize_reward: float
+    reward: float
 
 
 def compute_state(env: CompilerEnv, actions: List[int]) -> StateToVisualize:
-    """Apply a list of actions and produce a new state to visualize."""  # This is where we get the compiler environment to do its thing, and compute
+    """Apply a list of actions and produce a new state to visualize."""
+    # This is where we get the compiler environment to do its thing, and compute
     # for us all of the features that we would like to visualize.
-    (ir, instcount, autophase), (codesize_reward,), done, _ = env.raw_step(
+    (ir, instcount, autophase), (reward,), done, _ = env.raw_step(
         actions=actions,
         observations=[
             env.observation.spaces["Ir"],
@@ -148,15 +186,43 @@ def compute_state(env: CompilerEnv, actions: List[int]) -> StateToVisualize:
         ir=ir,
         instcount=instcount,
         autophase=autophase,
-        codesize_reward=codesize_reward,
+        reward=reward,
     )
 
 
-@app.route("/api/v1/start")
-def start():
-    # For the sake of simplicity we're ignoring the fact that the user may want
-    # to select their own "benchmark" value:
-    env = compiler_gym.make("llvm-v0", benchmark="cbench-v1/qsort")
+@app.route("/api/v2/describe")
+def describe():
+    env = compiler_gym.make("llvm-v0")
+    env.reset()
+    return jsonify(
+        {
+            # A mapping from dataset name to benchmark name. To generate a full
+            # benchmark URI, join the two values with a '/'. E.g. given a benchmark
+            # "qsort" in the dataset "benchmark://cbench-v1", the full URI is
+            # "benchmark://cbench-v1/qsort".
+            "benchmarks": {
+                dataset.name: list(
+                    islice(
+                        (x[len(dataset.name) + 1 :] for x in dataset.benchmark_uris()),
+                        10,
+                    )
+                )
+                for dataset in env.datasets
+            },
+            # A mapping from the name of an action to the numeric value. This
+            # numeric value is what is passed as argument to the step() function.
+            "actions": {k: v for v, k in enumerate(env.action_space.flags)},
+            # A list of reward space names. You select the reward space to use
+            # during start().
+            "rewards": sorted(list(env.reward.spaces.keys())),
+        }
+    )
+
+
+@app.route("/api/v2/start/<reward>/<path:benchmark>")
+def start(reward: str, benchmark: str):
+    env = compiler_gym.make("llvm-v0", benchmark=benchmark)
+    env.reward_space = reward
     env.reset()
     state = compute_state(env, [])
     session_id = len(sessions)
@@ -164,7 +230,7 @@ def start():
     return jsonify({"session_id": session_id, "state": state.dict()})
 
 
-@app.route("/api/v1/stop/<session_id>")
+@app.route("/api/v2/stop/<session_id>")
 def stop(session_id: int):
     session_id = int(session_id)
 
@@ -174,7 +240,7 @@ def stop(session_id: int):
     return jsonify({"session_id": session_id})
 
 
-@app.route("/api/v1/step/<session_id>/<action>")
+@app.route("/api/v2/step/<session_id>/<action>")
 def step(session_id: int, action: int):
     session_id = int(session_id)
     action = int(action)


### PR DESCRIPTION
1. Update all endpoint URL prefixes from `/api/v1` to `/api/v2`.
2. Add a new `/api/v2/describe` endpoint that returns a mapping of action names, a mapping of benchmark names, and a list of reward spaces.
3. Change instcount and autophase feature vectors to dictionaries of named (key, value) pairs. E.g.
```
$ curl -s localhost:5000/api/v2/step/0/10 | jq
{
  "state": {
    "autophase": {
      "ArgsPhi": 2,
      ...
      "twoPred": 20,
      "twoPredOneSuc": 3,
      "twoSuccessor": 29
    },
    ...
}
```
4. Add reward space and benchmark arguments to start(). E.g.
```
$ curl -s localhost:5000/api/v2/start/IrInstructionCountOz/benchmark%3A%2F%2Fcbench-v1%2Fqsort | jq
```
5. Add an `api/v2/undo/<state_id>` endpoint that undoes the most recent action in a session, returning the previous state.