### PR TITLE
Environment wrapper improvements

### DIFF
--- a/compiler_gym/envs/compiler_env.py
+++ b/compiler_gym/envs/compiler_env.py
@@ -488,12 +488,12 @@ class CompilerEnv(gym.Env):
         return self._session_id is not None
 
     @property
-    def observation_space(self) -> Optional[ObservationSpaceSpec]:
+    def observation_space(self) -> Optional[Space]:
         """The observation space that is used to return an observation value in
         :func:`~step()`.
 
-        :getter: Returns the specification of the default observation space, or
-            :code:`None` if not set.
+        :getter: Returns the underlying observation space, or :code:`None` if
+            not set.
         :setter: Set the default observation space.
         """
         if self.observation_space_spec:

--- a/compiler_gym/views/observation_space_spec.py
+++ b/compiler_gym/views/observation_space_spec.py
@@ -123,7 +123,9 @@ class ObservationSpaceSpec:
         def make_scalar(scalar_range, dtype, defaults):
             scalar_range_tuple = _scalar_range2tuple(scalar_range, defaults)
             return Scalar(
-                min=scalar_range_tuple[0], max=scalar_range_tuple[1], dtype=dtype
+                min=dtype(scalar_range_tuple[0]),
+                max=dtype(scalar_range_tuple[1]),
+                dtype=dtype,
             )
 
         def make_seq(scalar_range, dtype, defaults):
@@ -200,7 +202,7 @@ class ObservationSpaceSpec:
         elif shape_type == "scalar_int64_range":
             space = make_scalar(
                 proto.scalar_int64_range,
-                np.int64,
+                int,
                 (np.iinfo(np.int64).min, np.iinfo(np.int64).max),
             )
 
@@ -209,9 +211,7 @@ class ObservationSpaceSpec:
 
             to_string = str
         elif shape_type == "scalar_double_range":
-            space = make_scalar(
-                proto.scalar_double_range, np.float64, (-np.inf, np.inf)
-            )
+            space = make_scalar(proto.scalar_double_range, float, (-np.inf, np.inf))
 
             def translate(observation):
                 return float(observation.scalar_double)

--- a/compiler_gym/wrappers/BUILD
+++ b/compiler_gym/wrappers/BUILD
@@ -18,5 +18,6 @@ py_library(
         "//compiler_gym/datasets",
         "//compiler_gym/envs",
         "//compiler_gym/util",
+        "//compiler_gym/views",
     ],
 )

--- a/compiler_gym/wrappers/core.py
+++ b/compiler_gym/wrappers/core.py
@@ -2,12 +2,14 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-from typing import Iterable, Union
+from typing import Iterable, Optional, Union
 
 import gym
 
 from compiler_gym.envs import CompilerEnv
+from compiler_gym.spaces.reward import Reward
 from compiler_gym.util.gym_type_hints import ObservationType, StepType
+from compiler_gym.views import ObservationSpaceSpec
 
 
 class CompilerEnvWrapper(gym.Wrapper):
