### PR TITLE
Improve GCC env docker compatibility

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -295,6 +295,11 @@ jobs:
         needs: build-macos
         runs-on: macos-latest
         steps:
+            - uses: docker-practice/actions-setup-docker@master
+
+            - name: Confirm docker install
+              run: docker version
+
             - uses: actions/checkout@v2
 
             - name: Set up Python
@@ -329,9 +334,6 @@ jobs:
         needs: build-macos
         runs-on: macos-latest
         steps:
-            - name: Stop Docker
-              run: killall Docker
-
             - uses: actions/checkout@v2
 
             - name: Set up Python

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -252,20 +252,55 @@ jobs:
               with:
                   fail_ci_if_error: true
                   verbose: true
+    test-gcc-env-linux-no-docker:
+        needs: build-linux
+        runs-on: ubuntu-latest
+        steps:
+            - name: Stop docker
+              run: |
+                  docker ps -q | xargs --no-run-if-empty sudo docker kill
+                  sudo systemctl stop docker
+
+            - name: Set up Python
+              uses: actions/setup-python@v2
+              with:
+                  python-version: 3.9
+
+            - uses: actions/checkout@v2
+
+            - name: Download Python wheel
+              uses: actions/download-artifact@v2
+              with:
+                  name: linux-wheel
+
+            - name: Install wheel
+              run: python -m pip install *.whl
+
+            - name: Install runtime dependencies
+              uses: ./.github/actions/install-runtime-dependencies
+
+            - name: Install test dependencies
+              run: python -m pip install -r tests/requirements.txt
+
+            - name: Run the test suite
+              run: make install-test-cov TEST_TARGET="tests/gcc"
+
+            - name: Upload coverage report to Codecov
+              uses: codecov/codecov-action@v2
+              with:
+                  fail_ci_if_error: true
+                  verbose: true
+
     test-gcc-env-macos:
         needs: build-macos
         runs-on: macos-latest
-        strategy:
-            fail-fast: false
-            matrix:
-                python: [3.9]
         steps:
             - uses: actions/checkout@v2
 
-            - name: Set up Python ${{ matrix.python }}
+            - name: Set up Python
               uses: actions/setup-python@v2
               with:
-                  python-version: ${{ matrix.python }}
+                  python-version: 3.9
 
             - name: Download Python wheel
               uses: actions/download-artifact@v2
@@ -289,6 +324,44 @@ jobs:
               with:
                   fail_ci_if_error: true
                   verbose: true
+
+    test-gcc-env-macos-no-docker:
+        needs: build-macos
+        runs-on: macos-latest
+        steps:
+            - name: Stop Docker
+              run: killall Docker
+
+            - uses: actions/checkout@v2
+
+            - name: Set up Python
+              uses: actions/setup-python@v2
+              with:
+                  python-version: 3.9
+
+            - name: Download Python wheel
+              uses: actions/download-artifact@v2
+              with:
+                  name: macos-wheel
+
+            - name: Install wheel
+              run: python -m pip install *.whl
+
+            - name: Install runtime dependencies
+              uses: ./.github/actions/install-runtime-dependencies
+
+            - name: Install test dependencies
+              run: python -m pip install -r tests/requirements.txt
+
+            - name: Run the test suite
+              run: make install-test-cov TEST_TARGET="tests/gcc"
+
+            - name: Upload coverage report to Codecov
+              uses: codecov/codecov-action@v2
+              with:
+                  fail_ci_if_error: true
+                  verbose: true
+
     test-examples-linux:
         needs: build-linux
         runs-on: ubuntu-latest

--- a/compiler_gym/envs/gcc/gcc_env.py
+++ b/compiler_gym/envs/gcc/gcc_env.py
@@ -7,7 +7,7 @@ import codecs
 import json
 import pickle
 from pathlib import Path
-from typing import Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 from compiler_gym.datasets import Benchmark
 from compiler_gym.envs.compiler_env import CompilerEnv
@@ -195,3 +195,11 @@ class GccEnv(CompilerEnv):
             -1 <= c < len(self.gcc_spec.options[i]) for i, c in enumerate(choices)
         )
         self.send_param("choices", ",".join(map(str, choices)))
+
+    def _init_kwargs(self) -> Dict[str, Any]:
+        """Return the arguments required to initialize a GccEnv."""
+        return {
+            # GCC has an additional gcc_bin argument.
+            "gcc_bin": self.gcc_spec.gcc.bin,
+            **super()._init_kwargs(),
+        }

