### PR TITLE
Add a standalone binary to compute LLMV observations

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -421,6 +421,7 @@ jobs:
                   wheel unpack *.whl
                   rm *.whl
                   chmod +x compiler_gym-*/compiler_gym-*.data/purelib/compiler_gym/third_party/csmith/csmith/bin/csmith
+                  chmod +x compiler_gym-*/compiler_gym-*.data/purelib/compiler_gym/envs/llvm/service/compute_observation
                   mv compiler_gym-llvm-service compiler_gym-*/compiler_gym-*.data/purelib/compiler_gym/envs/llvm/service/compiler_gym-llvm-service
                   wheel pack compiler_gym-*
 

--- a/compiler_gym/envs/llvm/BUILD
+++ b/compiler_gym/envs/llvm/BUILD
@@ -13,8 +13,18 @@ py_library(
     data = ["//compiler_gym/envs/llvm/service"],
     visibility = ["//visibility:public"],
     deps = [
+        ":compute_observation",
         ":llvm_benchmark",
         ":llvm_env",
+        "//compiler_gym/util",
+    ],
+)
+
+py_library(
+    name = "compute_observation",
+    srcs = ["compute_observation.py"],
+    data = ["//compiler_gym/envs/llvm/service:compute_observation-files"],
+    deps = [
         "//compiler_gym/util",
     ],
 )

--- a/compiler_gym/envs/llvm/__init__.py
+++ b/compiler_gym/envs/llvm/__init__.py
@@ -5,6 +5,7 @@
 """Register the LLVM environments."""
 from itertools import product
 
