### PR TITLE
[llvm] Add support for accessing ProGraML as JSON.

### DIFF
--- a/compiler_gym/envs/llvm/service/LlvmSession.cc
+++ b/compiler_gym/envs/llvm/service/LlvmSession.cc
@@ -331,7 +331,8 @@ Status LlvmSession::computeObservation(LlvmObservationSpace space, Observation& 
       *reply.mutable_int64_list()->mutable_value() = {features.begin(), features.end()};
       break;
     }
-    case LlvmObservationSpace::PROGRAML: {
+    case LlvmObservationSpace::PROGRAML:
+    case LlvmObservationSpace::PROGRAML_JSON: {
       // Build the ProGraML graph.
       programl::ProgramGraph graph;
       auto status =

--- a/compiler_gym/envs/llvm/service/ObservationSpaces.cc
+++ b/compiler_gym/envs/llvm/service/ObservationSpaces.cc
@@ -102,6 +102,21 @@ std::vector<ObservationSpace> getLlvmObservationSpaceList() {
         *space.mutable_default_value()->mutable_string_value() = nodeLinkGraph.dump();
         break;
       }
+      case LlvmObservationSpace::PROGRAML_JSON: {
+        // ProGraML serializes the graph to JSON.
+        ScalarRange encodedSize;
+        encodedSize.mutable_min()->set_value(0);
+        space.set_opaque_data_format("json://");
+        *space.mutable_string_size_range() = encodedSize;
+        space.set_deterministic(true);
+        space.set_platform_dependent(false);
+        programl::ProgramGraph graph;
+        json nodeLinkGraph;
+        CHECK(programl::graph::format::ProgramGraphToNodeLinkGraph(graph, &nodeLinkGraph).ok())
+            << "Failed to serialize default ProGraML graph";
+        *space.mutable_default_value()->mutable_string_value() = nodeLinkGraph.dump();
+        break;
+      }
       case LlvmObservationSpace::CPU_INFO: {
         // Hardware info is returned as a JSON
         ScalarRange encodedSize;

--- a/compiler_gym/envs/llvm/service/ObservationSpaces.h
+++ b/compiler_gym/envs/llvm/service/ObservationSpaces.h
@@ -45,7 +45,7 @@ enum class LlvmObservationSpace {
    */
   AUTOPHASE,
   /**
-   * Returns the graph representation of a program.
+   * Returns the graph representation of a program as a networkx Graph.
    *
    * From:
    *
@@ -54,6 +54,16 @@ enum class LlvmObservationSpace {
    *     and Analysis. ArXiv:2003.10536. https://arxiv.org/abs/2003.10536
    */
   PROGRAML,
+  /**
+   * Returns the graph representation of a program as a JSON node-link graph.
+   *
+   * From:
+   *
+   *     Cummins, C., Fisches, Z. V., Ben-Nun, T., Hoefler, T., & Leather, H.
+   *     (2020). ProGraML: Graph-based Deep Learning for Program Optimization
+   *     and Analysis. ArXiv:2003.10536. https://arxiv.org/abs/2003.10536
+   */
+  PROGRAML_JSON,
   /** A JSON dictionary of properties describing the CPU. */
   CPU_INFO,
   /** The number of LLVM-IR instructions in the current module. */

--- a/tests/llvm/observation_spaces_test.py
+++ b/tests/llvm/observation_spaces_test.py
@@ -48,6 +48,7 @@ def test_observation_spaces(env: LlvmEnv):
         "Autophase",
         "AutophaseDict",
         "Programl",
+        "ProgramlJson",
         "CpuInfo",
         "Inst2vecPreprocessedText",
         "Inst2vecEmbeddingIndices",
@@ -384,6 +385,15 @@ def test_programl_observation_space(env: LlvmEnv):
 
     assert space.deterministic
     assert not space.platform_dependent
+
+
+def test_programl_json_observation_space(env: LlvmEnv):
+    env.reset("cbench-v1/crc32")
+    key = "ProgramlJson"
+    space = env.observation.spaces[key]
+    assert isinstance(space.space, Sequence)
+    graph: Dict[str, Any] = env.observation[key]
+    assert isinstance(graph, dict)
 
 
 def test_cpuinfo_observation_space(env: LlvmEnv):


### PR DESCRIPTION
This adds a new ProgramlJson observation space that bypasses the
networkx graph construction and instead returns the raw node link data
for ProGraML graphs:

```py
>>> import compiler_gym
>>> env = compiler_gym.make("llvm-v0")
>>> env.reset()
>>> env.observation.ProgramlJson()
...
{'block': 60,
 'features': {'full_text': ['store i32 %182, i32* %17, align 4, !tbaa !4']},
 'function': 13,
 'id': 995,
 'text': 'store',
 'type': 0},
{'block': 60,
 'features': {'full_text': ['i32 %182']},
 'function': 13,
 'id': 996,
 'text': 'i32',
 'type': 1},
{'block': 60,
 'features': {'full_text': ['i32* %17']},
 'function': 13,
 'id': 997,
 'text': 'i32*',
 'type': 1},
{'block': 60,
 'features': {'full_text': ['br label %183']},
 'function': 13,
 'id': 998,
 'text': 'br',
 'type': 0},
{'block': 61,
 'features': {'full_text': ['%184 = load i8*, i8** %9, align 8, !tbaa !0']},
 'function': 13,
 'id': 999,
 'text': 'load',
 'type': 0},
...]}
```