### PR TITLE
[tests] Qualify temporary directory with username.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -259,12 +259,12 @@ livedocs: gendocs doxygen
 # Testing #
 ###########
 
-COMPILER_GYM_SITE_DATA ?= "/tmp/compiler_gym/tests/site_data"
-COMPILER_GYM_CACHE ?= "/tmp/compiler_gym/tests/cache"
+COMPILER_GYM_SITE_DATA ?= "/tmp/compiler_gym_$(USER)/tests/site_data"
+COMPILER_GYM_CACHE ?= "/tmp/compiler_gym_$(USER)/tests/cache"
 
 # A directory that is used as the working directory for running pytest tests
 # by symlinking the tests directory into it.
-INSTALL_TEST_ROOT ?= "/tmp/compiler_gym/install_tests"
+INSTALL_TEST_ROOT ?= "/tmp/compiler_gym_$(USER)/install_tests"
 
 # The target to use. If not provided, all tests will be run. For `make test` and
 # related, this is a bazel target pattern, with default value '//...'. For `make
@@ -345,7 +345,7 @@ COMPILER_GYM_DATA_FILE_LOCATIONS = \
     $(HOME)/.local/share/compiler_gym \
     $(HOME)/logs/compiler_gym \
     /dev/shm/compiler_gym \
-    /tmp/compiler_gym \
+    /tmp/compiler_gym_$(USER) \
     $(NULL)
 
 .PHONY: clean distclean uninstall purge

--- a/benchmarks/bench_test.py
+++ b/benchmarks/bench_test.py
@@ -9,12 +9,14 @@ To run these benchmarks an optimized build using bazel:
     $ bazel test -c opt --test_output=streamed //benchmarks:bench_test
 
 A record of the benchmark results is stored in
-/tmp/compiler_gym/pytest_benchmark/<device>/<run_id>_bench_test.json. Compare
+/tmp/compiler_gym_<user>/pytest_benchmark/<device>/<run_id>_bench_test.json. Compare
 multiple runs using:
 
     $ pytest-benchmark compare --group-by=name --sort=fullname \
-        /tmp/compiler_gym/pytest_benchmark/*/*_bench_test.json
+        /tmp/compiler_gym_<user>/pytest_benchmark/*/*_bench_test.json
 """
+from getpass import getuser
+
 import gym
 import pytest
 
@@ -182,7 +184,7 @@ def test_fork(benchmark, make_env):
 if __name__ == "__main__":
     main(
         extra_pytest_args=[
-            "--benchmark-storage=/tmp/compiler_gym/pytest_benchmark",
+            f"--benchmark-storage=/tmp/compiler_gym_{getuser()}/pytest_benchmark",
             "--benchmark-save=bench_test",
             "--benchmark-sort=name",
             "-x",

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 import os
 import sys
+from getpass import getuser
 from typing import List, Optional
 
 import pytest
@@ -35,8 +36,10 @@ def main(extra_pytest_args: Optional[List[str]] = None, debug_level: int = 1):
     dbg.set_debug_level(debug_level)
 
     # Keep test data isolated from user data.
-    os.environ["COMPILER_GYM_SITE_DATA"] = "/tmp/compiler_gym/tests/site_data"
-    os.environ["COMPILER_GYM_CACHE"] = "/tmp/compiler_gym/tests/cache"
+    os.environ[
+        "COMPILER_GYM_SITE_DATA"
+    ] = f"/tmp/compiler_gym_{getuser()}/tests/site_data"
+    os.environ["COMPILER_GYM_CACHE"] = f"/tmp/compiler_gym_{getuser()}/tests/cache"
 
     pytest_args = sys.argv + ["-vv"]
     # Support for sharding. If a py_test target has the shard_count attribute


### PR DESCRIPTION
Use `/tmp/compiler_gym_{user}` as a scratch directory for testing to prevent conflicts on multi-user systems.
