### PR TITLE
[www] Make the Flask API stateless.

### DIFF
--- a/www/www.py
+++ b/www/www.py
@@ -4,142 +4,72 @@
 # LICENSE file in the root directory of this source tree.
 """A CompilerGym API and web frontend.
 
-This exposes an API with five operations:
+This exposes an API with two operations:
 
-   1. describe() -> dict  (/api/v3/describe)
+   1. /api/v4/describe
 
         Describe the CompilerGym interface. This generates a list of action
         names and their numeric values, a list of benchmark datasets and the
         benchmarks within them, and a list of reward spaces.
 
-   2. start(reward, actions, benchmark) -> session_id, state[]
-        (/api/v3/start/<reward>/<actions>/<benchmark>)
+        Example usage:
 
-        Start a session. This would happen when the user navigates to the page
-        in their web browser. One tab = one session. Takes a reward space name,
-        a list of actions, and a benchmark URI as inputs. If no actions are to
-        be performed, use "-". Returns a numeric session ID (this probably isn't
-        the right way of doing things but I don't know any better :-) ). Also
-        returns a list of states, which is the set of things we want to
-        visualize to represent the current environment state. There is an
-        initial state, and then one state for each action.
-
-   3. step(session_id, actions) -> state[]  (/api/v3/<session_id>/<actions>)
-
-        Run a list of actions and produce a list of states, replacing the old
-        ones.
-
-   4. undo(session_id, n) -> state  (/api/v3/<session_id>/undo/<n>)
-
-        Undo `n` previous actions, returning the previous state.
-
-   5. stop(session_id)  (/api/v3/stop/<session_id>)
-
-        End a session. This would be when the user closes the tab / disconnects.
-
-To run this script, install the python dependencies using:
-
-    pip install flask compiler_gym pydantic
-
-Then launch it by running, in this directory:
-
-    FLASK_APP=demo_api.py flask run
-
-Interact with the API through GET requests, such as using curl. A "describe"
-endpoint provides details on teh available actions, benchmarks, and rewards.:
-
-    $ curl -s localhost:5000/api/v3/describe | jq
-    {
-        "actions": {
-            "-adce": 1,
-            ...
-            "-tailcallelim": 122
-        },
-        "benchmarks": {
-            "benchmark://anghabench-v1": [
-                "8cc/extr_buffer.c_buf_append",
-                ...
-                "8cc/extr_buffer.c_quote_cstring_len"
-            ],
-            "benchmark://blas-v0": [
-                ...
-            ],
-            "benchmark://cbench-v1": [
-                "adpcm",
-                ...
-                "jpeg-c"
-            ],
-            ...
-        },
-        "rewards": [
-            "IrInstructionCount",
-            ...
-            "ObjectTextSizeOz"
-        ]
-    }
-
-To start a session, specify a reward space and a benchmark. Note that this
-requires URL-encoding the benchmark name as it contains slashes. e.g. to start a
-new session using reward IrInstructionCountOz and benchmark
-"benchmark://cbench-v1/qsort":
-
-    $ curl -s localhost:5000/api/v3/start/IrInstructionCountOz/benchmark%3A%2F%2Fcbench-v1%2Fqsort | jq
-    {
-        "session_id": 0,
-        "states": [
+            $ curl localhost:5000/api/v4/describe
             {
-                "autophase": {
-                    "ArgsPhi": 10,
+                "actions": {
+                    "-adce": 1,
                     ...
-                    "twoSuccessor": 31
+                    "-tailcallelim": 122
                 },
-                "commandline": "opt  input.bc -o output.bc",
-                "done": false,
-                "instcount": {
-                    "AShrCount": 0,
-                    "AddCount": 9,
+                "benchmarks": {
+                    "benchmark://anghabench-v1": [
+                        "8cc/extr_buffer.c_buf_append",
+                        ...
+                        "8cc/extr_buffer.c_quote_cstring_len"
+                    ],
+                    "benchmark://blas-v0": [
+                        ...
+                    ],
+                    "benchmark://cbench-v1": [
+                        "adpcm",
+                        ...
+                        "jpeg-c"
+                    ],
                     ...
-                    "ZExtCount": 15
                 },
-                "ir": "; ModuleID = '-'\nsource_filename = \"-\"\ntarget ...",
-                "reward": 0
+                "rewards": [
+                    "IrInstructionCount",
+                    ...
+                    "ObjectTextSizeOz"
+                ]
             }
-        ]
-    }
 
-That "state" dict contains the things that we would want to visualize in the
-GUI. Our session ID is 0, lets take a step in this session using action "10":
+   2. /ap/v4/step
 
-    $ curl -s localhost:5000/api/v3/step/0/10 | jq
-    {
-        "states": [
+        Compute the state from the given environment description. Query
+        arguments:
+
+            benchmark: The name of the benchmark.
+
+            reward: The name of the reward signal to use.
+
+            actions: An optional, command-separated list of actions to run.
+
+            all_rewards: An optional string that if "1" means that a list of
+                all rewards will be returned, one for each action. Else, only
+                the reward for the final action is returned.
+
+        Example usage:
+
+            $ curl 'localhost:5000/api/v4/step?benchmark=benchmark://cbench-v1/adpcm&reward=IrInstructionCountOz&actions=1,2,3'
             {
-                "autophase": {
-                    "ArgsPhi": 2,
-                    ..,
-                    "twoSuccessor": 29
-                },
-                "commandline": "opt -simplifycfg input.bc -o output.bc",
+                "commandline": "opt - ...",
+                "rewards": [0.003],
                 "done": false,
-                "instcount": {
-                    "AShrCount": 0,
-                    ...
-                    "ZExtCount": 15
-                },
-                "ir": "; ModuleID = '-'\nsource_filename = \"-\"\ntarget ...",
-                "reward": 0.06501547987616099
+                "ir": "...",
+                "instcount": {...},
+                "autophase": {...},
             }
-        ]
-    }
-
-Notice that the state dict has changed. Some of the numbers in the "autophase"
-and "instcount" feature dictionary have changed, there is a reward value, and
-the commandline now includes the flag needed to run action "10" (which turned
-out to be the "-simplifycfg" flag).
-
-We could carry on taking steps, or just end the session:
-
-    $ curl -s localhost:5000/api/v3/stop/0
 """
 import logging
 import os
