### PR TITLE
Fix libLLVMPolly link for custom C++ binaries.

### DIFF
--- a/compiler_gym/third_party/autophase/BUILD
+++ b/compiler_gym/third_party/autophase/BUILD
@@ -5,7 +5,7 @@
 #
 # Autophase https://github.com/ucb-bar/autophase
 load("@rules_python//python:defs.bzl", "py_library")
-load("@rules_cc//cc:defs.bzl", "cc_library")
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 
 py_library(
     name = "autophase",
@@ -27,8 +27,21 @@ cc_library(
     ],
 )
 
+filegroup(
+    name = "compute_autophase-files",
+    srcs = [
+        ":compute_autophase",
+    ] + select({
+        "@llvm//:darwin": [],
+        "//conditions:default": [
+            ":libLLVMPolly",
+        ],
+    }),
+    visibility = ["//visibility:public"],
+)
+
 cc_binary(
-    name = "compute_autophase",
+    name = "compute_autophase-prelinked",
     srcs = ["compute_autophase.cc"],
     copts = [
         "-DGOOGLE_PROTOBUF_NO_RTTI",
@@ -40,4 +53,32 @@ cc_binary(
         "@glog",
         "@llvm//10.0.0",
     ],
+)
+
+genrule(
+    name = "compute_autophase-bin",
+    srcs = [":compute_autophase-prelinked"],
+    outs = ["compute_autophase"],
+    cmd = select({
+        "@llvm//:darwin": (
+            "cp $(location :compute_autophase-prelinked) $@"
+        ),
+        "//conditions:default": (
+            "cp $(location :compute_autophase-prelinked) $@ && " +
+            "chmod 666 $@ && " +
+            "patchelf --set-rpath '$$ORIGIN' $@ && " +
+            "chmod 555 $@"
+        ),
+    }),
+)
+
+genrule(
+    name = "libLLVMPolly",
+    srcs = [
+        "@clang-llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04//:all_files",
+        "@clang-llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04//:clang",
+    ],
+    outs = ["libLLVMPolly.so"],
+    cmd = "cp $$(dirname $(location @clang-llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04//:clang))/../lib/LLVMPolly.so $@",
+    visibility = ["//visibility:public"],
 )

--- a/compiler_gym/third_party/llvm/BUILD
+++ b/compiler_gym/third_party/llvm/BUILD
@@ -3,6 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 load("@rules_python//python:defs.bzl", "py_library")
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 
 py_library(
     name = "llvm",
@@ -13,8 +14,21 @@ py_library(
     ],
 )
 
+filegroup(
+    name = "compute_ir_instruction_count-files",
+    srcs = [
+        ":compute_ir_instruction_count",
+    ] + select({
+        "@llvm//:darwin": [],
+        "//conditions:default": [
+            ":libLLVMPolly",
+        ],
+    }),
+    visibility = ["//visibility:public"],
+)
+
 cc_binary(
-    name = "compute_ir_instruction_count",
+    name = "compute_ir_instruction_count-prelinked",
     srcs = ["compute_ir_instruction_count.cc"],
     copts = [
         "-DGOOGLE_PROTOBUF_NO_RTTI",
@@ -25,6 +39,34 @@ cc_binary(
         "@glog",
         "@llvm//10.0.0",
     ],
+)
+
+genrule(
+    name = "compute_ir_instruction_count-bin",
+    srcs = [":compute_ir_instruction_count-prelinked"],
+    outs = ["compute_ir_instruction_count"],
+    cmd = select({
+        "@llvm//:darwin": (
+            "cp $(location :compute_ir_instruction_count-prelinked) $@"
+        ),
+        "//conditions:default": (
+            "cp $(location :compute_ir_instruction_count-prelinked) $@ && " +
+            "chmod 666 $@ && " +
+            "patchelf --set-rpath '$$ORIGIN' $@ && " +
+            "chmod 555 $@"
+        ),
+    }),
+)
+
+genrule(
+    name = "libLLVMPolly",
+    srcs = [
+        "@clang-llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04//:all_files",
+        "@clang-llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04//:clang",
+    ],
+    outs = ["libLLVMPolly.so"],
+    cmd = "cp $$(dirname $(location @clang-llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04//:clang))/../lib/LLVMPolly.so $@",
+    visibility = ["//visibility:public"],
 )
 
 py_library(


### PR DESCRIPTION
This adds the same patch-elf tricky that is employed by the LLVM
service to the other C++ binaries that link against LLVM.
