### PR TITLE
[docs] Add a new "Environments" section to docs.

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,13 +8,18 @@ for applying reinforcement learning to compiler optimizations.
    :caption: User Guide
 
    getting_started
-   llvm/index
    cli
    about
    rpc
    changelog
    contributing
    faq
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Environments
+
+   llvm/index
 
 ..
     .. toctree::


### PR DESCRIPTION
Adds a new top-level section to the documentation. This is to make room for new documentation pages for the GCC environment reference (#314) and loop_tool (#298).

![image](https://user-images.githubusercontent.com/1636663/129938307-5b60ff0d-6410-4e59-9636-bf47e77aa3ce.png)