### PR TITLE
Improved error reporting from ObservationView.__getitem__().

### DIFF
--- a/tests/views/observation_test.py
+++ b/tests/views/observation_test.py
@@ -16,8 +16,8 @@ from compiler_gym.views import ObservationView
 from tests.test_main import main
 
 
-class MockGetObservation:
-    """Mock for the get_observation callack of ObservationView."""
+class MockRawStep:
+    """Mock for the raw_step callack of ObservationView."""
 
     def __init__(self, ret=None):
         self.called_observation_spaces = []
@@ -35,7 +35,7 @@ class MockGetObservation:
 
 def test_empty_space():
     with pytest.raises(ValueError) as ctx:
-        ObservationView(MockGetObservation(), [])
+        ObservationView(MockRawStep(), [])
     assert str(ctx.value) == "No observation spaces"
 
 
@@ -73,7 +73,7 @@ def test_observed_value_types():
             ),
         ),
     ]
-    mock = MockGetObservation(
+    mock = MockRawStep(
         ret=[
             "Hello, IR",
             [1.0, 2.0],


### PR DESCRIPTION
This patch improves the error reporting when computing an observation fails. First, if the service produces an unexpected number of observations, a ServiceError is raised, rather than the previous assertion. Second, if the environment reports that it has reached a terminal state, a ServiceError is raised, containing the error details produced by the environment. 