### PR TITLE
[www] Truncate very-large IR strings.

### DIFF
--- a/www/demo_api.py
+++ b/www/demo_api.py
@@ -139,6 +139,7 @@ from pydantic import BaseModel
 
 import compiler_gym
 from compiler_gym import CompilerEnv
+from compiler_gym.util.truncate import truncate
 
 app = Flask("compiler_gym")
 CORS(app)
@@ -195,7 +196,7 @@ def compute_state(env: CompilerEnv, actions: List[int]) -> StateToVisualize:
     return StateToVisualize(
         commandline=env.commandline(),
         done=done,
-        ir=ir,
+        ir=truncate(ir, max_line_len=250, max_lines=1024),
         instcount=instcount,
         autophase=autophase,
         reward=reward,


### PR DESCRIPTION
Limit the size of the IR string to ~256kB of data.