--- a/compiler_gym/service/runtime/CreateAndRunCompilerGymServiceImpl.h
+++ b/compiler_gym/service/runtime/CreateAndRunCompilerGymServiceImpl.h
@@ -138,9 +138,9 @@ template <typename CompilationSessionType>
   serverThread.join();
 
   if (service.sessionCount()) {
-    std::cerr << "ERROR: Killing a service with " << service.sessionCount()
-              << (service.sessionCount() > 1 ? " active sessions!" : " active session!")
-              << std::endl;
+    LOG(ERROR) << "ERROR: Killing a service with " << service.sessionCount()
+               << (service.sessionCount() > 1 ? " active sessions!" : " active session!")
+               << std::endl;
     exit(6);
   }
 

--- a/tests/gcc/datasets/anghabench_test.py
+++ b/tests/gcc/datasets/anghabench_test.py
@@ -10,7 +10,6 @@ import gym
 import pytest
 
 import compiler_gym.envs.gcc  # noqa register environments
-from compiler_gym.envs.gcc.datasets import AnghaBenchDataset
 from tests.pytest_plugins.common import skip_on_ci
 from tests.pytest_plugins.gcc import with_gcc_support
 from tests.test_main import main
@@ -18,46 +17,47 @@ from tests.test_main import main
 pytest_plugins = ["tests.pytest_plugins.common", "tests.pytest_plugins.gcc"]
 
 
-@pytest.fixture(scope="module")
-def anghabench_dataset() -> AnghaBenchDataset:
-    with gym.make("gcc-v0") as env:
-        ds = env.datasets["anghabench-v1"]
-    yield ds
+@with_gcc_support
+def test_anghabench_size(gcc_bin: str):
+    with gym.make("gcc-v0", gcc_bin=gcc_bin) as env:
+        anghabench_dataset = env.datasets["anghabench-v1"]
+
+        if sys.platform == "darwin":
+            assert anghabench_dataset.size == 1041265
+        else:
+            assert anghabench_dataset.size == 1041333
 
 
 @with_gcc_support
-def test_anghabench_size(anghabench_dataset: AnghaBenchDataset):
-    if sys.platform == "darwin":
-        assert anghabench_dataset.size == 1041265
-    else:
-        assert anghabench_dataset.size == 1041333
+def test_missing_benchmark_name(gcc_bin: str, mocker):
+    with gym.make("gcc-v0", gcc_bin=gcc_bin) as env:
+        anghabench_dataset = env.datasets["anghabench-v1"]
 
+        # Mock install() so that on CI it doesn't download and unpack the tarfile.
+        mocker.patch.object(anghabench_dataset, "install")
 
-@with_gcc_support
-def test_missing_benchmark_name(anghabench_dataset: AnghaBenchDataset, mocker):
-    # Mock install() so that on CI it doesn't download and unpack the tarfile.
-    mocker.patch.object(anghabench_dataset, "install")
+        with pytest.raises(
+            LookupError, match=r"^Benchmark not found: benchmark://anghabench-v1"
+        ):
+            anghabench_dataset.benchmark("benchmark://anghabench-v1")
+        anghabench_dataset.install.assert_called_once()
 
-    with pytest.raises(
-        LookupError, match=r"^Benchmark not found: benchmark://anghabench-v1"
-    ):
-        anghabench_dataset.benchmark("benchmark://anghabench-v1")
-    anghabench_dataset.install.assert_called_once()
-
-    with pytest.raises(
-        LookupError, match=r"^Benchmark not found: benchmark://anghabench-v1/"
-    ):
-        anghabench_dataset.benchmark("benchmark://anghabench-v1/")
-    assert anghabench_dataset.install.call_count == 2
+        with pytest.raises(
+            LookupError, match=r"^Benchmark not found: benchmark://anghabench-v1/"
+        ):
+            anghabench_dataset.benchmark("benchmark://anghabench-v1/")
+        assert anghabench_dataset.install.call_count == 2
 
 
 @with_gcc_support
 @skip_on_ci
 @pytest.mark.parametrize("index", range(10))
-def test_anghabench_random_select(anghabench_dataset: AnghaBenchDataset, index: int):
-    uri = next(islice(anghabench_dataset.benchmark_uris(), index, None))
-    benchmark = anghabench_dataset.benchmark(uri)
-    with gym.make("gcc-v0") as env:
+def test_anghabench_random_select(gcc_bin: str, index: int):
+    with gym.make("gcc-v0", gcc_bin=gcc_bin) as env:
+        anghabench_dataset = env.datasets["anghabench-v1"]
+
+        uri = next(islice(anghabench_dataset.benchmark_uris(), index, None))
+        benchmark = anghabench_dataset.benchmark(uri)
         env.reset(benchmark=benchmark)
 
 

