### PR TITLE
[ci] Fix Linux test action for running GCC tests without docker.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -260,6 +260,7 @@ jobs:
               run: |
                   docker ps -q | xargs --no-run-if-empty sudo docker kill
                   sudo systemctl stop docker
+                  sudo apt-get remove -y docker docker-engine docker.io containerd runc
 
             - name: Set up Python
               uses: actions/setup-python@v2


### PR DESCRIPTION
Fixes the GCC test action introduced in #415.