### PR TITLE
[leaderboard] Change benchmarks execution to Round Robin

### DIFF
--- a/compiler_gym/leaderboard/llvm_instcount.py
+++ b/compiler_gym/leaderboard/llvm_instcount.py
@@ -246,7 +246,6 @@ def eval_llvm_instcount_policy(policy: Policy) -> None:
 
             # Repeat the searches for the requested number of iterations.
             benchmarks *= FLAGS.n
-            benchmarks = sorted(benchmarks)
             total_count = len(benchmarks)
 
             # If we are resuming from a previous job, read the states that have


### PR DESCRIPTION
Hi! Benchmarks were being sorted that means that we had something like `[1, 1, 2, 2, 3 ,3]`, so if we remove the sort and leave it as it is we'll have `[1, 2, 3, 1, 2, 3]`. I think this is what was expected after reading the description. Please let me know what do you think :)!

Signed-off-by: thecoblack <victoracb13@gmail.com>

Fixes #243 