--- a/tests/gcc/datasets/csmith_test.py
+++ b/tests/gcc/datasets/csmith_test.py
@@ -10,7 +10,7 @@ import gym
 import numpy as np
 import pytest
 
-from compiler_gym.envs.gcc.datasets import CsmithBenchmark, CsmithDataset
+from compiler_gym.envs.gcc.datasets import CsmithBenchmark
 from tests.pytest_plugins.common import is_ci
 from tests.pytest_plugins.gcc import with_gcc_support
 from tests.test_main import main
@@ -18,48 +18,54 @@ from tests.test_main import main
 pytest_plugins = ["tests.pytest_plugins.common", "tests.pytest_plugins.gcc"]
 
 
-@pytest.fixture(scope="module")
-def csmith_dataset() -> CsmithDataset:
-    with gym.make("gcc-v0") as env:
-        ds = env.datasets["generator://csmith-v0"]
-    yield ds
-
-
 @with_gcc_support
-def test_csmith_size(csmith_dataset: CsmithDataset):
-    assert csmith_dataset.size == 0
-    assert len(csmith_dataset) == 0
+def test_csmith_size(gcc_bin: str):
+    with gym.make("gcc-v0", gcc_bin=gcc_bin) as env:
+        csmith_dataset = env.datasets["generator://csmith-v0"]
+
+        assert csmith_dataset.size == 0
+        assert len(csmith_dataset) == 0
 
 
 @with_gcc_support
 @pytest.mark.parametrize("index", range(3) if is_ci() else range(10))
-def test_csmith_random_select(csmith_dataset: CsmithDataset, index: int, tmpwd: Path):
-    uri = next(islice(csmith_dataset.benchmark_uris(), index, None))
-    benchmark = csmith_dataset.benchmark(uri)
-    assert isinstance(benchmark, CsmithBenchmark)
-    with gym.make("gcc-v0") as env:
+def test_csmith_random_select(gcc_bin: str, index: int, tmpwd: Path):
+    with gym.make("gcc-v0", gcc_bin=gcc_bin) as env:
+        csmith_dataset = env.datasets["generator://csmith-v0"]
+
+        uri = next(islice(csmith_dataset.benchmark_uris(), index, None))
+        benchmark = csmith_dataset.benchmark(uri)
+        assert isinstance(benchmark, CsmithBenchmark)
         env.reset(benchmark=benchmark)
 
-    assert benchmark.source
-    benchmark.write_sources_to_directory(tmpwd)
-    assert (tmpwd / "source.c").is_file()
+        assert benchmark.source
+        benchmark.write_sources_to_directory(tmpwd)
+        assert (tmpwd / "source.c").is_file()
 
 
 @with_gcc_support
-def test_random_benchmark(csmith_dataset: CsmithDataset):
-    num_benchmarks = 5
-    rng = np.random.default_rng(0)
-    random_benchmarks = {
-        b.uri
-        for b in (csmith_dataset.random_benchmark(rng) for _ in range(num_benchmarks))
-    }
-    assert len(random_benchmarks) == num_benchmarks
+def test_random_benchmark(gcc_bin: str):
+    with gym.make("gcc-v0", gcc_bin=gcc_bin) as env:
+        csmith_dataset = env.datasets["generator://csmith-v0"]
+
+        num_benchmarks = 5
+        rng = np.random.default_rng(0)
+        random_benchmarks = {
+            b.uri
+            for b in (
+                csmith_dataset.random_benchmark(rng) for _ in range(num_benchmarks)
+            )
+        }
+        assert len(random_benchmarks) == num_benchmarks
 
 
 @with_gcc_support
-def test_csmith_from_seed_retry_count_exceeded(csmith_dataset: CsmithDataset):
-    with pytest.raises(OSError, match="Csmith failed after 5 attempts with seed 1"):
-        csmith_dataset.benchmark_from_seed(seed=1, max_retries=3, retry_count=5)
+def test_csmith_from_seed_retry_count_exceeded(gcc_bin: str):
+    with gym.make("gcc-v0", gcc_bin=gcc_bin) as env:
+        csmith_dataset = env.datasets["generator://csmith-v0"]
+
+        with pytest.raises(OSError, match="Csmith failed after 5 attempts with seed 1"):
+            csmith_dataset.benchmark_from_seed(seed=1, max_retries=3, retry_count=5)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
* Add a separate CI job to run the GCC tests.
* Add a CI job to run the GCC tests without docker.
* Fix a bug in `fork()` for GCC.
* Run the GCC tests on whichever is available out of: system compiler, docker.