### PR TITLE
[llvm] Fix LLVM environment init when C++ compiler is not installed.

### DIFF
--- a/compiler_gym/envs/llvm/llvm_benchmark.py
+++ b/compiler_gym/envs/llvm/llvm_benchmark.py
@@ -3,6 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 """This module defines a utility function for constructing LLVM benchmarks."""
+import logging
 import os
 import random
 import subprocess
@@ -33,25 +34,31 @@ def _communicate(process, input=None, timeout=None):
         raise
 
 
-def _get_system_includes() -> Iterable[Path]:
+def get_compiler_includes(compiler: str) -> Iterable[Path]:
     """Run the system compiler in verbose mode on a dummy input to get the
     system header search path.
     """
-    system_compiler = os.environ.get("CXX", "c++")
     # Create a temporary directory to write the compiled 'binary' to, since
     # GNU assembler does not support piping to stdout.
     with tempfile.TemporaryDirectory() as d:
-        process = subprocess.Popen(
-            [system_compiler, "-xc++", "-v", "-c", "-", "-o", str(Path(d) / "a.out")],
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.PIPE,
-            stdin=subprocess.PIPE,
-            universal_newlines=True,
-        )
+        try:
+            process = subprocess.Popen(
+                [compiler, "-xc++", "-v", "-c", "-", "-o", str(Path(d) / "a.out")],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.PIPE,
+                stdin=subprocess.PIPE,
+                universal_newlines=True,
+            )
+        except FileNotFoundError as e:
+            raise OSError(
+                f"Failed to invoke {compiler}. "
+                f"Is there a working system compiler?\n"
+                f"Error: {e}"
+            ) from e
         _, stderr = _communicate(process, input="", timeout=30)
     if process.returncode:
         raise OSError(
-            f"Failed to invoke {system_compiler}. "
+            f"Failed to invoke {compiler}. "
             f"Is there a working system compiler?\n"
             f"Error: {stderr.strip()}"
         )
@@ -80,7 +87,7 @@ def _get_system_includes() -> Iterable[Path]:
             in_search_list = True
     else:
         raise OSError(
-            f"Failed to parse '#include <...>' search paths from {system_compiler}:\n"
+            f"Failed to parse '#include <...>' search paths from {compiler}:\n"
             f"{stderr.strip()}"
         )
 
@@ -103,7 +110,11 @@ def get_system_includes() -> List[Path]:
     # Memoize the system includes paths.
     global _SYSTEM_INCLUDES
     if _SYSTEM_INCLUDES is None:
-        _SYSTEM_INCLUDES = list(_get_system_includes())
+        system_compiler = os.environ.get("CXX", "c++")
+        try:
+            _SYSTEM_INCLUDES = list(get_compiler_includes(system_compiler))
+        except OSError as e:
+            logging.warning("%s", e)
     return _SYSTEM_INCLUDES
 
 

--- a/tests/llvm/custom_benchmarks_test.py
+++ b/tests/llvm/custom_benchmarks_test.py
@@ -290,30 +290,26 @@ def test_two_custom_benchmarks_reset(env: LlvmEnv):
     assert env.benchmark == benchmark2.uri
 
 
-def test_get_system_includes_nonzero_exit_status():
+def test_get_compiler_includes_not_found():
+    with pytest.raises(OSError) as ctx:
+        list(llvm.llvm_benchmark.get_compiler_includes("not-a-real-binary"))
+    assert "Failed to invoke not-a-real-binary" in str(ctx.value)
+
+
+def test_get_compiler_includes_nonzero_exit_status():
     """Test that setting the $CXX to an invalid binary raises an error."""
-    old_cxx = os.environ.get("CXX")
-    os.environ["CXX"] = "false"
-    try:
-        with pytest.raises(OSError) as ctx:
-            list(
-                llvm.llvm_benchmark._get_system_includes()  # pylint: disable=protected-access
-            )
-        assert "Failed to invoke false" in str(ctx.value)
-    finally:
-        if old_cxx:
-            os.environ["CXX"] = old_cxx
+    with pytest.raises(OSError) as ctx:
+        list(llvm.llvm_benchmark.get_compiler_includes("false"))
+    assert "Failed to invoke false" in str(ctx.value)
 
 
-def test_get_system_includes_output_parse_failure():
+def test_get_compiler_includes_output_parse_failure():
     """Test that setting the $CXX to an invalid binary raises an error."""
     old_cxx = os.environ.get("CXX")
     os.environ["CXX"] = "echo"
     try:
         with pytest.raises(OSError) as ctx:
-            list(
-                llvm.llvm_benchmark._get_system_includes()  # pylint: disable=protected-access
-            )
+            list(llvm.llvm_benchmark.get_compiler_includes("echo"))
         assert "Failed to parse '#include <...>' search paths from echo" in str(
             ctx.value
         )


### PR DESCRIPTION
Issue #360.