@@ -147,16 +77,15 @@ import re
 import sys
 from itertools import islice
 from pathlib import Path
-from threading import Lock, Thread
-from time import sleep, time
-from typing import Dict, List, Tuple
+from threading import Lock
+from typing import Any, Dict, List
 
-from flask import Flask, jsonify, send_file
+from flask import Flask, jsonify, request, send_file
 from flask_cors import CORS
 from pydantic import BaseModel
 
 import compiler_gym
-from compiler_gym import CompilerEnv
+from compiler_gym.envs import LlvmEnv
 from compiler_gym.util.truncate import truncate
 
 app = Flask("compiler_gym")
@@ -167,11 +96,13 @@ resource_dir: Path = (Path(__file__).parent / "frontends/compiler_gym/build").ab
 
 logger = logging.getLogger(__name__)
 
+# A single compiler environment that is used to serve all endpoints.
+env: LlvmEnv = compiler_gym.make("llvm-v0")
+env_lock = Lock()
+
 
 class StateToVisualize(BaseModel):
-    """Encapsulates everything we want to visualize in the frontend. This
-    will change from step to step.
-    """
+    """Encapsulates the state to visualize in the frontend."""
 
     # This summarizes the sequence of actions that the user has selected so far:
     commandline: str
@@ -190,58 +121,12 @@ class StateToVisualize(BaseModel):
     # The reward signal measures how "good" the previous action was. Over time
     # the sequence of actions that produces the highest cumulative reward is the
     # best:
