### PR TITLE
[www] Update the version of the tar package.

### DIFF
--- a/www/frontends/compiler_gym/package-lock.json
+++ b/www/frontends/compiler_gym/package-lock.json
@@ -5651,7 +5651,7 @@
         "promise-inflight": "^1.0.1",
         "rimraf": "^3.0.2",
         "ssri": "^8.0.1",
-        "tar": "^6.0.2",
+        "tar": "^6.1.9",
         "unique-filename": "^1.1.1"
       },
       "engines": {


### PR DESCRIPTION
https://github.com/npm/node-tar/security/advisories/GHSA-r628-mhmh-qjhw
