### PR TITLE
Integrate www into packaging scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,9 @@ Deployment
         Run the `make install-test` suite against the build artifact generated
         by `make bdist_wheel-linux`.
 
+	make www
+		Run a local instance of the web visualization service. See www/README.md
+		for details.
 
 Tidying up
 -----------
@@ -198,6 +201,14 @@ all: docs bdist_wheel bdist_wheel-linux
 
 .PHONY: bazel-fetch bazel-build bdist_wheel bdist_wheel-linux bdist_wheel-linux-shell bdist_wheel-linux-test
 
+#################
+# Web interface #
+#################
+
+www:
+	cd www && $(PYTHON) run.py
+
+.PHONY: www
 
 #################
 # Documentation #

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@
 -r examples/requirements.txt
 -r requirements_pre_commit.txt
 -r tests/requirements.txt
+-r www/requirements.txt

--- a/www/requirements.txt
+++ b/www/requirements.txt
@@ -1,0 +1,2 @@
+Flask==2.0.1
+Flask-Cors==3.0.10

--- a/www/run.py
+++ b/www/run.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+#
+# Script to launch the backend Flask server and frontend server. Usage:
+#
+#     python run.py
+import os
+import subprocess
+import sys
+from time import sleep
+
+os.environ["FLASK_APP"] = "demo_api.py"
+p = subprocess.Popen(["flask", "run"])
+try:
+    for _ in range(5):
+        sleep(0.5)
+        if p.poll() is not None:
+            print("Failed to start python server", file=sys.stderr)
+            sys.exit(1)
+    os.chdir("frontends/compiler_gym")
+    subprocess.check_call(["npm", "install"])
+    subprocess.check_call(["npm", "start"])
+finally:
+    p.terminate()


### PR DESCRIPTION
* Add Flask to the python dependencies that are installed by `make init`.
* Add a new script `www/run.py` which launches the Flask API and frontend service in a single command.
* Add a `make www` target which runs the above script.