-    reward: float
+    rewards: List[float]
 
 
-class Session(BaseModel):
-    states: List[Tuple[CompilerEnv, StateToVisualize]]
-    last_use: float  # As returned by time().
-
-    def close(self):
-        for env, _ in self.states:
-            env.close()
-
-    class Config:
-        arbitrary_types_allowed = True
-
-
-# A set of sessions that are in use, keyed by a numeric session ID. Each session
-# is represented by a list of (environment, state) tuples, whether the
-# environment is a CompilerGym environment and the state is a StateToVisualize.
-# Initially, a session consists of a single (environment, state) tuple. When an
-# action is taken, this generates a new (environment, state) tuple that is
-# appended the session list. In this way, undoing an operation is as simple as
-# popping the most recent (environment, state) tuple from the list.
-sessions: Dict[int, Session] = {}
-sessions_lock = Lock()
-
-
-def compute_state(env: CompilerEnv, actions: List[int]) -> StateToVisualize:
-    """Apply a list of actions and produce a new state to visualize."""
-    # This is where we get the compiler environment to do its thing, and compute
-    # for us all of the features that we would like to visualize.
-    (ir, instcount, autophase), (reward,), done, _ = env.raw_step(
-        actions=actions,
-        observations=[
-            env.observation.spaces["Ir"],
-            env.observation.spaces["InstCountDict"],
-            env.observation.spaces["AutophaseDict"],
-        ],
-        rewards=[env.reward_space],
-    )
-    return StateToVisualize(
-        commandline=env.commandline(),
-        done=done,
-        ir=truncate(ir, max_line_len=250, max_lines=1024),
-        instcount=instcount,
-        autophase=autophase,
-        reward=reward,
-    )
-
-
-@app.route("/api/v3/describe")
+@app.route("/api/v4/describe")
 def describe():
