### PR TITLE
Add ObservationView to reward reset() arguments

### DIFF
--- a/compiler_gym/envs/compiler_env.py
+++ b/compiler_gym/envs/compiler_env.py
@@ -793,7 +793,7 @@ class CompilerEnv(gym.Env):
                 self.action_space.name, reply.new_action_space.action
             )
 
-        self.reward.reset(benchmark=self.benchmark)
+        self.reward.reset(benchmark=self.benchmark, observation_view=self.observation)
         if self.reward_space:
             self.episode_reward = 0.0
 

--- a/compiler_gym/envs/llvm/llvm_rewards.py
+++ b/compiler_gym/envs/llvm/llvm_rewards.py
@@ -36,9 +36,10 @@ class CostFunctionReward(Reward):
         self.init_cost_function: str = init_cost_function
         self.previous_cost: Optional[ObservationType] = None
 
-    def reset(self, benchmark: Benchmark) -> None:
+    def reset(self, benchmark: Benchmark, observation_view: ObservationView) -> None:
         """Called on env.reset(). Reset incremental progress."""
         del benchmark  # unused
+        del observation_view  # unused
         self.previous_cost = None
 
     def update(
@@ -68,9 +69,9 @@ class NormalizedReward(CostFunctionReward):
         self.cost_norm: Optional[ObservationType] = None
         self.benchmark: Benchmark = None
 
-    def reset(self, benchmark: str) -> None:
+    def reset(self, benchmark: str, observation_view: ObservationView) -> None:
         """Called on env.reset(). Reset incremental progress."""
-        super().reset(benchmark)
+        super().reset(benchmark, observation_view)
         # The benchmark has changed so we must compute a new cost normalization
         # value. If the benchmark has not changed then the previously computed
         # value is still valid.

--- a/compiler_gym/spaces/reward.py
+++ b/compiler_gym/spaces/reward.py
@@ -6,6 +6,7 @@ from typing import List, Optional, Tuple, Union
 
 import numpy as np
 
+import compiler_gym
 from compiler_gym.spaces.scalar import Scalar
 from compiler_gym.util.gym_type_hints import ObservationType, RewardType
 
@@ -88,12 +89,15 @@ class Reward(Scalar):
         self.deterministic = deterministic
         self.platform_dependent = platform_dependent
 
-    def reset(self, benchmark: str) -> None:
+    def reset(
+        self, benchmark: str, observation_view: "compiler_gym.views.ObservationView"
+    ) -> None:
         """Reset the rewards space. This is called on
         :meth:`env.reset() <compiler_gym.envs.CompilerEnv.reset>`.
 
         :param benchmark: The URI of the benchmark that is used for this
             episode.
+        :param observation: An observation view for reward initialization
         """
         pass
 
@@ -153,7 +157,7 @@ class DefaultRewardFromObservation(Reward):
         )
         self.previous_value: Optional[ObservationType] = None
 
-    def reset(self, benchmark: str) -> None:
+    def reset(self, benchmark: str, observation_view) -> None:
         """Called on env.reset(). Reset incremental progress."""
         del benchmark  # unused
         self.previous_value = None

--- a/compiler_gym/views/reward.py
+++ b/compiler_gym/views/reward.py
@@ -60,7 +60,7 @@ class RewardView:
         observations = [self._observation_view[obs] for obs in space.observation_spaces]
         return space.update(self.previous_action, observations, self._observation_view)
 
-    def reset(self, benchmark: Benchmark) -> None:
+    def reset(self, benchmark: Benchmark, observation_view: ObservationView) -> None:
         """Reset the rewards space view. This is called on
         :meth:`env.reset() <compiler_gym.envs.CompilerEnv.reset>`.
 
@@ -68,7 +68,7 @@ class RewardView:
         """
         self.previous_action = None
         for space in self.spaces.values():
-            space.reset(benchmark=benchmark)
+            space.reset(benchmark=benchmark, observation_view=observation_view)
 
     def add_space(self, space: Reward) -> None:
         """Register a new :class:`Reward <compiler_gym.spaces.Reward>` space.

--- a/examples/example_compiler_gym_service/__init__.py
+++ b/examples/example_compiler_gym_service/__init__.py
@@ -36,7 +36,7 @@ class RuntimeReward(Reward):
         )
         self.previous_runtime = None
 
-    def reset(self, benchmark: str):
+    def reset(self, benchmark: str, observation_view):
         del benchmark  # unused
         self.previous_runtime = None
 


### PR DESCRIPTION
This PR will enable a Reward's reset method to inspect the observation_view of the environment.  For loop_tool this means it can grab the `flops` observation space.