@@ -27,7 +29,17 @@ class CompilerEnvWrapper(gym.Wrapper):
         :raises TypeError: If :code:`env` is not a :class:`CompilerEnv
             <compiler_gym.envs.CompilerEnv>`.
         """
-        super().__init__(env)
+        # No call to gym.Wrapper superclass constructor here because we need to
+        # avoid setting the observation_space member variable, which in the
+        # CompilerEnv class is a property with a custom setter. Instead we set
+        # the observation_space_spec directly.
+        self.env = env
+        self.action_space = self.env.action_space
+        self.reward_range = self.env.reward_range
+        self.metadata = self.env.metadata
+
+    def step(self, action, observations=None, rewards=None):
+        return self.env.step(action, observations=observations, rewards=rewards)
 
     def reset(self, *args, **kwargs) -> ObservationType:
         return self.env.reset(*args, **kwargs)
@@ -35,14 +47,47 @@ class CompilerEnvWrapper(gym.Wrapper):
     def fork(self) -> CompilerEnv:
         return type(self)(env=self.env.fork())
 
+    @property
+    def observation_space(self):
+        if self.env.observation_space_spec:
+            return self.env.observation_space_spec.space
+
+    @observation_space.setter
+    def observation_space(
+        self, observation_space: Optional[Union[str, ObservationSpaceSpec]]
+    ) -> None:
+        self.env.observation_space = observation_space
+
+    @property
+    def observation_space_spec(self):
+        return self.env.observation_space_spec
+
+    @observation_space_spec.setter
+    def observation_space_spec(
+        self, observation_space_spec: Optional[ObservationSpaceSpec]
+    ) -> None:
+        self.env.observation_space_spec = observation_space_spec
+
+    @property
+    def reward_space(self) -> Optional[Reward]:
+        return self.env.reward_space
+
+    @reward_space.setter
+    def reward_space(self, reward_space: Optional[Union[str, Reward]]) -> None:
+        self.env.reward_space = reward_space
+
 
 class ActionWrapper(CompilerEnvWrapper):
     """Wraps a :class:`CompilerEnv <compiler_gym.envs.CompilerEnv>` environment
     to allow an action space transformation.
     """
 
-    def step(self, action: Union[int, Iterable[int]]) -> StepType:
-        return self.env.step(self.action(action))
+    def step(
+        self, action: Union[int, Iterable[int]], observations=None, rewards=None
+    ) -> StepType:
+        return self.env.step(
+            self.action(action), observations=observations, rewards=rewards
+        )
 
     def action(self, action):
         """Translate the action to the new space."""
@@ -87,9 +132,10 @@ class RewardWrapper(CompilerEnvWrapper):
         # TODO(cummins): Refactor step() so that we don't have to do this
         # recalculation of episode_reward, as this is prone to errors if, say,
         # the base reward returns NaN or an invalid type.
-        self.unwrapped.episode_reward -= reward
-        reward = self.reward(reward)
-        self.unwrapped.episode_reward += reward
+        if reward is not None and self.episode_reward is not None:
+            self.unwrapped.episode_reward -= reward
+            reward = self.reward(reward)
+            self.unwrapped.episode_reward += reward
         return observation, reward, done, info
 
     def reward(self, reward):

--- a/examples/example_compiler_gym_service/env_tests.py
+++ b/examples/example_compiler_gym_service/env_tests.py
@@ -96,10 +96,10 @@ def test_observation_spaces(env: CompilerEnv):
         size_range=(0, None), dtype=str, opaque_data_format=""
     )
     assert env.observation.spaces["features"].space == Box(
-        shape=(3,), low=-100, high=100, dtype=np.int64
+        shape=(3,), low=-100, high=100, dtype=int
     )
     assert env.observation.spaces["runtime"].space == Scalar(
-        min=0, max=np.inf, dtype=np.float64
+        min=0, max=np.inf, dtype=float
     )
 
 

--- a/tests/wrappers/core_wrappers_test.py
+++ b/tests/wrappers/core_wrappers_test.py
@@ -3,6 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 """Unit tests for //compiler_gym/wrappers."""
+import pytest
+
 from compiler_gym.datasets import Datasets
 from compiler_gym.envs.llvm import LlvmEnv
 from compiler_gym.wrappers import (
@@ -16,34 +18,44 @@ from tests.test_main import main
 pytest_plugins = ["tests.pytest_plugins.llvm"]
 
 
-def test_wrapped_close(env: LlvmEnv):
-    env = CompilerEnvWrapper(env)
+@pytest.fixture(
+    scope="module",
+    params=[ActionWrapper, CompilerEnvWrapper, ObservationWrapper, RewardWrapper],
+)
+def wrapper_type(request):
+    """A test fixture that yields one of the CompilerGym wrapper types."""
+    return request.param
+
+
+def test_wrapped_close(env: LlvmEnv, wrapper_type):
+    env = wrapper_type(env)
     env.close()
     assert env.service is None
 
 
-def test_wrapped_properties(env: LlvmEnv):
+def test_wrapped_properties(env: LlvmEnv, wrapper_type):
     """Test accessing the non-standard properties."""
+    env = wrapper_type(env)
     assert env.actions == []
     assert env.benchmark
     assert isinstance(env.datasets, Datasets)
 
 
-def test_wrapped_fork_type(env: LlvmEnv):
+def test_wrapped_fork_type(env: LlvmEnv, wrapper_type):
     """Test forking a wrapper."""
 
-    env = CompilerEnvWrapper(env)
+    env = wrapper_type(env)
     fkd = env.fork()
     try:
-        assert isinstance(fkd, CompilerEnvWrapper)
+        assert isinstance(fkd, wrapper_type)
     finally:
         fkd.close()
 
 
-def test_wrapped_fork_subtype(env: LlvmEnv):
+def test_wrapped_fork_subtype(env: LlvmEnv, wrapper_type):
     """Test forking a wrapper subtype."""
 
-    class MyWrapper(CompilerEnvWrapper):
+    class MyWrapper(wrapper_type):
         def __init__(self, env):
             super().__init__(env)
 
@@ -55,11 +67,11 @@ def test_wrapped_fork_subtype(env: LlvmEnv):
         fkd.close()
 
 
-def test_wrapped_fork_subtype_custom_constructor(env: LlvmEnv):
+def test_wrapped_fork_subtype_custom_constructor(env: LlvmEnv, wrapper_type):
     """Test forking a wrapper with a custom constructor. This requires a custom
     fork() implementation."""
 
-    class MyWrapper(CompilerEnvWrapper):
+    class MyWrapper(wrapper_type):
         def __init__(self, env, foo):
             super().__init__(env)
             self.foo = foo
@@ -77,11 +89,108 @@ def test_wrapped_fork_subtype_custom_constructor(env: LlvmEnv):
 
 
 def test_wrapped_step_multi_step(env: LlvmEnv):
-    env.reset(benchmark="benchmark://cbench-v1/dijkstra")
+    """Test passing a list of actions to step()."""
+    env = CompilerEnvWrapper(env)
+    env.reset()
     env.step([0, 0, 0])
 
-    assert env.benchmark == "benchmark://cbench-v1/dijkstra"
     assert env.actions == [0, 0, 0]
+
+
+def test_wrapped_step_custom_args(env: LlvmEnv, wrapper_type):
+    """Test passing the custom CompilerGym step() keyword arguments."""
+
+    class MyWrapper(wrapper_type):
+        def observation(self, observation):
+            return observation  # pass thru
+
+        def action(self, action):
+            return action  # pass thru
+
+    env = MyWrapper(env)
+    env.reset()
+    (ir, ic), (icr, icroz), _, _ = env.step(
+        action=[0, 0, 0],
+        observations=["Ir", "IrInstructionCount"],
+        rewards=["IrInstructionCount", "IrInstructionCountOz"],
+    )
+    assert isinstance(ir, str)
+    assert isinstance(ic, int)
+    assert isinstance(icr, float)
+    assert isinstance(icroz, float)
+
+    assert env.unwrapped.observation.spaces["Ir"].space.contains(ir)
+    assert env.unwrapped.observation.spaces["IrInstructionCount"].space.contains(ic)
+
+
+def test_wrapped_benchmark(env: LlvmEnv, wrapper_type):
+    """Test that benchmark property has expected values."""
+
+    class MyWrapper(wrapper_type):
+        def observation(self, observation):
+            return observation  # pass thru
+
+    env.observation_space = "Ir"
+    env = MyWrapper(env)
+
+    ir_a = env.reset(benchmark="benchmark://cbench-v1/dijkstra")
+    assert env.benchmark == "benchmark://cbench-v1/dijkstra"
+
+    ir_b = env.reset(benchmark="benchmark://cbench-v1/qsort")
+    assert env.benchmark == "benchmark://cbench-v1/qsort"
+
+    # Check that the observations for different benchmarks are different.
+    assert ir_a != ir_b
+
+
+def test_wrapped_env_in_episode(env: LlvmEnv, wrapper_type):
+    class MyWrapper(wrapper_type):
+        def observation(self, observation):
+            return observation
+
+    env = MyWrapper(env)
+    assert not env.in_episode
+
+    env.reset()
+    assert env.in_episode
+
+
+def test_wrapped_env_changes_default_spaces(env: LlvmEnv, wrapper_type):
+    """Test when an environment wrapper changes the default observation and reward spaces."""
+
+    class MyWrapper(wrapper_type):
+        def __init__(self, env: LlvmEnv):
+            super().__init__(env)
+            self.env.observation_space = "Autophase"
+            self.env.reward_space = "IrInstructionCount"
+
+        def observation(self, observation):
+            return observation  # pass thru
+
+    env = MyWrapper(env)
+    assert env.observation_space.shape == (56,)
+    assert env.observation_space_spec.id == "Autophase"
+    assert env.reward_space.id == "IrInstructionCount"
+
+    observation = env.reset()
+    assert env.observation_space.contains(observation)
+
+
+def test_wrapped_env_change_spaces(env: LlvmEnv, wrapper_type):
+    """Test changing the observation and reward spaces on a wrapped environment."""
+
+    class MyWrapper(wrapper_type):
+        def observation(self, observation):
+            return observation  # pass thru
+
+    env = MyWrapper(env)
+
+    env.observation_space = "Autophase"
+    env.reward_space = "IrInstructionCount"
+
+    assert env.observation_space.shape == (56,)
+    assert env.observation_space_spec.id == "Autophase"
+    assert env.reward_space.id == "IrInstructionCount"
 
 
 def test_wrapped_action(env: LlvmEnv):
@@ -101,16 +210,27 @@ def test_wrapped_action(env: LlvmEnv):
 
 
 def test_wrapped_observation(env: LlvmEnv):
-    class MyWrapper(ObservationWrapper):
-        def observation(self, observation):
-            return isinstance(observation, str)
-            return len(str)
+    """Test using an ObservationWrapper that returns the length of the Ir string."""
 
-    env.observation_space = "Ir"
+    class MyWrapper(ObservationWrapper):
+        def __init__(self, env):
+            super().__init__(env)
+            self.observation_space = "Ir"
+
+        def observation(self, observation):
+            return len(observation)
+
     env = MyWrapper(env)
     assert env.reset() > 0
     observation, _, _, _ = env.step(0)
     assert observation > 0
+
+
+def test_wrapped_observation_missing_definition(env: LlvmEnv):
+
+    env = ObservationWrapper(env)
+    with pytest.raises(NotImplementedError):
+        env.reset()
 
 
 def test_wrapped_reward(env: LlvmEnv):


### PR DESCRIPTION
Fix numerous incompatibility bugs discovered through more rigorous unit testing:

- Add support for custom kwargs to `env.step()`.
- Add support for changing default observation and reward spaces in wrapped environments.
- Fix type annotation for `env.observation_space`.