+from compiler_gym.envs.llvm.compute_observation import compute_observation
 from compiler_gym.envs.llvm.llvm_benchmark import (
     ClangInvocation,
     get_system_includes,
@@ -16,11 +17,12 @@ from compiler_gym.util.registration import register
 from compiler_gym.util.runfiles_path import runfiles_path
 
 __all__ = [
-    "LlvmEnv",
-    "make_benchmark",
     "ClangInvocation",
+    "compute_observation",
     "get_system_includes",
     "LLVM_SERVICE_BINARY",
+    "LlvmEnv",
+    "make_benchmark",
     "observation_spaces",
     "reward_spaces",
 ]

--- a/compiler_gym/envs/llvm/compute_observation.py
+++ b/compiler_gym/envs/llvm/compute_observation.py
@@ -1,0 +1,111 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""This module defines a utility function for computing LLVM observations."""
+import subprocess
+from pathlib import Path
+from typing import List
+
+import google.protobuf.text_format
+
+from compiler_gym.service.proto import Observation
+from compiler_gym.util.runfiles_path import runfiles_path
+from compiler_gym.util.shell_format import plural
+from compiler_gym.views.observation_space_spec import ObservationSpaceSpec
+
+_COMPUTE_OBSERVATION_BIN = runfiles_path(
+    "compiler_gym/envs/llvm/service/compute_observation"
+)
+
+
+def pascal_case_to_enum(pascal_case: str) -> str:
+    """Convert PascalCase to ENUM_CASE."""
+    word_arrays: List[List[str]] = [[]]
+
+    for c in pascal_case:
+        if c.isupper() and word_arrays[-1]:
+            word_arrays.append([c])
+        else:
+            word_arrays[-1].append(c.upper())
+
+    return "_".join(["".join(word) for word in word_arrays])
+
+
+def compute_observation(
+    observation_space: ObservationSpaceSpec, bitcode: Path, timeout: float = 300
+):
+    """Compute an LLVM observation.
+
+    This is a utility function that uses a standalone C++ binary to compute an
+    observation from an LLVM bitcode file. It is intended for use cases where
+    you want to compute an observation without the overhead of initializing a
+    full environment.
+
+    Example usage:
+
+        >>> env = compiler_gym.make("llvm-v0")
+        >>> space = env.observation.spaces["Ir"]
+        >>> bitcode = Path("bitcode.bc")
+        >>> observation = llvm.compute_observation(space, bitcode, timeout=30)
+
+    .. warning::
+
+        This is not part of the core CompilerGym API and may change in a future
+        release.
+
+    :param observation_space: The observation that is to be computed.
+
+    :param bitcode: The path of an LLVM bitcode file.
+
+    :param timeout: The maximum number of seconds to allow the computation to
+        run before timing out.
+
+    :raises ValueError: If computing the observation fails.
+
+    :raises TimeoutError: If computing the observation times out.
+
+    :raises FileNotFoundError: If the given bitcode does not exist.
+    """
+    if not Path(bitcode).is_file():
+        raise FileNotFoundError(bitcode)
+
+    observation_space_name = pascal_case_to_enum(observation_space.id)
+
+    process = subprocess.Popen(
+        [str(_COMPUTE_OBSERVATION_BIN), observation_space_name, str(bitcode)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    try:
+        stdout, stderr = process.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired as e:
+        raise TimeoutError(
+            f"Failed to compute {observation_space.id} observation in "
+            f"{timeout:.1f} {plural(int(round(timeout)), 'second', 'seconds')}"
+        ) from e
+
+    if process.returncode:
+        try:
+            stderr = stderr.decode("utf-8")
+            raise ValueError(
+                f"Failed to compute {observation_space.id} observation: {stderr}"
+            )
+        except UnicodeDecodeError as e:
+            raise ValueError(
+                f"Failed to compute {observation_space.id} observation"
+            ) from e
+
+    try:
+        stdout = stdout.decode("utf-8")
+    except UnicodeDecodeError as e:
+        raise ValueError(f"Failed to parse {observation_space.id} observation: {e}")
+
+    observation = Observation()
+    try:
+        google.protobuf.text_format.Parse(stdout, observation)
+    except google.protobuf.text_format.ParseError as e:
+        raise ValueError(f"Failed to parse {observation_space.id} observation") from e
+
+    return observation_space.translate(observation)

--- a/compiler_gym/envs/llvm/service/BUILD
+++ b/compiler_gym/envs/llvm/service/BUILD
@@ -157,6 +157,7 @@ cc_library(
         ":Benchmark",
         ":BenchmarkFactory",
         ":Cost",
+        ":Observation",
         ":ObservationSpaces",
         "//compiler_gym/service:CompilationSession",
         "//compiler_gym/service/proto:compiler_gym_service_cc_grpc",
@@ -175,6 +176,29 @@ cc_library(
         "@programl//programl/ir/llvm:llvm-10",
         "@programl//programl/proto:programl_cc",
         "@subprocess",
+    ],
+)
+
+cc_library(
+    name = "Observation",
+    srcs = ["Observation.cc"],
+    hdrs = ["Observation.h"],
+    deps = [
+        ":Benchmark",
+        ":Cost",
+        ":ObservationSpaces",
+        "//compiler_gym/service/proto:compiler_gym_service_cc_grpc",
+        "//compiler_gym/third_party/autophase:InstCount",
+        "//compiler_gym/third_party/cpuinfo",
+        "//compiler_gym/util:GrpcStatusMacros",
+        "@boost//:filesystem",
+        "@glog",
+        "@llvm//10.0.0",
+        "@magic_enum",
+        "@nlohmann_json//:json",
+        "@programl//programl/graph/format:node_link_graph",
+        "@programl//programl/ir/llvm:llvm-10",
+        "@programl//programl/proto:programl_cc",
     ],
 )
 

--- a/compiler_gym/envs/llvm/service/BUILD
+++ b/compiler_gym/envs/llvm/service/BUILD
@@ -1,6 +1,11 @@
 # This package exposes the LLVM optimization pipeline as a CompilerGym service.
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 
+package(default_visibility = [
+    "//compiler_gym/envs/llvm:__subpackages__",
+    "//tests:__subpackages__",
+])
+
 # This target includes the service binary and its runtime dependencies and
 # libraries.
 filegroup(
@@ -10,7 +15,7 @@ filegroup(
     ] + select({
         "@llvm//:darwin": [],
         "//conditions:default": [
-            "//compiler_gym/envs/llvm/service:libLLVMPolly",
+            ":libLLVMPolly",
         ],
     }),
     visibility = ["//visibility:public"],
@@ -33,7 +38,6 @@ genrule(
             "chmod 555 $@"
         ),
     }),
-    visibility = ["//compiler_gym/envs/llvm:__subpackages__"],
 )
 
 # This target copies the LLVMPolly.so file from LLVM to libLLVMPolly.so.
@@ -68,7 +72,6 @@ cc_library(
         "ActionSpace.h",
         "//compiler_gym/envs/llvm/service/passes:ActionEnum.h",
     ],
-    visibility = ["//tests:__subpackages__"],
     deps = [
         "//compiler_gym/service/proto:compiler_gym_service_cc",
         "//compiler_gym/util:EnumUtil",
@@ -80,10 +83,6 @@ cc_library(
     name = "Benchmark",
     srcs = ["Benchmark.cc"],
     hdrs = ["Benchmark.h"],
-    visibility = [
-        "//compiler_gym/envs/llvm/service:__subpackages__",
-        "//tests:__subpackages__",
-    ],
     deps = [
         ":Cost",
         "//compiler_gym/service/proto:compiler_gym_service_cc",
@@ -102,10 +101,6 @@ cc_library(
     name = "BenchmarkFactory",
     srcs = ["BenchmarkFactory.cc"],
     hdrs = ["BenchmarkFactory.h"],
-    visibility = [
-        "//compiler_gym/envs/llvm/service:__subpackages__",
-        "//tests:__subpackages__",
-    ],
     deps = [
         ":Benchmark",
         ":Cost",
@@ -119,6 +114,55 @@ cc_library(
         "@glog",
         "@llvm//10.0.0",
     ],
+)
+
+filegroup(
+    name = "compute_observation-files",
+    srcs = [
+        ":compute_observation",
+    ] + select({
+        "@llvm//:darwin": [],
+        "//conditions:default": [
+            ":libLLVMPolly",
+        ],
+    }),
+)
+
+cc_binary(
+    name = "compute_observation-prelinked",
+    srcs = ["ComputeObservation.cc"],
+    copts = [
+        "-DGOOGLE_PROTOBUF_NO_RTTI",
+        "-fno-rtti",
+    ],
+    deps = [
+        ":BenchmarkFactory",
+        ":Observation",
+        ":ObservationSpaces",
+        "//compiler_gym/service/proto:compiler_gym_service_cc",
+        "@boost//:filesystem",
+        "@glog",
+        "@llvm//10.0.0",
+        "@magic_enum",
+    ],
+)
+
+genrule(
+    name = "compute_observation-bin",
+    srcs = [":compute_observation-prelinked"],
+    outs = ["compute_observation"],
+    cmd = select({
+        "@llvm//:darwin": (
+            "cp $(location :compute_observation-prelinked) $@"
+        ),
+        "//conditions:default": (
+            "cp $(location :compute_observation-prelinked) $@ && " +
+            "chmod 666 $@ && " +
+            "patchelf --set-rpath '$$ORIGIN' $@ && " +
+            "chmod 555 $@"
+        ),
+    }),
+    visibility = ["//visibility:public"],
 )
 
 cc_library(
@@ -206,7 +250,6 @@ cc_library(
     name = "ObservationSpaces",
     srcs = ["ObservationSpaces.cc"],
     hdrs = ["ObservationSpaces.h"],
-    visibility = ["//tests:__subpackages__"],
     deps = [
         ":Benchmark",
         "//compiler_gym/service/proto:compiler_gym_service_cc",

--- a/compiler_gym/envs/llvm/service/Benchmark.cc
+++ b/compiler_gym/envs/llvm/service/Benchmark.cc
@@ -196,15 +196,19 @@ Status Benchmark::verify_module() {
   return Status::OK;
 }
 
-Status Benchmark::writeBitcodeToFile(const fs::path& path) {
+Status writeBitcodeFile(const llvm::Module& module, const fs::path& path) {
   std::error_code error;
   llvm::raw_fd_ostream outfile(path.string(), error);
   if (error.value()) {
     return Status(StatusCode::INTERNAL,
                   fmt::format("Failed to write bitcode file: {}", path.string()));
   }
-  llvm::WriteBitcodeToFile(module(), outfile);
+  llvm::WriteBitcodeToFile(module, outfile);
   return Status::OK;
+}
+
+Status Benchmark::writeBitcodeToFile(const fs::path& path) {
+  return writeBitcodeFile(module(), path);
 }
 
 Status Benchmark::computeRuntime(Observation& observation) {

--- a/compiler_gym/envs/llvm/service/Benchmark.h
+++ b/compiler_gym/envs/llvm/service/Benchmark.h
@@ -49,6 +49,15 @@ constexpr int kDefaultBuildtimesPerObservationCount = 1;
 grpc::Status readBitcodeFile(const boost::filesystem::path& path, Bitcode* bitcode);
 
 /**
+ * Write the module bitcode to the given path.
+ *
+ * @param module The module to write to file.
+ * @param path The path of the bitcode file to write.
+ * @return `OK` on success.
+ */
+grpc::Status writeBitcodeFile(const llvm::Module& module, const boost::filesystem::path& path);
+
+/**
  * Construct an LLVM module from a bitcode.
  *
  * Parses the given bitcode into a module and strips the identifying `ModuleID`

--- a/compiler_gym/envs/llvm/service/ComputeObservation.cc
+++ b/compiler_gym/envs/llvm/service/ComputeObservation.cc
@@ -1,0 +1,58 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+#include <fmt/format.h>
+#include <glog/logging.h>
+
+#include <boost/filesystem.hpp>
+#include <iostream>
+#include <magic_enum.hpp>
+
+#include "compiler_gym/envs/llvm/service/BenchmarkFactory.h"
+#include "compiler_gym/envs/llvm/service/Observation.h"
+#include "compiler_gym/envs/llvm/service/ObservationSpaces.h"
+#include "compiler_gym/service/proto/compiler_gym_service.pb.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IRReader/IRReader.h"
+#include "llvm/Support/ErrorOr.h"
+#include "llvm/Support/SourceMgr.h"
+
+namespace fs = boost::filesystem;
+
+using namespace compiler_gym;
+using namespace compiler_gym::llvm_service;
+
+int main(int argc, char** argv) {
+  google::InitGoogleLogging(argv[0]);
+
+  CHECK(argc == 3) << "Usage: compute_observation <observation-space> <bitcode-path>";
+
+  const auto observationSpaceArg = magic_enum::enum_cast<LlvmObservationSpace>(argv[1]);
+  CHECK(observationSpaceArg.has_value())
+      << fmt::format("Invalid observation space name: {}", argv[1]);
+  const LlvmObservationSpace observationSpace = observationSpaceArg.value();
+
+  fs::path workingDirectory{"."};
+
+  compiler_gym::Benchmark benchmarkMessage;
+  benchmarkMessage.set_uri("user");
+  benchmarkMessage.mutable_program()->set_uri(fmt::format("file:///{}", argv[2]));
+
+  auto& benchmarkFactory = BenchmarkFactory::getSingleton(workingDirectory);
+  std::unique_ptr<::llvm_service::Benchmark> benchmark;
+  {
+    const auto status = benchmarkFactory.getBenchmark(benchmarkMessage, &benchmark);
+    CHECK(status.ok()) << "Failed to compute observation: " << status.error_message();
+  }
+
+  Observation observation;
+  {
+    const auto status = setObservation(observationSpace, workingDirectory, *benchmark, observation);
+    CHECK(status.ok()) << "Failed to compute observation: " << status.error_message();
+  }
+
+  std::cout << observation.DebugString() << std::endl;
+
+  return 0;
+}

--- a/compiler_gym/envs/llvm/service/LlvmSession.cc
+++ b/compiler_gym/envs/llvm/service/LlvmSession.cc
@@ -18,6 +18,7 @@
 #include "compiler_gym/envs/llvm/service/Benchmark.h"
 #include "compiler_gym/envs/llvm/service/BenchmarkFactory.h"
 #include "compiler_gym/envs/llvm/service/Cost.h"
+#include "compiler_gym/envs/llvm/service/Observation.h"
 #include "compiler_gym/envs/llvm/service/ObservationSpaces.h"
 #include "compiler_gym/envs/llvm/service/passes/ActionHeaders.h"
 #include "compiler_gym/envs/llvm/service/passes/ActionSwitch.h"
@@ -56,17 +57,6 @@ namespace {
 llvm::TargetLibraryInfoImpl getTargetLibraryInfo(llvm::Module& module) {
   llvm::Triple triple(module.getTargetTriple());
   return llvm::TargetLibraryInfoImpl(triple);
-}
-
-Status writeBitcodeToFile(const llvm::Module& module, const fs::path& path) {
-  std::error_code error;
-  llvm::raw_fd_ostream outfile(path.string(), error);
-  if (error.value()) {
-    return Status(StatusCode::INTERNAL,
-                  fmt::format("Failed to write bitcode file: {}", path.string()));
-  }
-  llvm::WriteBitcodeToFile(module, outfile);
-  return Status::OK;
 }
 
 }  // anonymous namespace
@@ -156,8 +146,8 @@ Status LlvmSession::computeObservation(const ObservationSpace& observationSpace,
         fmt::format("Could not interpret observation space name: {}", observationSpace.name()));
   }
   const LlvmObservationSpace observationSpaceEnum = it->second;
-  RETURN_IF_ERROR(computeObservation(observationSpaceEnum, observation));
-  return Status::OK;
+
+  return setObservation(observationSpaceEnum, workingDirectory(), benchmark(), observation);
 }
 
 Status LlvmSession::handleSessionParameter(const std::string& key, const std::string& value,
@@ -247,7 +237,7 @@ Status LlvmSession::runOptWithArgs(const std::vector<std::string>& optArgs) {
   // Create temporary files for `opt` to read from and write to.
   const auto before_path = fs::unique_path(workingDirectory() / "module-%%%%%%%%.bc");
   const auto after_path = fs::unique_path(workingDirectory() / "module-%%%%%%%%.bc");
-  RETURN_IF_ERROR(writeBitcodeToFile(benchmark().module(), before_path));
+  RETURN_IF_ERROR(writeBitcodeFile(benchmark().module(), before_path));
 
   // Build a command line invocation: `opt input.bc -o output.bc <optArgs...>`.
   const auto optPath = util::getSiteDataPath("llvm-v0/bin/opt");
@@ -288,185 +278,6 @@ Status LlvmSession::runOptWithArgs(const std::vector<std::string>& optArgs) {
   auto module = makeModule(benchmark().context(), bitcode, benchmark().name(), &status);
   RETURN_IF_ERROR(status);
   benchmark().replaceModule(std::move(module));
-
-  return Status::OK;
-}
-
-Status LlvmSession::computeObservation(LlvmObservationSpace space, Observation& reply) {
-  switch (space) {
-    case LlvmObservationSpace::IR: {
-      // Serialize the LLVM module to an IR string.
-      std::string ir;
-      llvm::raw_string_ostream rso(ir);
-      benchmark().module().print(rso, /*AAW=*/nullptr);
-      reply.set_string_value(ir);
-      break;
-    }
-    case LlvmObservationSpace::IR_SHA1: {
-      std::stringstream ss;
-      const BenchmarkHash hash = benchmark().module_hash();
-      // Hex encode, zero pad, and concatenate the unsigned integers that
-      // contain the hash.
-      for (uint32_t val : hash) {
-        ss << std::setfill('0') << std::setw(sizeof(BenchmarkHash::value_type) * 2) << std::hex
-           << val;
-      }
-      reply.set_string_value(ss.str());
-      break;
-    }
-    case LlvmObservationSpace::BITCODE_FILE: {
-      // Generate an output path with 16 bits of randomness.
-      const auto outpath = fs::unique_path(workingDirectory() / "module-%%%%%%%%.bc");
-      RETURN_IF_ERROR(writeBitcodeToFile(benchmark().module(), outpath));
-      reply.set_string_value(outpath.string());
-      break;
-    }
-    case LlvmObservationSpace::INST_COUNT: {
-      const auto features = InstCount::getFeatureVector(benchmark().module());
-      *reply.mutable_int64_list()->mutable_value() = {features.begin(), features.end()};
-      break;
-    }
-    case LlvmObservationSpace::AUTOPHASE: {
-      const auto features = autophase::InstCount::getFeatureVector(benchmark().module());
-      *reply.mutable_int64_list()->mutable_value() = {features.begin(), features.end()};
-      break;
-    }
-    case LlvmObservationSpace::PROGRAML:
-    case LlvmObservationSpace::PROGRAML_JSON: {
-      // Build the ProGraML graph.
-      programl::ProgramGraph graph;
-      auto status =
-          programl::ir::llvm::BuildProgramGraph(benchmark().module(), &graph, programlOptions_);
-      if (!status.ok()) {
-        return Status(StatusCode::INTERNAL, status.error_message());
-      }
-
-      // Serialize the graph to a JSON node link graph.
-      json nodeLinkGraph;
-      status = programl::graph::format::ProgramGraphToNodeLinkGraph(graph, &nodeLinkGraph);
-      if (!status.ok()) {
-        return Status(StatusCode::INTERNAL, status.error_message());
-      }
-      *reply.mutable_string_value() = nodeLinkGraph.dump();
-      break;
-    }
-    case LlvmObservationSpace::CPU_INFO: {
-      json hwinfo;
-      auto caches = {
-          std::make_tuple("l1i_cache", cpuinfo_get_l1i_caches(), cpuinfo_get_l1d_caches_count()),
-          {"l1d_cache", cpuinfo_get_l1d_caches(), cpuinfo_get_l1d_caches_count()},
-          {"l2_cache", cpuinfo_get_l2_caches(), cpuinfo_get_l2_caches_count()},
-          {"l3_cache", cpuinfo_get_l3_caches(), cpuinfo_get_l3_caches_count()},
-          {"l4_cache", cpuinfo_get_l4_caches(), cpuinfo_get_l4_caches_count()}};
-      for (auto [name, cache, count] : caches) {
-        std::string sizeName = std::string(name) + "_size";
-        std::string countName = std::string(name) + "_count";
-        if (cache) {
-          hwinfo[sizeName] = cache->size;
-          hwinfo[countName] = count;
-        } else {
-          hwinfo[sizeName] = -1;
-          hwinfo[countName] = count;
-        }
-      }
-      hwinfo["cores_count"] = cpuinfo_get_cores_count();
-      auto cpu = cpuinfo_get_packages();
-      hwinfo["name"] = cpu->name;
-      *reply.mutable_string_value() = hwinfo.dump();
-      break;
-    }
-    case LlvmObservationSpace::IR_INSTRUCTION_COUNT: {
-      double cost;
-      RETURN_IF_ERROR(setCost(LlvmCostFunction::IR_INSTRUCTION_COUNT, benchmark().module(),
-                              workingDirectory(), &cost));
-      reply.set_scalar_int64(static_cast<int64_t>(cost));
-      break;
-    }
-    case LlvmObservationSpace::IR_INSTRUCTION_COUNT_O0: {
-      const auto cost = getBaselineCost(benchmark().baselineCosts(), LlvmBaselinePolicy::O0,
-                                        LlvmCostFunction::IR_INSTRUCTION_COUNT);
-      reply.set_scalar_int64(static_cast<int64_t>(cost));
-      break;
-    }
-    case LlvmObservationSpace::IR_INSTRUCTION_COUNT_O3: {
-      const auto cost = getBaselineCost(benchmark().baselineCosts(), LlvmBaselinePolicy::O3,
-                                        LlvmCostFunction::IR_INSTRUCTION_COUNT);
-      reply.set_scalar_int64(static_cast<int64_t>(cost));
-      break;
-    }
-    case LlvmObservationSpace::IR_INSTRUCTION_COUNT_OZ: {
-      const auto cost = getBaselineCost(benchmark().baselineCosts(), LlvmBaselinePolicy::Oz,
-                                        LlvmCostFunction::IR_INSTRUCTION_COUNT);
-      reply.set_scalar_int64(static_cast<int64_t>(cost));
-      break;
-    }
-    case LlvmObservationSpace::OBJECT_TEXT_SIZE_BYTES: {
-      double cost;
-      RETURN_IF_ERROR(setCost(LlvmCostFunction::OBJECT_TEXT_SIZE_BYTES, benchmark().module(),
-                              workingDirectory(), &cost));
-      reply.set_scalar_int64(static_cast<int64_t>(cost));
-      break;
-    }
-    case LlvmObservationSpace::OBJECT_TEXT_SIZE_O0: {
-      const auto cost = getBaselineCost(benchmark().baselineCosts(), LlvmBaselinePolicy::O0,
-                                        LlvmCostFunction::OBJECT_TEXT_SIZE_BYTES);
-      reply.set_scalar_int64(static_cast<int64_t>(cost));
-      break;
-    }
-    case LlvmObservationSpace::OBJECT_TEXT_SIZE_O3: {
-      const auto cost = getBaselineCost(benchmark().baselineCosts(), LlvmBaselinePolicy::O3,
-                                        LlvmCostFunction::OBJECT_TEXT_SIZE_BYTES);
-      reply.set_scalar_int64(static_cast<int64_t>(cost));
-      break;
-    }
-    case LlvmObservationSpace::OBJECT_TEXT_SIZE_OZ: {
-      const auto cost = getBaselineCost(benchmark().baselineCosts(), LlvmBaselinePolicy::Oz,
-                                        LlvmCostFunction::OBJECT_TEXT_SIZE_BYTES);
-      reply.set_scalar_int64(static_cast<int64_t>(cost));
-      break;
-    }
-#ifdef COMPILER_GYM_EXPERIMENTAL_TEXT_SIZE_COST
-    case LlvmObservationSpace::TEXT_SIZE_BYTES: {
-      double cost;
-      RETURN_IF_ERROR(setCost(LlvmCostFunction::TEXT_SIZE_BYTES, benchmark().module(),
-                              workingDirectory(), &cost));
-      reply.set_scalar_int64(static_cast<int64_t>(cost));
-      break;
-    }
-    case LlvmObservationSpace::TEXT_SIZE_O0: {
-      const auto cost = getBaselineCost(benchmark().baselineCosts(), LlvmBaselinePolicy::O0,
-                                        LlvmCostFunction::TEXT_SIZE_BYTES);
-      reply.set_scalar_int64(static_cast<int64_t>(cost));
-      break;
-    }
-    case LlvmObservationSpace::TEXT_SIZE_O3: {
-      const auto cost = getBaselineCost(benchmark().baselineCosts(), LlvmBaselinePolicy::O3,
-                                        LlvmCostFunction::TEXT_SIZE_BYTES);
-      reply.set_scalar_int64(static_cast<int64_t>(cost));
-      break;
-    }
-    case LlvmObservationSpace::TEXT_SIZE_OZ: {
-      const auto cost = getBaselineCost(benchmark().baselineCosts(), LlvmBaselinePolicy::Oz,
-                                        LlvmCostFunction::TEXT_SIZE_BYTES);
-      reply.set_scalar_int64(static_cast<int64_t>(cost));
-      break;
-    }
-#endif
-    case LlvmObservationSpace::RUNTIME: {
-      return benchmark().computeRuntime(reply);
-    }
-    case LlvmObservationSpace::IS_BUILDABLE: {
-      reply.set_scalar_int64(benchmark().isBuildable() ? 1 : 0);
-      break;
-    }
-    case LlvmObservationSpace::IS_RUNNABLE: {
-      reply.set_scalar_int64(benchmark().isRunnable() ? 1 : 0);
-      break;
-    }
-    case LlvmObservationSpace::BUILDTIME: {
-      return benchmark().computeBuildtime(reply);
-    }
-  }
 
   return Status::OK;
 }

--- a/compiler_gym/envs/llvm/service/LlvmSession.h
+++ b/compiler_gym/envs/llvm/service/LlvmSession.h
@@ -15,6 +15,7 @@
 #include "compiler_gym/envs/llvm/service/ActionSpace.h"
 #include "compiler_gym/envs/llvm/service/Benchmark.h"
 #include "compiler_gym/envs/llvm/service/Cost.h"
+#include "compiler_gym/envs/llvm/service/Observation.h"
 #include "compiler_gym/envs/llvm/service/ObservationSpaces.h"
 #include "compiler_gym/service/CompilationSession.h"
 #include "compiler_gym/service/proto/compiler_gym_service.grpc.pb.h"
@@ -126,7 +127,6 @@ class LlvmSession final : public CompilationSession {
   }
 
   // Immutable state.
-  const programl::ProgramGraphOptions programlOptions_;
   const std::unordered_map<std::string, LlvmObservationSpace> observationSpaceNames_;
   // Mutable state initialized in init().
   LlvmActionSpace actionSpace_;

--- a/compiler_gym/envs/llvm/service/Observation.cc
+++ b/compiler_gym/envs/llvm/service/Observation.cc
@@ -1,0 +1,219 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+#include "compiler_gym/envs/llvm/service/Observation.h"
+
+#include <cpuinfo.h>
+#include <glog/logging.h>
+
+#include <iomanip>
+#include <sstream>
+#include <string>
+
+#include "boost/filesystem.hpp"
+#include "compiler_gym/envs/llvm/service/Benchmark.h"
+#include "compiler_gym/envs/llvm/service/Cost.h"
+#include "compiler_gym/envs/llvm/service/ObservationSpaces.h"
+#include "compiler_gym/third_party/autophase/InstCount.h"
+#include "compiler_gym/third_party/llvm/InstCount.h"
+#include "compiler_gym/util/GrpcStatusMacros.h"
+#include "llvm/Bitcode/BitcodeWriter.h"
+// #include "llvm/IR/Metadata.h"
+#include "llvm/IR/Module.h"
+#include "llvm/Support/raw_ostream.h"
+#include "nlohmann/json.hpp"
+#include "programl/graph/format/node_link_graph.h"
+#include "programl/ir/llvm/llvm.h"
+
+namespace fs = boost::filesystem;
+
+namespace compiler_gym::llvm_service {
+
+using grpc::Status;
+using grpc::StatusCode;
+using nlohmann::json;
+
+const programl::ProgramGraphOptions programlOptions;
+
+Status setObservation(LlvmObservationSpace space, const fs::path& workingDirectory,
+                      Benchmark& benchmark, Observation& reply) {
+  switch (space) {
+    case LlvmObservationSpace::IR: {
+      // Serialize the LLVM module to an IR string.
+      std::string ir;
+      llvm::raw_string_ostream rso(ir);
+      benchmark.module().print(rso, /*AAW=*/nullptr);
+      reply.set_string_value(ir);
+      break;
+    }
+    case LlvmObservationSpace::IR_SHA1: {
+      std::stringstream ss;
+      const BenchmarkHash hash = benchmark.module_hash();
+      // Hex encode, zero pad, and concatenate the unsigned integers that
+      // contain the hash.
+      for (uint32_t val : hash) {
+        ss << std::setfill('0') << std::setw(sizeof(BenchmarkHash::value_type) * 2) << std::hex
+           << val;
+      }
+      reply.set_string_value(ss.str());
+      break;
+    }
+    case LlvmObservationSpace::BITCODE_FILE: {
+      // Generate an output path with 16 bits of randomness.
+      const auto outpath = fs::unique_path(workingDirectory / "module-%%%%%%%%.bc");
+      RETURN_IF_ERROR(writeBitcodeFile(benchmark.module(), outpath.string()));
+      reply.set_string_value(outpath.string());
+      break;
+    }
+    case LlvmObservationSpace::INST_COUNT: {
+      const auto features = InstCount::getFeatureVector(benchmark.module());
+      *reply.mutable_int64_list()->mutable_value() = {features.begin(), features.end()};
+      break;
+    }
+    case LlvmObservationSpace::AUTOPHASE: {
+      const auto features = autophase::InstCount::getFeatureVector(benchmark.module());
+      *reply.mutable_int64_list()->mutable_value() = {features.begin(), features.end()};
+      break;
+    }
+    case LlvmObservationSpace::PROGRAML:
+    case LlvmObservationSpace::PROGRAML_JSON: {
+      // Build the ProGraML graph.
+      programl::ProgramGraph graph;
+      auto status =
+          programl::ir::llvm::BuildProgramGraph(benchmark.module(), &graph, programlOptions);
+      if (!status.ok()) {
+        return Status(StatusCode::INTERNAL, status.error_message());
+      }
+
+      // Serialize the graph to a JSON node link graph.
+      json nodeLinkGraph;
+      status = programl::graph::format::ProgramGraphToNodeLinkGraph(graph, &nodeLinkGraph);
+      if (!status.ok()) {
+        return Status(StatusCode::INTERNAL, status.error_message());
+      }
+      *reply.mutable_string_value() = nodeLinkGraph.dump();
+      break;
+    }
+    case LlvmObservationSpace::CPU_INFO: {
+      json hwinfo;
+      auto caches = {
+          std::make_tuple("l1i_cache", cpuinfo_get_l1i_caches(), cpuinfo_get_l1d_caches_count()),
+          {"l1d_cache", cpuinfo_get_l1d_caches(), cpuinfo_get_l1d_caches_count()},
+          {"l2_cache", cpuinfo_get_l2_caches(), cpuinfo_get_l2_caches_count()},
+          {"l3_cache", cpuinfo_get_l3_caches(), cpuinfo_get_l3_caches_count()},
+          {"l4_cache", cpuinfo_get_l4_caches(), cpuinfo_get_l4_caches_count()}};
+      for (auto [name, cache, count] : caches) {
+        std::string sizeName = std::string(name) + "_size";
+        std::string countName = std::string(name) + "_count";
+        if (cache) {
+          hwinfo[sizeName] = cache->size;
+          hwinfo[countName] = count;
+        } else {
+          hwinfo[sizeName] = -1;
+          hwinfo[countName] = count;
+        }
+      }
+      hwinfo["cores_count"] = cpuinfo_get_cores_count();
+      auto cpu = cpuinfo_get_packages();
+      hwinfo["name"] = cpu->name;
+      *reply.mutable_string_value() = hwinfo.dump();
+      break;
+    }
+    case LlvmObservationSpace::IR_INSTRUCTION_COUNT: {
+      double cost;
+      RETURN_IF_ERROR(setCost(LlvmCostFunction::IR_INSTRUCTION_COUNT, benchmark.module(),
+                              workingDirectory, &cost));
+      reply.set_scalar_int64(static_cast<int64_t>(cost));
+      break;
+    }
+    case LlvmObservationSpace::IR_INSTRUCTION_COUNT_O0: {
+      const auto cost = getBaselineCost(benchmark.baselineCosts(), LlvmBaselinePolicy::O0,
+                                        LlvmCostFunction::IR_INSTRUCTION_COUNT);
+      reply.set_scalar_int64(static_cast<int64_t>(cost));
+      break;
+    }
+    case LlvmObservationSpace::IR_INSTRUCTION_COUNT_O3: {
+      const auto cost = getBaselineCost(benchmark.baselineCosts(), LlvmBaselinePolicy::O3,
+                                        LlvmCostFunction::IR_INSTRUCTION_COUNT);
+      reply.set_scalar_int64(static_cast<int64_t>(cost));
+      break;
+    }
+    case LlvmObservationSpace::IR_INSTRUCTION_COUNT_OZ: {
+      const auto cost = getBaselineCost(benchmark.baselineCosts(), LlvmBaselinePolicy::Oz,
+                                        LlvmCostFunction::IR_INSTRUCTION_COUNT);
+      reply.set_scalar_int64(static_cast<int64_t>(cost));
+      break;
+    }
+    case LlvmObservationSpace::OBJECT_TEXT_SIZE_BYTES: {
+      double cost;
+      RETURN_IF_ERROR(setCost(LlvmCostFunction::OBJECT_TEXT_SIZE_BYTES, benchmark.module(),
+                              workingDirectory, &cost));
+      reply.set_scalar_int64(static_cast<int64_t>(cost));
+      break;
+    }
+    case LlvmObservationSpace::OBJECT_TEXT_SIZE_O0: {
+      const auto cost = getBaselineCost(benchmark.baselineCosts(), LlvmBaselinePolicy::O0,
+                                        LlvmCostFunction::OBJECT_TEXT_SIZE_BYTES);
+      reply.set_scalar_int64(static_cast<int64_t>(cost));
+      break;
+    }
+    case LlvmObservationSpace::OBJECT_TEXT_SIZE_O3: {
+      const auto cost = getBaselineCost(benchmark.baselineCosts(), LlvmBaselinePolicy::O3,
+                                        LlvmCostFunction::OBJECT_TEXT_SIZE_BYTES);
+      reply.set_scalar_int64(static_cast<int64_t>(cost));
+      break;
+    }
+    case LlvmObservationSpace::OBJECT_TEXT_SIZE_OZ: {
+      const auto cost = getBaselineCost(benchmark.baselineCosts(), LlvmBaselinePolicy::Oz,
+                                        LlvmCostFunction::OBJECT_TEXT_SIZE_BYTES);
+      reply.set_scalar_int64(static_cast<int64_t>(cost));
+      break;
+    }
+#ifdef COMPILER_GYM_EXPERIMENTAL_TEXT_SIZE_COST
+    case LlvmObservationSpace::TEXT_SIZE_BYTES: {
+      double cost;
+      RETURN_IF_ERROR(
+          setCost(LlvmCostFunction::TEXT_SIZE_BYTES, benchmark.module(), workingDirectory, &cost));
+      reply.set_scalar_int64(static_cast<int64_t>(cost));
+      break;
+    }
+    case LlvmObservationSpace::TEXT_SIZE_O0: {
+      const auto cost = getBaselineCost(benchmark.baselineCosts(), LlvmBaselinePolicy::O0,
+                                        LlvmCostFunction::TEXT_SIZE_BYTES);
+      reply.set_scalar_int64(static_cast<int64_t>(cost));
+      break;
+    }
+    case LlvmObservationSpace::TEXT_SIZE_O3: {
+      const auto cost = getBaselineCost(benchmark.baselineCosts(), LlvmBaselinePolicy::O3,
+                                        LlvmCostFunction::TEXT_SIZE_BYTES);
+      reply.set_scalar_int64(static_cast<int64_t>(cost));
+      break;
+    }
+    case LlvmObservationSpace::TEXT_SIZE_OZ: {
+      const auto cost = getBaselineCost(benchmark.baselineCosts(), LlvmBaselinePolicy::Oz,
+                                        LlvmCostFunction::TEXT_SIZE_BYTES);
+      reply.set_scalar_int64(static_cast<int64_t>(cost));
+      break;
+    }
+#endif
+    case LlvmObservationSpace::RUNTIME: {
+      return benchmark.computeRuntime(reply);
+    }
+    case LlvmObservationSpace::IS_BUILDABLE: {
+      reply.set_scalar_int64(benchmark.isBuildable() ? 1 : 0);
+      break;
+    }
+    case LlvmObservationSpace::IS_RUNNABLE: {
+      reply.set_scalar_int64(benchmark.isRunnable() ? 1 : 0);
+      break;
+    }
+    case LlvmObservationSpace::BUILDTIME: {
+      return benchmark.computeBuildtime(reply);
+    }
+  }
+
+  return Status::OK;
+}
+
+}  // namespace compiler_gym::llvm_service

--- a/compiler_gym/envs/llvm/service/Observation.h
+++ b/compiler_gym/envs/llvm/service/Observation.h
@@ -1,0 +1,29 @@
+
+
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+#pragma once
+
+#include "boost/filesystem.hpp"
+#include "compiler_gym/envs/llvm/service/Benchmark.h"
+#include "compiler_gym/envs/llvm/service/ObservationSpaces.h"
+#include "compiler_gym/service/proto/compiler_gym_service.pb.h"
+
+namespace compiler_gym::llvm_service {
+
+/**
+ * Compute an observation using the given space.
+ *
+ * @param space The observation space to compute.
+ * @param workingDirectory A scratch directory.
+ * @param benchmark The benchmark to compute the observation on.
+ * @param reply The observation to set.
+ * @return `OK` on success.
+ */
+grpc::Status setObservation(LlvmObservationSpace space,
+                            const boost::filesystem::path& workingDirectory, Benchmark& benchmark,
+                            Observation& reply);
+
+}  // namespace compiler_gym::llvm_service

--- a/docs/source/cc/compiler_gym/envs/llvm/service.rst
+++ b/docs/source/cc/compiler_gym/envs/llvm/service.rst
@@ -45,6 +45,13 @@ LlvmSession.h
 
 .. doxygenfile:: compiler_gym/envs/llvm/service/LlvmSession.h
 
+Observation.h
+-------------
+
+:code:`#include "compiler_gym/envs/llvm/service/Observation.h"`
+
+.. doxygenfile:: compiler_gym/envs/llvm/service/Observation.h
+
 ObservationSpaces.h
 -------------------
 

--- a/docs/source/compiler_gym/envs/gcc.rst
+++ b/docs/source/compiler_gym/envs/gcc.rst
@@ -47,7 +47,7 @@ Compiler Description
 Datasets
 --------
 
-.. currentmodule:: compiler_gym.envs.llvm.datasets
+.. currentmodule:: compiler_gym.envs.gcc.datasets
 
 .. autofunction:: get_gcc_datasets
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -38,7 +38,7 @@ for applying reinforcement learning to compiler optimizations.
    compiler_gym/datasets
    compiler_gym/envs
    compiler_gym/envs/gcc
-   compiler_gym/envs/llvm
+   llvm/api
    compiler_gym/leaderboard
    compiler_gym/service
    compiler_gym/spaces

--- a/docs/source/llvm/api.rst
+++ b/docs/source/llvm/api.rst
@@ -55,3 +55,11 @@ Datasets
 .. autoclass:: POJ104Dataset
 
 .. autoclass:: TensorFlowDataset
+
+
+Miscellaneous
+-------------
+
+.. currentmodule:: compiler_gym.envs.llvm
+
+.. autofunction:: compute_observation

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,7 @@ setuptools.setup(
             "envs/gcc/service/compiler_gym-gcc-service",
             "envs/llvm/service/compiler_gym-llvm-service",
             "envs/llvm/service/libLLVMPolly.so",
+            "envs/llvm/service/compute_observation",
             "envs/llvm/service/passes/*.txt",
             "third_party/cbench/benchmarks.txt",
             "third_party/cbench/cbench-v*/*",

--- a/tests/llvm/BUILD
+++ b/tests/llvm/BUILD
@@ -41,6 +41,16 @@ py_test(
 )
 
 py_test(
+    name = "compute_observation_test",
+    srcs = ["compute_observation_test.py"],
+    deps = [
+        "//compiler_gym/envs/llvm",
+        "//tests:test_main",
+        "//tests/pytest_plugins:llvm",
+    ],
+)
+
+py_test(
     name = "custom_benchmarks_test",
     srcs = ["custom_benchmarks_test.py"],
     data = [

--- a/tests/llvm/compute_observation_test.py
+++ b/tests/llvm/compute_observation_test.py
@@ -1,0 +1,76 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Tests for the compute_observation() function."""
+from pathlib import Path
+
+import networkx.algorithms.isomorphism
+import pytest
+
+from compiler_gym.envs.llvm import LlvmEnv, compute_observation
+from tests.test_main import main
+
+pytest_plugins = ["tests.pytest_plugins.llvm"]
+
+
+def test_invalid_observation_space_name(env: LlvmEnv, tmpdir):
+    tmpdir = Path(tmpdir)
+    env.reset()
+    env.write_bitcode(tmpdir / "ir.bc")
+    space = env.observation.spaces["Ir"]
+    space.id = "NotARealName"
+
+    with pytest.raises(
+        ValueError, match="Invalid observation space name: NOT_A_REAL_NAME"
+    ):
+        compute_observation(space, tmpdir / "ir.bc")
+
+
+def test_missing_file(env: LlvmEnv, tmpdir):
+    tmpdir = Path(tmpdir)
+    env.reset()
+
+    with pytest.raises(FileNotFoundError, match=str(tmpdir / "ir.bc")):
+        compute_observation(env.observation.spaces["Ir"], tmpdir / "ir.bc")
+
+
+def test_timeout_expired(env: LlvmEnv, tmpdir):
+    tmpdir = Path(tmpdir)
+    env.reset(benchmark="cbench-v1/jpeg-c")  # larger benchmark
+    env.write_bitcode(tmpdir / "ir.bc")
+    space = env.observation.spaces["Programl"]
+
+    with pytest.raises(
+        TimeoutError, match="Failed to compute Programl observation in 0.1 seconds"
+    ):
+        compute_observation(space, tmpdir / "ir.bc", timeout=0.1)
+
+
+@pytest.mark.parametrize(
+    "observation_space", ["Ir", "IrInstructionCount", "ObjectTextSizeBytes"]
+)
+def test_observation_equivalence(env: LlvmEnv, tmpdir, observation_space: str):
+    """Test that compute_observation() produces the same result as the environment."""
+    tmpdir = Path(tmpdir)
+    env.reset()
+    env.write_bitcode(tmpdir / "ir.bc")
+
+    observation = compute_observation(
+        env.observation.spaces[observation_space], tmpdir / "ir.bc"
+    )
+    assert observation == env.observation[observation_space]
+
+
+def test_observation_programl_equivalence(env: LlvmEnv, tmpdir):
+    """Test that compute_observation() produces the same result as the environment."""
+    tmpdir = Path(tmpdir)
+    env.reset()
+    env.write_bitcode(tmpdir / "ir.bc")
+
+    G = compute_observation(env.observation.spaces["Programl"], tmpdir / "ir.bc")
+    networkx.algorithms.isomorphism.is_isomorphic(G, env.observation.Programl())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This adds a new standalone `compute_observation` binary that takes an observation space name and a LLVM bitcode and computes an observation. There is a corresponding `compiler_gym.envs.llvm.compute_observation()` python function to run the binary.

It is intended for use cases where you want to compute an observation without the overhead of initializing a full environment.

Example usage:

```py
>>> env = compiler_gym.make("llvm-v0")
>>> space = env.observation.spaces["Ir"]
>>> bitcode = Path("bitcode.bc")
>>> observation = llvm.compute_observation(space, bitcode, timeout=30)
```