### PR TITLE
[wrappers] Add a mutex-locked environment wrapper.

### DIFF
--- a/compiler_gym/wrappers/BUILD
+++ b/compiler_gym/wrappers/BUILD
@@ -11,6 +11,7 @@ py_library(
         "commandline.py",
         "core.py",
         "datasets.py",
+        "locked_step.py",
         "time_limit.py",
     ],
     visibility = ["//visibility:public"],

--- a/compiler_gym/wrappers/__init__.py
+++ b/compiler_gym/wrappers/__init__.py
@@ -19,6 +19,7 @@ from compiler_gym.wrappers.datasets import (
     IterateOverBenchmarks,
     RandomOrderBenchmarks,
 )
+from compiler_gym.wrappers.locked_step import LockedStep
 from compiler_gym.wrappers.time_limit import TimeLimit
 
 __all__ = [
@@ -28,6 +29,7 @@ __all__ = [
     "ConstrainedCommandline",
     "CycleOverBenchmarks",
     "IterateOverBenchmarks",
+    "LockedStep",
     "ObservationWrapper",
     "RandomOrderBenchmarks",
     "RewardWrapper",

--- a/compiler_gym/wrappers/locked_step.py
+++ b/compiler_gym/wrappers/locked_step.py
@@ -1,0 +1,52 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+from threading import Lock
+from typing import Optional
+
+from compiler_gym.envs import CompilerEnv
+from compiler_gym.util.gym_type_hints import ObservationType, StepType
+from compiler_gym.wrappers.core import CompilerEnvWrapper
+
+_GLOBAL_STEP_LOCK = Lock()
+
+
+class LockedStep(CompilerEnvWrapper):
+    """A wrapper that protects environment operations with a thread lock.
+
+    This class is used to prevent the :code:`step()`, :code:`reset()`, and
+    :code:`fork()` methods of multiple compiler environments from executing
+    simultaneously. It does this by sharing acquiring a thread lock during these
+    operations which is shared between all instances of this wrapped class.
+
+    Example usage:
+
+        >>> envs = [compiler_gym.make("llvm-v0") for _ in range(10)]
+        >>> threads = [threading.Thread(target=run, args=(env,)) for env in envs]
+        >>> [t.start() for t in threads]
+    """
+
+    def __init__(self, env: CompilerEnv, lock: Optional[Lock] = None):
+        """Constructor.
+
+        :param env: The environment to wrap.
+
+        :param lock: The thread lock to acquire when performing an operation.
+            If not provided, a default lock is used and shared.
+        """
+        super().__init__(env)
+        self.lock = lock or _GLOBAL_STEP_LOCK
+
+    def reset(self, *args, **kwargs) -> ObservationType:
+        with self.lock:
+            return self.env.reset(*args, **kwargs)
+
+    def step(self, *args, **kwargs) -> StepType:
+        with self.lock:
+            return self.env.step(*args, **kwargs)
+
+    def fork(self):
+        with self.lock:
+            fkd = self.env.fork()
+            return LockedStep(env=fkd, lock=self.lock)

--- a/docs/source/compiler_gym/wrappers.rst
+++ b/docs/source/compiler_gym/wrappers.rst
@@ -66,3 +66,11 @@ Datasets wrappers
 .. autoclass:: RandomOrderBenchmarks
 
     .. automethod:: __init__
+
+
+Miscellaneous
+-------------
+
+.. autoclass:: LockedStep
+
+    .. automethod:: __init__

--- a/tests/wrappers/BUILD
+++ b/tests/wrappers/BUILD
@@ -38,6 +38,17 @@ py_test(
 )
 
 py_test(
+    name = "locked_step_test",
+    timeout = "short",
+    srcs = ["locked_step_test.py"],
+    deps = [
+        "//compiler_gym/wrappers",
+        "//tests:test_main",
+        "//tests/pytest_plugins:llvm",
+    ],
+)
+
+py_test(
     name = "time_limit_wrappers_test",
     timeout = "short",
     srcs = ["time_limit_wrappers_test.py"],

--- a/tests/wrappers/locked_step_test.py
+++ b/tests/wrappers/locked_step_test.py
@@ -1,0 +1,74 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Unit tests for compiler_gym.wrappers.locked_step."""
+from compiler_gym.envs.llvm import LlvmEnv
+from compiler_gym.wrappers import LockedStep
+from tests.test_main import main
+
+pytest_plugins = ["tests.pytest_plugins.llvm"]
+
+
+class MockLock:
+    def __init__(self):
+        self.acquire_count = 0
+        self.release_count = 0
+
+    def acquire(self):
+        self.acquire_count += 1
+
+    def release(self):
+        self.release_count += 1
+
+    def __enter__(self):
+        self.acquire()
+
+    def __exit__(self, *args):
+        self.release()
+
+
+def test_wrapped_acquire_count(env: LlvmEnv):
+    lock = MockLock()
+
+    env = LockedStep(env, lock=lock)
+
+    env.reset()
+    assert lock.acquire_count == 1
+    assert lock.release_count == 1
+
+    env.step(env.action_space.sample())
+    assert lock.acquire_count == 2
+    assert lock.release_count == 2
+
+    env.observation["IrInstructionCount"]
+    assert lock.acquire_count == 2
+    assert lock.release_count == 2
+
+    env.reward["IrInstructionCount"]
+    assert lock.acquire_count == 2
+    assert lock.release_count == 2
+
+    fkd = env.fork()
+    try:
+        assert lock.acquire_count == 3
+        assert lock.release_count == 3
+        assert fkd.lock.acquire_count == 3
+        assert fkd.lock.release_count == 3
+    finally:
+        fkd.close()
+
+
+def test_wrapped_default_lock(env: LlvmEnv):
+    env = LockedStep(env)
+    env.reset()
+    env.step(env.action_space.sample())
+    env.observation["IrInstructionCount"]
+    env.reward["IrInstructionCount"]
+    fkd = env.fork()
+    fkd.step(env.action_space.sample())
+    fkd.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This class is used to prevent the `step()`, `reset()`, and `fork()` methods of multiple compiler environments from executing simultaneously. It does this by sharing acquiring a thread lock during these operations which is shared between all instances of this wrapped class.

Example usage:

```py
>>> envs = [compiler_gym.make("llvm-v0") for _ in range(10)]
>>> threads = [threading.Thread(target=run, args=(env,)) for env in envs]
>>> [t.start() for t in threads]
```

Issue #370.