### PR TITLE
[UI] Added historical chart for single observations

### DIFF
--- a/www/frontends/compiler_gym/public/index.html
+++ b/www/frontends/compiler_gym/public/index.html
@@ -1,3 +1,8 @@
+<!--
+ Copyright (c) Facebook, Inc. and its affiliates.
+ This source code is licensed under the MIT license found in the
+ LICENSE file in the root directory of this source tree.
+ -->
 <!DOCTYPE html>
 <html lang="en">
   <head>
@@ -7,7 +12,7 @@
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="Web site created using create-react-app"
+      content="CompilerGym Explorer - compiler optimization problems for reinforcement learning"
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/compilerGym-logo.png" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />

--- a/www/frontends/compiler_gym/src/assets/scss/highcharts.scss
+++ b/www/frontends/compiler_gym/src/assets/scss/highcharts.scss
@@ -109,3 +109,26 @@
 .description-tooltip2 {
   font-size: smaller;
 }
+
+/*** SingleChart Modal ****/
+
+.wrap-modals {
+  position: relative;
+}
+
+.modal_trends {
+  background-color: rgba(0,0,0,0.5);
+  position: sticky;
+  height: 50vh;
+  width: 100%;
+  top: 36px;
+  right: 0;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  z-index: 10;
+  button {
+    border-radius: 10px;
+    font-size: small;
+  }
+}