-    with compiler_gym.make("llvm-v0") as env:
+    with env_lock:
         env.reset()
         return jsonify(
             {
@@ -271,90 +156,75 @@ def describe():
         )
 
 
-@app.route("/api/v3/start/<reward>/<actions>/<path:benchmark>")
-def start(reward: str, actions: str, benchmark: str):
-    # FIXME(cummins): Workaround unusual bug where the requested benchmark URI
-    # uses a :/ separateor instead of ://.
-    benchmark = re.sub(":/([^/])", r"://\1", benchmark)
-    env = compiler_gym.make("llvm-v0", benchmark=benchmark)
-    env.reward_space = reward
-    env.reset()
-    state = compute_state(env, [])
-    with sessions_lock:
-        session_id = len(sessions)
-        session = Session(states=[(env, state)], last_use=time())
-        sessions[session_id] = session
+def _step(
+    benchmark: str, reward: str, actions: List[int], reward_history: bool
+) -> StateToVisualize:
+    rewards = []
 
-    # Accept an optional comma-separated list of actions to compute and return.
-    if actions != "-":
-        step(session_id, actions)
+    with env_lock:
+        env.reward_space = reward
+        env.reset()
 
-    return jsonify(
-        {
-            "session_id": session_id,
-            "states": [state.dict() for _, state in session.states],
-        }
+        # Replay all actions except the last one.
+        if reward_history:
+            # Replay actions one at a time to receive incremental rewards. The first
+            # reward represents the state prior to any actions.
+            rewards.append(0)
+            for action in actions[:-1]:
+                _, reward, done, info = env.step(action)
+                rewards.append(reward)
+                if done:
+                    raise ValueError(
+                        f"Failed to apply action {action}: {info['error_details']}"
+                    )
+        else:
+            # Replay actions in a single batch.
+            _, _, done, info = env.step(actions[:-1])
+            if done:
+                raise ValueError(
+                    f"Failed to apply actions {actions}: {info['error_details']}"
+                )
+
+        # Perform the final action.
+        (ir, instcount, autophase), (reward,), done, _ = env.raw_step(
+            actions=actions[-1:],
+            observations=[
+                env.observation.spaces["Ir"],
+                env.observation.spaces["InstCountDict"],
+                env.observation.spaces["AutophaseDict"],
+            ],
+            rewards=[env.reward_space],
+        )
+
+    rewards.append(reward)
+    return StateToVisualize(
+        commandline=env.commandline(),
+        done=done,
+        ir=truncate(ir, max_line_len=250, max_lines=1024),
+        instcount=instcount,
+        autophase=autophase,
+        rewards=rewards,
     )
 
 
-@app.route("/api/v3/stop/<session_id>")
-def stop(session_id: int):
-    session_id = int(session_id)
+@app.route("/api/v4/step")
+def step() -> Dict[str, Any]:
+    actions_str: str = request.args.get("actions")
+    benchmark: str = request.args.get("benchmark")
+    reward: str = request.args.get("reward")
+    reward_history: bool = request.args.get("reward_history", "0") == "1"
 
-    session = sessions[session_id]
-    session.close()
-    with sessions_lock:
-        del sessions[session_id]
+    try:
+        actions: List[int] = (
+            [int(x) for x in actions_str.split(",")] if actions_str else []
+        )
+    except ValueError as e:
+        return jsonify({"error": f"Invalid actions: {e}"}), 400
 
-    return jsonify({"session_id": session_id})
-
-
-@app.route("/api/v3/step/<session_id>/<actions>")
-def step(session_id: int, actions: str):
-    session_id = int(session_id)
-
-    state_dicts = []
-    session = sessions[session_id]
-    for action in [int(a) for a in actions.split(",")]:
-        new_env = session.states[-1][0].fork()
-        new_state = compute_state(new_env, [action])
-        session.states.append((new_env, new_state))
-        state_dicts.append(new_state.dict())
-
-    session.last_use = time()
-    return jsonify({"states": state_dicts})
-
-
-@app.route("/api/v3/undo/<session_id>/<n>")
-def undo(session_id: int, n: int):
-    session_id = int(session_id)
-    n = int(n)
-
-    session = sessions[session_id]
-    for _ in range(min(n, len(session.states))):
-        env, _ = session.states.pop()
-        env.close()
-    _, old_state = session.states[-1]
-
-    session.last_use = time()
-    return jsonify({"state": old_state.dict()})
-
-
-def idle_session_watchdog(ttl_seconds: int = 1200):
-    """Background thread to perform periodic garbage collection of sessions
-    that haven't been used in `ttl_seconds` seconds.
-    """
-    while True:
-        session_ids_to_remove = []
-        for session_id, session in sessions.items():
-            if session.last_use + ttl_seconds < time():
-                session_ids_to_remove.append(session_id)
-        with sessions_lock:
-            for session_id in session_ids_to_remove:
-                sessions[session_id].close()
-                del sessions[session_id]
-        logger.info("Garbage collected %d sessions", len(session_ids_to_remove))
-        sleep(ttl_seconds)
+    try:
+        return jsonify(_step(benchmark, reward, actions, reward_history).dict())
+    except Exception as e:
+        return jsonify({"error": str(e)}), 400
 
 
 # Web endpoints.
@@ -391,5 +261,4 @@ if __name__ == "__main__":
     logger.addHandler(handler)
 
     logger.info("Serving from %s", resource_dir)
-    Thread(target=idle_session_watchdog).start()
     app.run(port=int(os.environ.get("PORT", "5000")), host="0.0.0.0")


### PR DESCRIPTION
Replace the start/end/undo/step endpoints with a single "step"
function that takes all of the variables needed to describe an
environment state (then benchmark, reward signal, and full actions
history).

This replaces the session-based API which is error prone and hard to
scale. Note that this new stateless API is only a proof-of-concept
implementation, as on every "step" it replays an entire episode. In
the future we will change this to maintain a pool of live environments
that can be used to serve stateless API requests more efficiently.

This new stateless API has two endpoints:

 ### /api/v4/describe

Unchanged from v3. Describe the CompilerGym interface. This generates a list of action
names and their numeric values, a list of benchmark datasets and the
benchmarks within them, and a list of reward spaces.

Example usage:

    $ curl localhost:5000/api/v4/describe
    {
        "actions": {
            "-adce": 1,
            ...
            "-tailcallelim": 122
        },
        "benchmarks": {
            "benchmark://anghabench-v1": [
                "8cc/extr_buffer.c_buf_append",
                ...
                "8cc/extr_buffer.c_quote_cstring_len"
            ],
            "benchmark://blas-v0": [
                ...
            ],
            "benchmark://cbench-v1": [
                "adpcm",
                ...
                "jpeg-c"
            ],
            ...
        },
        "rewards": [
            "IrInstructionCount",
            ...
            "ObjectTextSizeOz"
        ]
    }

### /ap/v4/step

Compute the state from the given environment description. Query arguments:

* benchmark: The name of the benchmark.
* reward: The name of the reward signal to use.
* actions: An optional, command-separated list of actions to run.
* all_rewards: An optional string that if "1" means that a list of
all rewards will be returned, one for each action. Else, only
the reward for the final action is returned.

Example usage:

    $ curl 'localhost:5000/api/v4/step?benchmark=benchmark://cbench-v1/adpcm&reward=IrInstructionCountOz&actions=1,2,3'
    {
        "commandline": "opt - ...",
        "rewards": [0.003],
        "done": false,
        "ir": "...",
        "instcount": {...},
        "autophase": {...},
    }

Issue #366.