--- a/www/frontends/compiler_gym/src/components/Navbars/ActionsNavbar.js
+++ b/www/frontends/compiler_gym/src/components/Navbars/ActionsNavbar.js
@@ -134,7 +134,7 @@ const ActionsNavbar = ({
           "1"
         );
         setSession(response);
-        console.log(response)
+        //console.log(response) For debugging.
         setParams({
           dataset: searchParams.get("dataset"),
           datasetUri: searchParams.get("dataset_uri"),
@@ -197,7 +197,7 @@ const ActionsNavbar = ({
 
   // Append current url params into a string to generata a link.
   const getShareLink = () => {
-    let shareLink = `${window.location.href}${location.search}`;
+    let shareLink = `${window.location.href}`;
     return shareLink;
   };
 

--- a/www/frontends/compiler_gym/src/components/Navbars/ActionsNavbar.js
+++ b/www/frontends/compiler_gym/src/components/Navbars/ActionsNavbar.js
@@ -134,7 +134,6 @@ const ActionsNavbar = ({
           "1"
         );
         setSession(response);
-        //console.log(response) For debugging.
         setParams({
           dataset: searchParams.get("dataset"),
           datasetUri: searchParams.get("dataset_uri"),

--- a/www/frontends/compiler_gym/src/components/Sections/ControlsContainer.js
+++ b/www/frontends/compiler_gym/src/components/Sections/ControlsContainer.js
@@ -105,7 +105,6 @@ const ControlsContainer = () => {
       setIsLoading(true)
       if (actions !== undefined) {
         const result = await api.getActions(`${dataset}/${datasetUri}`, reward, actions, "1");
-        console.log(result);
         setSession(result);
         setActionSpace(30);
         let actionsTaken = actions.map((o, i) => `${o}.${i + 1}`);
@@ -116,7 +115,6 @@ const ControlsContainer = () => {
           });
       } else {
         const result = await api.getActions(`${dataset}/${datasetUri}`, reward, actionsIdsTaken.length ? actionsIdsTaken : "", actionsIdsTaken.length ? "1" : null );
-        console.log(result);
         setSession(result);
         setActionSpace(30);
         if (actionsIdsTaken.length) {

--- a/www/frontends/compiler_gym/src/components/StateVisualizations/AutophaseHistoricalChart.js
+++ b/www/frontends/compiler_gym/src/components/StateVisualizations/AutophaseHistoricalChart.js
@@ -9,9 +9,12 @@ import classnames from "classnames";
 import { groupBy, getMaxDelta, percIncrease } from "../../utils/Helpers";
 import AutophaseDict from "../../utils/AutophaseDict";
 import SparkLineTable from "./SparkLineTable";
+import ModalSingleChart from "./ModalSingleChart";
 
 const AutophaseHistoricalChart = ({ sessionStates, commandLine, darkTheme, sortBy }) => {
   const [steps, setSteps] = useState([]);
+  const [showModal, setModal] = useState(false);
+  const [modalData, setModalData] = useState({});
 
   useEffect(() => {
     setSteps(commandLine.split(" input.bc -o output.bc")[0].split(" "));
@@ -82,13 +85,21 @@ const AutophaseHistoricalChart = ({ sessionStates, commandLine, darkTheme, sortB
   return (
     <div
       className={classnames(
-        "mt-2 pt-2",
+        "mt-2 pt-2 wrap-modals",
         { "bg-dark text-white": darkTheme },
         { "": !darkTheme }
       )}
     >
       <h4 className="text-center">Historical Values</h4>
-      <SparkLineTable>
+      {showModal && (
+        <div className="modal_trends">
+          <div className="chart-container">
+            <ModalSingleChart data={modalData} darkTheme={darkTheme}/>
+          </div>
+          <button onClick={() => setModal(false)}>Close</button>
+        </div>
+      )}
+      <SparkLineTable setModal={setModal} setModalData={setModalData}>
         <thead>
           <tr>
             <th>Autophase</th>

--- a/www/frontends/compiler_gym/src/components/StateVisualizations/InstCountsHistoricalChart.js
+++ b/www/frontends/compiler_gym/src/components/StateVisualizations/InstCountsHistoricalChart.js
@@ -9,9 +9,12 @@ import classnames from "classnames";
 import { groupBy, getMaxDelta, percIncrease } from "../../utils/Helpers";
 import InstCountDict from "../../utils/InstCountDict";
 import SparkLineTable from "./SparkLineTable";
+import ModalSingleChart from "./ModalSingleChart";
 
 const InstCountsHistoricalChart = ({ sessionStates, commandLine, darkTheme, sortBy }) => {
   const [steps, setSteps] = useState([]);
+  const [showModal, setModal] = useState(false);
+  const [modalData, setModalData] = useState({});
 
   useEffect(() => {
     setSteps(commandLine.split(" input.bc -o output.bc")[0].split(" "));
@@ -82,13 +85,21 @@ const InstCountsHistoricalChart = ({ sessionStates, commandLine, darkTheme, sort
   return (
     <div
       className={classnames(
-        "mt-2 pt-2",
+        "mt-2 pt-2 wrap-modals",
         { "bg-dark text-white": darkTheme },
         { "": !darkTheme }
       )}
     >
       <h4 className="text-center">Historical Values</h4>
-      <SparkLineTable>
+      {showModal && (
+        <div className="modal_trends">
+          <div className="chart-container">
+            <ModalSingleChart data={modalData} darkTheme={darkTheme}/>
+          </div>
+          <button onClick={() => setModal(false)}>Close</button>
+        </div>
+      )}
+      <SparkLineTable setModal={setModal} setModalData={setModalData}>
         <thead>
           <tr>
             <th>InstCounts</th>

--- a/www/frontends/compiler_gym/src/components/StateVisualizations/ModalSingleChart.js
+++ b/www/frontends/compiler_gym/src/components/StateVisualizations/ModalSingleChart.js
@@ -1,0 +1,70 @@
+import React from "react";
+import Highcharts from "highcharts";
+import HighchartsReact from "highcharts-react-official";
+
+const ModalSingleChart = ({ data, darkTheme }) => {
+  const options = {
+    colors: ["#2593B8", "#434348"],
+    chart: {
+      type: "area",
+    },
+    title: {
+      text: undefined,
+    },
+    xAxis: {
+      categories: data.xAxis.categories,
+      labels: {
+        enabled: true,
+        style: {
+          color: darkTheme && "white",
+        },
+      },
+    },
+    yAxis: {
+      title: null,
+      labels: {
+        enabled: true,
+        style: {
+          color: darkTheme && "white",
+        },
+      },
+    },
+    credits: {
+      enabled: false,
+    },
+    legend: {
+      enabled: false,
+    },
+    tooltip: {
+      formatter: function () {
+        return (
+          "Action: <b>" + this.x + "</b> <br/> Value: <b>" + this.y + "</b>"
+        );
+      },
+    },
+    plotOptions: {
+      series: {
+        pointWidth: 4,
+        marker: {
+          radius: 2,
+        },
+      },
+    },
+    series: [
+      {
+        data: data.series[0].data,
+      },
+    ],
+    exporting: {
+      buttons: {
+        contextButton: {
+          menuItems: ["viewFullscreen", "printChart"],
+        },
+      },
+    },
+  };
+
+  return <HighchartsReact highcharts={Highcharts} options={options} />;
+};
+
+export default ModalSingleChart;

--- a/www/frontends/compiler_gym/src/components/StateVisualizations/ModalSingleChart.js
+++ b/www/frontends/compiler_gym/src/components/StateVisualizations/ModalSingleChart.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 import React from "react";
 import Highcharts from "highcharts";
 import HighchartsReact from "highcharts-react-official";

--- a/www/frontends/compiler_gym/src/components/StateVisualizations/SparkLineTable.js
+++ b/www/frontends/compiler_gym/src/components/StateVisualizations/SparkLineTable.js
@@ -114,7 +114,12 @@ const SparkLine = (props) => {
     };
   }, [props.options]);
 
-  return <td ref={container}></td>;
+  const handleClick = (data) => {
+    props.setModal(true)
+    props.setModalData(data)
+  }
+
+  return <td ref={container} onClick={() => handleClick(props.options)}></td>;
 };
 
 class SparkLineTable extends React.Component {
@@ -153,24 +158,30 @@ class SparkLineTable extends React.Component {
       },
       plotOptions: {
         series: {
-            color:'#2593B8'
-        }
+          color: "#2593B8",
+        },
       },
       series: [
         {
           data: data,
           pointStart: 0,
-        }
+        },
       ],
 
       tooltip: {
         useHTML: true,
         headerFormat: `<span><b>{point.x}</b></span><br/>`,
-        pointFormat: `<span><b>Value:</b> {point.y}</span>`
+        pointFormat: `<span><b>Value:</b> {point.y}</span>`,
       },
     };
 
-    return <SparkLine options={options} />;
+    return (
+      <SparkLine
+        options={options}
+        setModal={this.props.setModal}
+        setModalData={this.props.setModalData}
+      />
+    );
   }
 
   render() {


### PR DESCRIPTION
@ChrisCummins just in case we need this feature.

This PR

- Cleans debugging lines,
- adds license header to index.html
- adds historical chart for single observations in global historical table/chart.


https://user-images.githubusercontent.com/84393628/133364569-b9becf55-00fe-437b-b4be-72ec56d08de2.mov


