### PR TITLE
Unrolling example service

### DIFF
--- a/compiler_gym/envs/llvm/llvm_benchmark.py
+++ b/compiler_gym/envs/llvm/llvm_benchmark.py
@@ -7,34 +7,19 @@ import logging
 import os
 import random
 import subprocess
-import sys
 import tempfile
 from concurrent.futures import as_completed
 from datetime import datetime
 from pathlib import Path
-from signal import Signals
 from typing import Iterable, List, Optional, Union
 
 from compiler_gym.datasets import Benchmark, BenchmarkInitError
 from compiler_gym.third_party import llvm
+from compiler_gym.util.commands import communicate, run_command
 from compiler_gym.util.runfiles_path import transient_cache_path
 from compiler_gym.util.thread_pool import get_thread_pool_executor
 
 logger = logging.getLogger(__name__)
-
-
-def _communicate(process, input=None, timeout=None):
-    """subprocess.communicate() which kills subprocess on timeout."""
-    try:
-        return process.communicate(input=input, timeout=timeout)
-    except subprocess.TimeoutExpired:
-        # kill() was added in Python 3.7.
-        if sys.version_info >= (3, 7, 0):
-            process.kill()
-        else:
-            process.terminate()
-        process.communicate(timeout=timeout)  # Wait for shutdown to complete.
-        raise
 
 
 def get_compiler_includes(compiler: str) -> Iterable[Path]:
@@ -58,7 +43,7 @@ def get_compiler_includes(compiler: str) -> Iterable[Path]:
                 f"Is there a working system compiler?\n"
                 f"Error: {e}"
             ) from e
-        _, stderr = _communicate(process, input="", timeout=30)
+        _, stderr = communicate(process, input="", timeout=30)
     if process.returncode:
         raise OSError(
             f"Failed to invoke {compiler}. "
@@ -187,26 +172,6 @@ class ClangInvocation:
             DEFAULT_COPT + copt + [str(path)],
             system_includes=system_includes,
             timeout=timeout,
-        )
-
-
-def _run_command(cmd: List[str], timeout: int):
-    process = subprocess.Popen(
-        cmd, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, universal_newlines=True
-    )
-    _, stderr = _communicate(process, timeout=timeout)
-    if process.returncode:
-        returncode = process.returncode
-        try:
-            # Try and decode the name of a signal. Signal returncodes
-            # are negative.
-            returncode = f"{returncode} ({Signals(abs(returncode)).name})"
-        except ValueError:
-            pass
-        raise BenchmarkInitError(
-            f"Compilation job failed with returncode {returncode}\n"
-            f"Command: {' '.join(cmd)}\n"
-            f"Stderr: {stderr.strip()}"
         )
 
 
@@ -369,10 +334,10 @@ def make_benchmark(
 
             # Fire off the clang and llvm-as jobs.
             futures = [
-                executor.submit(_run_command, job.command(out), job.timeout)
+                executor.submit(run_command, job.command(out), job.timeout)
                 for job, out in zip(clang_jobs, clang_outs)
             ] + [
-                executor.submit(_run_command, command, timeout)
+                executor.submit(run_command, command, timeout)
                 for command in llvm_as_commands
             ]
 
@@ -404,7 +369,7 @@ def make_benchmark(
             llvm_link = subprocess.Popen(
                 llvm_link_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE
             )
-            bitcode, stderr = _communicate(llvm_link, timeout=timeout)
+            bitcode, stderr = communicate(llvm_link, timeout=timeout)
             if llvm_link.returncode:
                 raise BenchmarkInitError(
                     f"Failed to link LLVM bitcodes with error: {stderr.decode('utf-8')}"

--- a/compiler_gym/service/runtime/BenchmarkCache.cc
+++ b/compiler_gym/service/runtime/BenchmarkCache.cc
@@ -27,8 +27,6 @@ const Benchmark* BenchmarkCache::get(const std::string& uri) const {
 
 void BenchmarkCache::add(const Benchmark&& benchmark) {
   const size_t benchmarkSize = benchmark.ByteSizeLong();
-  VLOG(3) << "Caching benchmark " << benchmark.uri() << " (" << benchmarkSize
-          << " bytes). Cache size = " << sizeInBytes() << " bytes, " << size() << " items";
 
   // Remove any existing value to keep the cache size consistent.
   const auto it = benchmarks_.find(benchmark.uri());
@@ -52,6 +50,9 @@ void BenchmarkCache::add(const Benchmark&& benchmark) {
 
   benchmarks_.insert({benchmark.uri(), std::move(benchmark)});
   sizeInBytes_ += benchmarkSize;
+
+  VLOG(3) << "Cached benchmark " << benchmark.uri() << " (" << benchmarkSize
+          << " bytes). Cache size = " << sizeInBytes() << " bytes, " << size() << " items";
 }
 
 void BenchmarkCache::evictToCapacity(std::optional<size_t> targetSize) {

--- a/compiler_gym/service/runtime/benchmark_cache.py
+++ b/compiler_gym/service/runtime/benchmark_cache.py
@@ -46,13 +46,6 @@ class BenchmarkCache:
 
     def __setitem__(self, uri: str, benchmark: Benchmark):
         """Add benchmark to cache."""
-        logger.debug(
-            "Caching benchmark %s. Cache size = %d bytes, %d items",
-            uri,
-            self.size_in_bytes,
-            self.size,
-        )
-
         # Remove any existing value to keep the cache size consistent.
         if uri in self._benchmarks:
             self._size_in_bytes -= self._benchmarks[uri].ByteSize()
@@ -79,6 +72,13 @@ class BenchmarkCache:
 
         self._benchmarks[uri] = benchmark
         self._size_in_bytes += size
+
+        logger.debug(
+            "Cached benchmark %s. Cache size = %d bytes, %d items",
+            uri,
+            self.size_in_bytes,
+            self.size,
+        )
 
     def evict_to_capacity(self, target_size_in_bytes: Optional[int] = None) -> None:
         """Evict benchmarks randomly to reduce the capacity below 50%."""

--- a/compiler_gym/third_party/llvm/__init__.py
+++ b/compiler_gym/third_party/llvm/__init__.py
@@ -99,9 +99,19 @@ def lli_path() -> Path:
     return download_llvm_files() / "bin/lli"
 
 
+def llc_path() -> Path:
+    """Return the path of llc."""
+    return download_llvm_files() / "bin/llc"
+
+
 def llvm_as_path() -> Path:
     """Return the path of llvm-as."""
     return download_llvm_files() / "bin/llvm-as"
+
+
+def llvm_dis_path() -> Path:
+    """Return the path of llvm-as."""
+    return download_llvm_files() / "bin/llvm-dis"
 
 
 def llvm_link_path() -> Path:

--- a/compiler_gym/third_party/neuro-vectorizer/BUILD
+++ b/compiler_gym/third_party/neuro-vectorizer/BUILD
@@ -1,0 +1,5 @@
+filegroup(
+    name = "header",
+    srcs = ["header.h"],
+    visibility = ["//visibility:public"],
+)

--- a/compiler_gym/third_party/neuro-vectorizer/LICENSE
+++ b/compiler_gym/third_party/neuro-vectorizer/LICENSE
@@ -1,16 +1,22 @@
-/*
+BSD 3-Clause License
+
 Copyright (c) 2019, Ameer Haj Ali (UC Berkeley), and Intel Corporation
 All rights reserved.
+
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
+
 1. Redistributions of source code must retain the above copyright notice, this
    list of conditions and the following disclaimer.
+
 2. Redistributions in binary form must reproduce the above copyright notice,
    this list of conditions and the following disclaimer in the documentation
    and/or other materials provided with the distribution.
+
 3. Neither the name of the copyright holder nor the names of its
    contributors may be used to endorse or promote products derived from
    this software without specific prior written permission.
+
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -21,34 +27,3 @@ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
 CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
-#include <stdbool.h>
-#include <stdio.h>
-#include <sys/time.h>
-
-#define ALIGNED16 __attribute__((aligned(16)))
-
-typedef int aint __attribute__((__aligned__(16)));
-
-// Warmup and then measure.
-#define BENCH(NAME, RUN_LINE, ITER, DIGEST_LINE) \
-  {                                              \
-    struct timeval Start, End;                   \
-    RUN_LINE;                                    \
-    gettimeofday(&Start, 0);                     \
-    for (int i = 0; i < (ITER); ++i) RUN_LINE;   \
-    gettimeofday(&End, 0);                       \
-    unsigned r = DIGEST_LINE;                    \
-    long mtime, s, us;                           \
-    s = End.tv_sec - Start.tv_sec;               \
-    us = End.tv_usec - Start.tv_usec;            \
-    mtime = (s * 1000 + us / 1000.0) + 0.5;      \
-    if (print_times)                             \
-      printf("%ld", mtime);                      \
-  }
-#define Mi 1048576        // 1<<20
-#define print_times true  // argc > 1;
-void init_memory(void* start, void* end);
-void init_memory_float(float* start, float* end);
-unsigned digest_memory(void* start, void* end);
-void atimer(const char* title, bool print);

--- a/compiler_gym/third_party/neuro-vectorizer/header.h
+++ b/compiler_gym/third_party/neuro-vectorizer/header.h
@@ -1,0 +1,51 @@
+/*
+Copyright (c) 2019, Ameer Haj Ali (UC Berkeley), and Intel Corporation
+All rights reserved.
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#include <stdbool.h>
+#include <stdio.h>
+#include <sys/time.h>
+
+/**
+ * Warmup and then measure.
+ *
+ * Adapted from Neurovectorizer's implementation:
+ * https://github.com/intel/neuro-vectorizer/blob/d1b068998c08865c59f1586845bb947229f70a51/training_data/header.h
+ *
+ * Which was in turn adapted from LLVM:
+ * https://github.com/llvm/llvm-test-suite/blob/7eca159e29ca4308256ef6e35560a2d884ac6b01/SingleSource/UnitTests/Vectorizer/gcc-loops.cpp#L330-L336
+ */
+#define BENCH(NAME, RUN_LINE, ITER, DIGEST_LINE) \
+  {                                              \
+    struct timeval Start, End;                   \
+    RUN_LINE;                                    \
+    gettimeofday(&Start, 0);                     \
+    for (int i = 0; i < (ITER); ++i) RUN_LINE;   \
+    gettimeofday(&End, 0);                       \
+    unsigned r = DIGEST_LINE;                    \
+    long mtime, s, us;                           \
+    s = End.tv_sec - Start.tv_sec;               \
+    us = End.tv_usec - Start.tv_usec;            \
+    mtime = (s * 1000 + us / 1000.0) + 0.5;      \
+    printf("%ld", mtime);                        \
+  }

--- a/compiler_gym/util/BUILD
+++ b/compiler_gym/util/BUILD
@@ -10,6 +10,7 @@ py_library(
     srcs = [
         "__init__.py",
         "capture_output.py",
+        "commands.py",
         "debug_util.py",
         "decorators.py",
         "download.py",

--- a/compiler_gym/util/commands.py
+++ b/compiler_gym/util/commands.py
@@ -40,4 +40,5 @@ def communicate(process, input=None, timeout=None):
             process.kill()
         else:
             process.terminate()
+        process.communicate(timeout=timeout)  # Wait for shutdown to complete.
         raise

--- a/compiler_gym/util/commands.py
+++ b/compiler_gym/util/commands.py
@@ -1,0 +1,43 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import subprocess
+import sys
+from signal import Signals
+from typing import List
+
+
+def run_command(cmd: List[str], timeout: int):
+    process = subprocess.Popen(
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True
+    )
+    stdout, stderr = communicate(process, timeout=timeout)
+    if process.returncode:
+        returncode = process.returncode
+        try:
+            # Try and decode the name of a signal. Signal returncodes
+            # are negative.
+            returncode = f"{returncode} ({Signals(abs(returncode)).name})"
+        except ValueError:
+            pass
+        raise OSError(
+            f"Compilation job failed with returncode {returncode}\n"
+            f"Command: {' '.join(cmd)}\n"
+            f"Stderr: {stderr.strip()}"
+        )
+    return stdout
+
+
+def communicate(process, input=None, timeout=None):
+    """subprocess.communicate() which kills subprocess on timeout."""
+    try:
+        return process.communicate(input=input, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        # kill() was added in Python 3.7.
+        if sys.version_info >= (3, 7, 0):
+            process.kill()
+        else:
+            process.terminate()
+        raise

--- a/examples/example_unrolling_service/BUILD
+++ b/examples/example_unrolling_service/BUILD
@@ -1,0 +1,28 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+load("@rules_python//python:defs.bzl", "py_library", "py_test")
+
+py_library(
+    name = "example_compiler_gym_service",
+    srcs = ["__init__.py"],
+    data = [
+        "//examples/example_compiler_gym_service/service_cc:compiler_gym-example-service-cc",
+        "//examples/example_compiler_gym_service/service_py:compiler_gym-example-service-py",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//compiler_gym/util",
+    ],
+)
+
+py_test(
+    name = "env_tests",
+    srcs = ["env_tests.py"],
+    deps = [
+        ":example_compiler_gym_service",
+        "//compiler_gym",
+        "//tests:test_main",
+    ],
+)

--- a/examples/example_unrolling_service/BUILD
+++ b/examples/example_unrolling_service/BUILD
@@ -5,11 +5,10 @@
 load("@rules_python//python:defs.bzl", "py_library", "py_test")
 
 py_library(
-    name = "example_compiler_gym_service",
+    name = "example_unrolling_service",
     srcs = ["__init__.py"],
     data = [
-        "//examples/example_compiler_gym_service/service_cc:compiler_gym-example-service-cc",
-        "//examples/example_compiler_gym_service/service_py:compiler_gym-example-service-py",
+        "//examples/example_unrolling_service/service_py:example-unrolling-service-py",
     ],
     visibility = ["//visibility:public"],
     deps = [
@@ -21,7 +20,7 @@ py_test(
     name = "env_tests",
     srcs = ["env_tests.py"],
     deps = [
-        ":example_compiler_gym_service",
+        ":example_unrolling_service",
         "//compiler_gym",
         "//tests:test_main",
     ],

--- a/examples/example_unrolling_service/BUILD
+++ b/examples/example_unrolling_service/BUILD
@@ -25,3 +25,12 @@ py_test(
         "//tests:test_main",
     ],
 )
+
+py_binary(
+    name = "example",
+    srcs = ["example.py"],
+    deps = [
+        ":example_unrolling_service",
+        "//compiler_gym",
+    ],
+)

--- a/examples/example_unrolling_service/BUILD
+++ b/examples/example_unrolling_service/BUILD
@@ -8,6 +8,9 @@ py_library(
     name = "example_unrolling_service",
     srcs = ["__init__.py"],
     data = [
+        "//examples/example_unrolling_service/benchmarks:conv2d.c",
+        "//examples/example_unrolling_service/benchmarks:header.h",
+        "//examples/example_unrolling_service/benchmarks:offsets1.c",
         "//examples/example_unrolling_service/service_py:example-unrolling-service-py",
     ],
     visibility = ["//visibility:public"],

--- a/examples/example_unrolling_service/BUILD
+++ b/examples/example_unrolling_service/BUILD
@@ -8,13 +8,12 @@ py_library(
     name = "example_unrolling_service",
     srcs = ["__init__.py"],
     data = [
-        "//examples/example_unrolling_service/benchmarks:conv2d.c",
-        "//examples/example_unrolling_service/benchmarks:header.h",
-        "//examples/example_unrolling_service/benchmarks:offsets1.c",
+        "//examples/example_unrolling_service/benchmarks",
         "//examples/example_unrolling_service/service_py:example-unrolling-service-py",
     ],
     visibility = ["//visibility:public"],
     deps = [
+        "//compiler_gym/envs/llvm",
         "//compiler_gym/util",
     ],
 )

--- a/examples/example_unrolling_service/README.md
+++ b/examples/example_unrolling_service/README.md
@@ -1,0 +1,16 @@
+# Unrolling CompilerGym Service Example
+
+TBD
+
+# Features:
+
+TBD
+
+
+## Usage
+
+Rub:
+
+```sh
+$ bazel test //examples/example_unrolling_service:env_tests
+```

--- a/examples/example_unrolling_service/README.md
+++ b/examples/example_unrolling_service/README.md
@@ -9,7 +9,12 @@ TBD
 
 ## Usage
 
-Rub:
+Run Example:
+```sh
+$ bazel run //examples/example_unrolling_service:example
+```
+
+Run Tests:
 
 ```sh
 $ bazel test //examples/example_unrolling_service:env_tests

--- a/examples/example_unrolling_service/README.md
+++ b/examples/example_unrolling_service/README.md
@@ -1,20 +1,29 @@
 # Unrolling CompilerGym Service Example
 
-TBD
+This is an example of how to create your own CompilerGym environment. All paths listed below are relative to the path of this README file.
 
-# Features:
-
-TBD
-
+* Actions: this environment focuses on the unrolling optimization. The actions are the different unrolling factors.
+    - The actions are listed in `action_spaces` struct in `service_py/example_service.py`
+    - The actions are implemented in `apply_action(...)` function in `service_py/example_service.py`
+* Observations: the observations are: textual form of the LLVM IR, statistical features of different types of IR instructions, runtime execution, or code size
+    - The observations are listed in `observation_spaces` struct in `service_py/example_service.py`.
+    - The observations are implemented in `get_observation(...)` function in `service_py/example_service.py`
+* Rewards: the rewards could be runtime or code size.
+    - The rewards are implemented in `__init__.py` and they reuse the runtime and code size observations mentioned above
+* Benchmarks: this environment expects your benchmarks to follow the templates from the [Neruovectorizer repo](https://github.com/intel/neuro-vectorizer/tree/master/training_data) repo, that was in turn adapted from the [LLVM loop test suite](https://github.com/llvm/llvm-test-suite/blob/main/SingleSource/UnitTests/Vectorizer/gcc-loops.cpp).
+    - To implement your benchmark, you need to: include the `header.h` file, implement your benchmark in a custom function, then invoke it using `BENCH` macro inside the `main()` function.
+    - Following this template is necessary in order for the benchmark to measure the execution runtime and write it to stdout, which is in turn parsed by this environment to measure the runtime reward.
+    - You can view and add examples of benchmarks in `benchmarks` directory
+    - Also, when adding your own benchmark, you need to add it to the `UnrollingDataset` class in `__init__.py`
 
 ## Usage
 
-Run Example:
+Run `example.py` example:
 ```sh
 $ bazel run //examples/example_unrolling_service:example
 ```
 
-Run Tests:
+Run `env_tests.py` unit tests:
 
 ```sh
 $ bazel test //examples/example_unrolling_service:env_tests

--- a/examples/example_unrolling_service/__init__.py
+++ b/examples/example_unrolling_service/__init__.py
@@ -1,0 +1,89 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""This module demonstrates how to """
+from pathlib import Path
+from typing import Iterable
+
+from compiler_gym.datasets import Benchmark, Dataset
+from compiler_gym.spaces import Reward
+from compiler_gym.util.registration import register
+from compiler_gym.util.runfiles_path import runfiles_path, site_data_path
+
+EXAMPLE_PY_SERVICE_BINARY: Path = runfiles_path(
+    "examples/example_compiler_gym_service/service_py/compiler_gym-example-service-py"
+)
+
+
+class RuntimeReward(Reward):
+    """An example reward that uses changes in the "runtime" observation value
+    to compute incremental reward.
+    """
+
+    def __init__(self):
+        super().__init__(
+            id="runtime",
+            observation_spaces=["runtime"],
+            default_value=0,
+            default_negates_returns=True,
+            deterministic=False,
+            platform_dependent=True,
+        )
+        self.previous_runtime = None
+
+    def reset(self, benchmark: str, observation_view):
+        del benchmark  # unused
+        self.previous_runtime = None
+
+    def update(self, action, observations, observation_view):
+        del action
+        del observation_view
+
+        if self.previous_runtime is None:
+            self.previous_runtime = observations[0]
+
+        reward = float(self.previous_runtime - observations[0])
+        self.previous_runtime = observations[0]
+        return reward
+
+
+class ExampleDataset(Dataset):
+    def __init__(self, *args, **kwargs):
+        super().__init__(
+            name="benchmark://example-v0",
+            license="MIT",
+            description="An example dataset",
+            site_data_base=site_data_path("example_dataset"),
+        )
+        self._benchmarks = {
+            "benchmark://example-v0/foo": Benchmark.from_file_contents(
+                "benchmark://example-v0/foo", "Ir data".encode("utf-8")
+            ),
+            "benchmark://example-v0/bar": Benchmark.from_file_contents(
+                "benchmark://example-v0/bar", "Ir data".encode("utf-8")
+            ),
+        }
+
+    def benchmark_uris(self) -> Iterable[str]:
+        yield from self._benchmarks.keys()
+
+    def benchmark(self, uri: str) -> Benchmark:
+        if uri in self._benchmarks:
+            return self._benchmarks[uri]
+        else:
+            raise LookupError("Unknown program name")
+
+
+# Register the example service on module import. After importing this module,
+# the example-v0 environment will be available to gym.make(...).
+
+register(
+    id="example-py-v0",
+    entry_point="compiler_gym.envs:CompilerEnv",
+    kwargs={
+        "service": EXAMPLE_PY_SERVICE_BINARY,
+        "rewards": [RuntimeReward()],
+        "datasets": [ExampleDataset()],
+    },
+)

--- a/examples/example_unrolling_service/__init__.py
+++ b/examples/example_unrolling_service/__init__.py
@@ -11,7 +11,7 @@ from compiler_gym.spaces import Reward
 from compiler_gym.util.registration import register
 from compiler_gym.util.runfiles_path import runfiles_path, site_data_path
 
-EXAMPLE_PY_SERVICE_BINARY: Path = runfiles_path(
+UNROLLING_PY_SERVICE_BINARY: Path = runfiles_path(
     "examples/example_unrolling_service/service_py/example-unrolling-service-py"
 )
 
@@ -53,7 +53,7 @@ class ExampleDataset(Dataset):
         super().__init__(
             name="benchmark://unrolling-v0",
             license="MIT",
-            description="An example dataset",
+            description="Unrolling example dataset",
             site_data_base=site_data_path("example_dataset"),
         )
         self._benchmarks = {
@@ -75,14 +75,14 @@ class ExampleDataset(Dataset):
             raise LookupError("Unknown program name")
 
 
-# Register the example service on module import. After importing this module,
-# the example-v0 environment will be available to gym.make(...).
+# Register the unrolling example service on module import. After importing this module,
+# the unrolling-py-v0 environment will be available to gym.make(...).
 
 register(
     id="unrolling-py-v0",
     entry_point="compiler_gym.envs:CompilerEnv",
     kwargs={
-        "service": EXAMPLE_PY_SERVICE_BINARY,
+        "service": UNROLLING_PY_SERVICE_BINARY,
         "rewards": [RuntimeReward()],
         "datasets": [ExampleDataset()],
     },

--- a/examples/example_unrolling_service/__init__.py
+++ b/examples/example_unrolling_service/__init__.py
@@ -12,7 +12,7 @@ from compiler_gym.util.registration import register
 from compiler_gym.util.runfiles_path import runfiles_path, site_data_path
 
 EXAMPLE_PY_SERVICE_BINARY: Path = runfiles_path(
-    "examples/example_compiler_gym_service/service_py/compiler_gym-example-service-py"
+    "examples/example_unrolling_service/service_py/example-unrolling-service-py"
 )
 
 
@@ -51,17 +51,17 @@ class RuntimeReward(Reward):
 class ExampleDataset(Dataset):
     def __init__(self, *args, **kwargs):
         super().__init__(
-            name="benchmark://example-v0",
+            name="benchmark://unrolling-v0",
             license="MIT",
             description="An example dataset",
             site_data_base=site_data_path("example_dataset"),
         )
         self._benchmarks = {
-            "benchmark://example-v0/foo": Benchmark.from_file_contents(
-                "benchmark://example-v0/foo", "Ir data".encode("utf-8")
+            "benchmark://unrolling-v0/foo": Benchmark.from_file_contents(
+                "benchmark://unrolling-v0/foo", "Ir data".encode("utf-8")
             ),
-            "benchmark://example-v0/bar": Benchmark.from_file_contents(
-                "benchmark://example-v0/bar", "Ir data".encode("utf-8")
+            "benchmark://unrolling-v0/bar": Benchmark.from_file_contents(
+                "benchmark://unrolling-v0/bar", "Ir data".encode("utf-8")
             ),
         }
 
@@ -79,7 +79,7 @@ class ExampleDataset(Dataset):
 # the example-v0 environment will be available to gym.make(...).
 
 register(
-    id="example-py-v0",
+    id="unrolling-py-v0",
     entry_point="compiler_gym.envs:CompilerEnv",
     kwargs={
         "service": EXAMPLE_PY_SERVICE_BINARY,

--- a/examples/example_unrolling_service/__init__.py
+++ b/examples/example_unrolling_service/__init__.py
@@ -30,21 +30,23 @@ class RuntimeReward(Reward):
             deterministic=False,
             platform_dependent=True,
         )
-        self.previous_runtime = None
+        self.baseline_runtime = 1
 
     def reset(self, benchmark: str, observation_view):
         del benchmark  # unused
-        self.previous_runtime = None
+        self.baseline_runtime = observation_view["runtime"]
 
     def update(self, action, observations, observation_view):
         del action
         del observation_view
 
-        if self.previous_runtime is None:
-            self.previous_runtime = observations[0]
+        if self.baseline_runtime is None:
+            self.baseline_runtime = observations[0]
 
-        reward = float(self.previous_runtime - observations[0])
-        self.previous_runtime = observations[0]
+        # Here we are using Contextual Bandits: the number of steps the RL agent has to take before
+        # the environment terminates is one. In Contextual Bandits the learner tries
+        # to find a single best action in the current state. It involves learning to search for best actions and trial-and-error
+        reward = float(self.baseline_runtime - observations[0]) / self.baseline_runtime
         return reward
 
 
@@ -62,21 +64,23 @@ class SizeReward(Reward):
             deterministic=False,
             platform_dependent=True,
         )
-        self.previous_size = None
+        self.baseline_size = None
 
     def reset(self, benchmark: str, observation_view):
         del benchmark  # unused
-        self.previous_size = None
+        self.baseline_size = None
 
     def update(self, action, observations, observation_view):
         del action
         del observation_view
 
-        if self.previous_size is None:
-            self.previous_size = observations[0]
+        if self.baseline_size is None:
+            self.baseline_size = observations[0]
 
-        reward = float(self.previous_size - observations[0])
-        self.previous_size = observations[0]
+        # Here we are using Contextual Bandits: the number of steps the RL agent has to take before
+        # the environment terminates is one. In Contextual Bandits the learner tries
+        # to find a single best action in the current state. It involves learning to search for best actions and trial-and-error
+        reward = float(self.baseline_size - observations[0]) / self.baseline_size
         return reward
 
 

--- a/examples/example_unrolling_service/__init__.py
+++ b/examples/example_unrolling_service/__init__.py
@@ -3,9 +3,9 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 """This module demonstrates how to """
+import subprocess
 from pathlib import Path
 from typing import Iterable
-import subprocess
 
 from compiler_gym.datasets import Benchmark, Dataset
 from compiler_gym.envs.llvm.llvm_benchmark import get_system_includes
@@ -39,24 +39,16 @@ class RuntimeReward(Reward):
             deterministic=False,
             platform_dependent=True,
         )
-        self.baseline_runtime = 1
+        self.baseline_runtime = 0
 
     def reset(self, benchmark: str, observation_view):
         del benchmark  # unused
         self.baseline_runtime = observation_view["runtime"]
 
     def update(self, action, observations, observation_view):
-        del action
-        del observation_view
-
-        if self.baseline_runtime is None:
-            self.baseline_runtime = observations[0]
-
-        # Here we are using Contextual Bandits: the number of steps the RL agent has to take before
-        # the environment terminates is one. In Contextual Bandits the learner tries
-        # to find a single best action in the current state. It involves learning to search for best actions and trial-and-error
-        reward = float(self.baseline_runtime - observations[0]) / self.baseline_runtime
-        return reward
+        del action  # unused
+        del observation_view  # unused
+        return float(self.baseline_runtime - observations[0]) / self.baseline_runtime
 
 
 class SizeReward(Reward):
@@ -73,24 +65,16 @@ class SizeReward(Reward):
             deterministic=False,
             platform_dependent=True,
         )
-        self.baseline_size = None
+        self.baseline_size = 0
 
     def reset(self, benchmark: str, observation_view):
         del benchmark  # unused
-        self.baseline_size = None
+        self.baseline_runtime = observation_view["size"]
 
     def update(self, action, observations, observation_view):
-        del action
-        del observation_view
-
-        if self.baseline_size is None:
-            self.baseline_size = observations[0]
-
-        # Here we are using Contextual Bandits: the number of steps the RL agent has to take before
-        # the environment terminates is one. In Contextual Bandits the learner tries
-        # to find a single best action in the current state. It involves learning to search for best actions and trial-and-error
-        reward = float(self.baseline_size - observations[0]) / self.baseline_size
-        return reward
+        del action  # unused
+        del observation_view  # unused
+        return float(self.baseline_size - observations[0]) / self.baseline_size
 
 
 class UnrollingDataset(Dataset):

--- a/examples/example_unrolling_service/__init__.py
+++ b/examples/example_unrolling_service/__init__.py
@@ -3,6 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 """This module demonstrates how to """
+import os
 from pathlib import Path
 from typing import Iterable
 
@@ -90,16 +91,19 @@ class UnrollingDataset(Dataset):
             name="benchmark://unrolling-v0",
             license="MIT",
             description="Unrolling example dataset",
-            site_data_base=site_data_path("example_dataset"),
+            site_data_base=site_data_path(
+                "example_dataset"
+            ),  # TODO: what should we set this to? we are not using it
         )
+        benchmarks_dir_path = os.path.join(os.path.dirname(__file__), "benchmarks")
         self._benchmarks = {
             "benchmark://unrolling-v0/offsets1": Benchmark.from_file(
                 "benchmark://unrolling-v0/offsets1",
-                "/Users/melhoushi/CompilerGym-Playground/dataset/offsets1.c",
+                os.path.join(benchmarks_dir_path, "offsets1.c"),
             ),
             "benchmark://unrolling-v0/conv2d": Benchmark.from_file(
                 "benchmark://unrolling-v0/conv2d",
-                "/Users/melhoushi/CompilerGym-Playground/dataset/conv2d.c",
+                os.path.join(benchmarks_dir_path, "conv2d.c"),
             ),
         }
 

--- a/examples/example_unrolling_service/__init__.py
+++ b/examples/example_unrolling_service/__init__.py
@@ -48,6 +48,38 @@ class RuntimeReward(Reward):
         return reward
 
 
+class SizeReward(Reward):
+    """An example reward that uses changes in the "size" observation value
+    to compute incremental reward.
+    """
+
+    def __init__(self):
+        super().__init__(
+            id="size",
+            observation_spaces=["size"],
+            default_value=0,
+            default_negates_returns=True,
+            deterministic=False,
+            platform_dependent=True,
+        )
+        self.previous_size = None
+
+    def reset(self, benchmark: str, observation_view):
+        del benchmark  # unused
+        self.previous_size = None
+
+    def update(self, action, observations, observation_view):
+        del action
+        del observation_view
+
+        if self.previous_size is None:
+            self.previous_size = observations[0]
+
+        reward = float(self.previous_size - observations[0])
+        self.previous_size = observations[0]
+        return reward
+
+
 class ExampleDataset(Dataset):
     def __init__(self, *args, **kwargs):
         super().__init__(
@@ -83,7 +115,7 @@ register(
     entry_point="compiler_gym.envs:CompilerEnv",
     kwargs={
         "service": UNROLLING_PY_SERVICE_BINARY,
-        "rewards": [RuntimeReward()],
+        "rewards": [RuntimeReward(), SizeReward()],
         "datasets": [ExampleDataset()],
     },
 )

--- a/examples/example_unrolling_service/__init__.py
+++ b/examples/example_unrolling_service/__init__.py
@@ -84,7 +84,7 @@ class SizeReward(Reward):
         return reward
 
 
-class ExampleDataset(Dataset):
+class UnrollingDataset(Dataset):
     def __init__(self, *args, **kwargs):
         super().__init__(
             name="benchmark://unrolling-v0",
@@ -93,11 +93,13 @@ class ExampleDataset(Dataset):
             site_data_base=site_data_path("example_dataset"),
         )
         self._benchmarks = {
-            "benchmark://unrolling-v0/foo": Benchmark.from_file_contents(
-                "benchmark://unrolling-v0/foo", "Ir data".encode("utf-8")
+            "benchmark://unrolling-v0/offsets1": Benchmark.from_file(
+                "benchmark://unrolling-v0/offsets1",
+                "/Users/melhoushi/CompilerGym-Playground/dataset/offsets1.c",
             ),
-            "benchmark://unrolling-v0/bar": Benchmark.from_file_contents(
-                "benchmark://unrolling-v0/bar", "Ir data".encode("utf-8")
+            "benchmark://unrolling-v0/conv2d": Benchmark.from_file(
+                "benchmark://unrolling-v0/conv2d",
+                "/Users/melhoushi/CompilerGym-Playground/dataset/conv2d.c",
             ),
         }
 
@@ -120,6 +122,6 @@ register(
     kwargs={
         "service": UNROLLING_PY_SERVICE_BINARY,
         "rewards": [RuntimeReward(), SizeReward()],
-        "datasets": [ExampleDataset()],
+        "datasets": [UnrollingDataset()],
     },
 )

--- a/examples/example_unrolling_service/benchmarks/BUILD
+++ b/examples/example_unrolling_service/benchmarks/BUILD
@@ -1,0 +1,5 @@
+exports_files([
+    "offsets1.c",
+    "conv2d.c",
+    "header.h",
+])

--- a/examples/example_unrolling_service/benchmarks/BUILD
+++ b/examples/example_unrolling_service/benchmarks/BUILD
@@ -1,3 +1,4 @@
+# TODO: use regular expressions instead of writing each file name manually
 exports_files([
     "offsets1.c",
     "conv2d.c",

--- a/examples/example_unrolling_service/benchmarks/BUILD
+++ b/examples/example_unrolling_service/benchmarks/BUILD
@@ -1,6 +1,12 @@
-# TODO: use regular expressions instead of writing each file name manually
-exports_files([
-    "offsets1.c",
-    "conv2d.c",
-    "header.h",
-])
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+filegroup(
+    name = "benchmarks",
+    srcs = glob(["*.c"]) + [
+        "//compiler_gym/third_party/neuro-vectorizer:header",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/examples/example_unrolling_service/benchmarks/conv2d.c
+++ b/examples/example_unrolling_service/benchmarks/conv2d.c
@@ -64,7 +64,7 @@ void conv2d(int* ret) {
   *ret = y[N - 1][Oh - 1][Ow - 1][Oc - 1];
 }
 
-int main(int argc, char* argv[]) {
+__attribute__((optnone)) int main(int argc, char* argv[]) {
   int dummy = 0;
   // TODO: initialize tensors
   BENCH("conv2d", conv2d(&dummy), 100, dummy);

--- a/examples/example_unrolling_service/benchmarks/conv2d.c
+++ b/examples/example_unrolling_service/benchmarks/conv2d.c
@@ -1,0 +1,73 @@
+#include "header.h"
+
+// TODO: use templates instead of macros
+#ifndef N
+#define N 32
+#endif
+
+#ifndef Ih
+#define Ih 3
+#endif
+
+#ifndef Iw
+#define Iw 12
+#endif
+
+#ifndef Ic
+#define Ic 12
+#endif
+
+#ifndef Oc
+#define Oc 64
+#endif
+
+#ifndef Kh
+#define Kh 3
+#endif
+
+#ifndef Kw
+#define Kw 3
+#endif
+
+// TODO: include pad, stride, and dilation
+
+#define Oh Ih - Kh + 1
+#define Ow Iw - Kw + 1
+
+float x[N][Ih][Iw][Ic];
+float w[Oc][Kh][Kw][Ic];
+float y[N][Oh][Ow][Oc];
+
+__attribute__((noinline))
+//template <N=32, Iw=...>
+void conv2d(int* ret) {
+  // loop over output
+  for (int n = 0; n < N; n++) {
+    for (int oh = 0; oh < Oh; oh++) {
+      for (int ow = 0; ow < Ow; ow++) {
+        for (int oc = 0; oc < Oc; oc++) {
+          y[n][oh][ow][oc] = 0;
+// loop over filter
+#pragma unroll(Kh)
+          for (int kh = 0; kh < Kh; kh++) {
+            for (int kw = 0; kw < Kw; kw++) {
+              for (int ic = 0; ic < Iw; ic++) {
+                // TODO: include pad, stride, and dilation
+                y[n][oh][ow][oc] += w[oc][kh][kw][ic] * x[n][oh - kh + 1][ow - kw + 1][ic];
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  *ret = y[N - 1][Oh - 1][Ow - 1][Oc - 1];
+}
+
+int main(int argc, char* argv[]) {
+  int dummy = 0;
+  // TODO: initialize tensors
+  BENCH("conv2d", conv2d(&dummy), 100, dummy);
+
+  return 0;
+}

--- a/examples/example_unrolling_service/benchmarks/header.h
+++ b/examples/example_unrolling_service/benchmarks/header.h
@@ -1,0 +1,54 @@
+/*
+Copyright (c) 2019, Ameer Haj Ali (UC Berkeley), and Intel Corporation
+All rights reserved.
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#include <stdbool.h>
+#include <stdio.h>
+#include <sys/time.h>
+
+#define ALIGNED16 __attribute__((aligned(16)))
+
+typedef int aint __attribute__((__aligned__(16)));
+
+// Warmup and then measure.
+#define BENCH(NAME, RUN_LINE, ITER, DIGEST_LINE) \
+  {                                              \
+    struct timeval Start, End;                   \
+    RUN_LINE;                                    \
+    gettimeofday(&Start, 0);                     \
+    for (int i = 0; i < (ITER); ++i) RUN_LINE;   \
+    gettimeofday(&End, 0);                       \
+    unsigned r = DIGEST_LINE;                    \
+    long mtime, s, us;                           \
+    s = End.tv_sec - Start.tv_sec;               \
+    us = End.tv_usec - Start.tv_usec;            \
+    mtime = (s * 1000 + us / 1000.0) + 0.5;      \
+    if (print_times)                             \
+      printf("%ld", mtime);                      \
+  }
+#define Mi 1048576        // 1<<20
+#define print_times true  // argc > 1;
+void init_memory(void* start, void* end);
+void init_memory_float(float* start, float* end);
+unsigned digest_memory(void* start, void* end);
+void atimer(const char* title, bool print);

--- a/examples/example_unrolling_service/benchmarks/offsets1.c
+++ b/examples/example_unrolling_service/benchmarks/offsets1.c
@@ -17,7 +17,7 @@ __attribute__((noinline)) void example1(int* ret) {
   *ret = A[N - 1];
 }
 
-int main(int argc, char* argv[]) {
+__attribute__((optnone)) int main(int argc, char* argv[]) {
   int dummy = 0;
   // TODO: initialize tensors
   BENCH("example1", example1(&dummy), 100, dummy);

--- a/examples/example_unrolling_service/benchmarks/offsets1.c
+++ b/examples/example_unrolling_service/benchmarks/offsets1.c
@@ -1,3 +1,5 @@
+#include "header.h"
+
 #ifndef N
 #define N 1000000
 #endif
@@ -17,7 +19,8 @@ __attribute__((noinline)) void example1(int* ret) {
 
 int main(int argc, char* argv[]) {
   int dummy = 0;
-  example1(&dummy);
+  // TODO: initialize tensors
+  BENCH("example1", example1(&dummy), 100, dummy);
 
   return 0;
 }

--- a/examples/example_unrolling_service/benchmarks/offsets1.c
+++ b/examples/example_unrolling_service/benchmarks/offsets1.c
@@ -1,0 +1,23 @@
+#ifndef N
+#define N 1000000
+#endif
+
+#ifndef n
+#define n 3
+#endif
+
+int A[N];
+
+__attribute__((noinline)) void example1(int* ret) {
+  //#pragma unroll(n)
+  for (int i = 0; i < N - 3; i++) A[i] = A[i + 1] + A[i + 2] + A[i + 3];
+
+  *ret = A[N - 1];
+}
+
+int main(int argc, char* argv[]) {
+  int dummy = 0;
+  example1(&dummy);
+
+  return 0;
+}

--- a/examples/example_unrolling_service/env_tests.py
+++ b/examples/example_unrolling_service/env_tests.py
@@ -22,10 +22,10 @@ from tests.test_main import main
 
 # Given that the C++ and Python service implementations have identical
 # featuresets, we can parameterize the tests and run them against both backends.
-EXAMPLE_ENVIRONMENTS = ["unrolling-py-v0"]
+UNROLLING_ENVIRONMENTS = ["unrolling-py-v0"]
 
 
-@pytest.fixture(scope="function", params=EXAMPLE_ENVIRONMENTS)
+@pytest.fixture(scope="function", params=UNROLLING_ENVIRONMENTS)
 def env(request) -> CompilerEnv:
     """Text fixture that yields an environment."""
     with gym.make(request.param) as env:
@@ -41,7 +41,7 @@ def bin(request) -> Path:
     yield request.param
 
 
-@pytest.mark.parametrize("env_id", EXAMPLE_ENVIRONMENTS)
+@pytest.mark.parametrize("env_id", UNROLLING_ENVIRONMENTS)
 def test_debug_level(env_id: str):
     """Test that debug level is set."""
     set_debug_level(3)

--- a/examples/example_unrolling_service/env_tests.py
+++ b/examples/example_unrolling_service/env_tests.py
@@ -1,0 +1,232 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Tests for the example CompilerGym service."""
+import logging
+import subprocess
+from pathlib import Path
+
+import gym
+import numpy as np
+import pytest
+from gym.spaces import Box
+
+import compiler_gym
+import examples.example_unrolling_service as example
+from compiler_gym.envs import CompilerEnv
+from compiler_gym.service import SessionNotFound
+from compiler_gym.spaces import NamedDiscrete, Scalar, Sequence
+from compiler_gym.util.debug_util import set_debug_level
+from tests.test_main import main
+
+# Given that the C++ and Python service implementations have identical
+# featuresets, we can parameterize the tests and run them against both backends.
+EXAMPLE_ENVIRONMENTS = ["example-py-v0"]
+
+
+@pytest.fixture(scope="function", params=EXAMPLE_ENVIRONMENTS)
+def env(request) -> CompilerEnv:
+    """Text fixture that yields an environment."""
+    with gym.make(request.param) as env:
+        yield env
+
+
+@pytest.fixture(
+    scope="module",
+    params=[example.EXAMPLE_PY_SERVICE_BINARY],
+    ids=["example-py-v0"],
+)
+def bin(request) -> Path:
+    yield request.param
+
+
+@pytest.mark.parametrize("env_id", EXAMPLE_ENVIRONMENTS)
+def test_debug_level(env_id: str):
+    """Test that debug level is set."""
+    set_debug_level(3)
+    with gym.make(env_id) as env:
+        assert env.logger.level == logging.DEBUG
+
+
+def test_invalid_arguments(bin: Path):
+    """Test that running the binary with unrecognized arguments is an error."""
+
+    def run(cmd):
+        p = subprocess.Popen(
+            cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True
+        )
+        stdout, stderr = p.communicate(timeout=10)
+        return p.returncode, stdout, stderr
+
+    returncode, _, stderr = run([str(bin), "foobar"])
+    assert "ERROR:" in stderr
+    assert "'foobar'" in stderr
+    assert returncode == 1
+
+    returncode, _, stderr = run([str(bin), "--foobar"])
+    # C++ and python flag parsing library emit slightly different error
+    # messages.
+    assert "ERROR:" in stderr or "FATAL" in stderr
+    assert "'foobar'" in stderr
+    assert returncode == 1
+
+
+def test_versions(env: CompilerEnv):
+    """Tests the GetVersion() RPC endpoint."""
+    assert env.version == compiler_gym.__version__
+    assert env.compiler_version == "1.0.0"
+
+
+def test_action_space(env: CompilerEnv):
+    """Test that the environment reports the service's action spaces."""
+    assert env.action_spaces == [
+        NamedDiscrete(
+            name="default",
+            items=["a", "b", "c"],
+        )
+    ]
+
+
+def test_observation_spaces(env: CompilerEnv):
+    """Test that the environment reports the service's observation spaces."""
+    env.reset()
+    assert env.observation.spaces.keys() == {"ir", "features", "runtime"}
+    assert env.observation.spaces["ir"].space == Sequence(
+        size_range=(0, None), dtype=str, opaque_data_format=""
+    )
+    assert env.observation.spaces["features"].space == Box(
+        shape=(3,), low=-100, high=100, dtype=int
+    )
+    assert env.observation.spaces["runtime"].space == Scalar(
+        min=0, max=np.inf, dtype=float
+    )
+
+
+def test_reward_spaces(env: CompilerEnv):
+    """Test that the environment reports the service's reward spaces."""
+    env.reset()
+    assert env.reward.spaces.keys() == {"runtime"}
+
+
+def test_step_before_reset(env: CompilerEnv):
+    """Taking a step() before reset() is illegal."""
+    with pytest.raises(SessionNotFound, match=r"Must call reset\(\) before step\(\)"):
+        env.step(0)
+
+
+def test_observation_before_reset(env: CompilerEnv):
+    """Taking an observation before reset() is illegal."""
+    with pytest.raises(SessionNotFound, match=r"Must call reset\(\) before step\(\)"):
+        _ = env.observation["ir"]
+
+
+def test_reward_before_reset(env: CompilerEnv):
+    """Taking a reward before reset() is illegal."""
+    with pytest.raises(SessionNotFound, match=r"Must call reset\(\) before step\(\)"):
+        _ = env.reward["runtime"]
+
+
+def test_reset_invalid_benchmark(env: CompilerEnv):
+    """Test requesting a specific benchmark."""
+    with pytest.raises(LookupError) as ctx:
+        env.reset(benchmark="example-v0/foobar")
+    assert str(ctx.value) == "Unknown program name"
+
+
+def test_invalid_observation_space(env: CompilerEnv):
+    """Test error handling with invalid observation space."""
+    with pytest.raises(LookupError):
+        env.observation_space = 100
+
+
+def test_invalid_reward_space(env: CompilerEnv):
+    """Test error handling with invalid reward space."""
+    with pytest.raises(LookupError):
+        env.reward_space = 100
+
+
+def test_double_reset(env: CompilerEnv):
+    """Test that reset() can be called twice."""
+    env.reset()
+    assert env.in_episode
+    env.step(env.action_space.sample())
+    env.reset()
+    env.step(env.action_space.sample())
+    assert env.in_episode
+
+
+def test_Step_out_of_range(env: CompilerEnv):
+    """Test error handling with an invalid action."""
+    env.reset()
+    with pytest.raises(ValueError) as ctx:
+        env.step(100)
+    assert str(ctx.value) == "Out-of-range"
+
+
+def test_default_ir_observation(env: CompilerEnv):
+    """Test default observation space."""
+    env.observation_space = "ir"
+    observation = env.reset()
+    assert observation == "Hello, world!"
+
+    observation, reward, done, info = env.step(0)
+    assert observation == "Hello, world!"
+    assert reward is None
+    assert not done
+
+
+def test_default_features_observation(env: CompilerEnv):
+    """Test default observation space."""
+    env.observation_space = "features"
+    observation = env.reset()
+    assert isinstance(observation, np.ndarray)
+    assert observation.shape == (3,)
+    assert observation.dtype == np.int64
+    assert observation.tolist() == [0, 0, 0]
+
+
+def test_default_reward(env: CompilerEnv):
+    """Test default reward space."""
+    env.reward_space = "runtime"
+    env.reset()
+    observation, reward, done, info = env.step(0)
+    assert observation is None
+    assert reward == 0
+    assert not done
+
+
+def test_observations(env: CompilerEnv):
+    """Test observation spaces."""
+    env.reset()
+    assert env.observation["ir"] == "Hello, world!"
+    np.testing.assert_array_equal(env.observation["features"], [0, 0, 0])
+
+
+def test_rewards(env: CompilerEnv):
+    """Test reward spaces."""
+    env.reset()
+    assert env.reward["runtime"] == 0
+
+
+def test_benchmarks(env: CompilerEnv):
+    assert list(env.datasets.benchmark_uris()) == [
+        "benchmark://example-v0/foo",
+        "benchmark://example-v0/bar",
+    ]
+
+
+def test_fork(env: CompilerEnv):
+    env.reset()
+    env.step(0)
+    env.step(1)
+    other_env = env.fork()
+    try:
+        assert env.benchmark == other_env.benchmark
+        assert other_env.actions == [0, 1]
+    finally:
+        other_env.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/example_unrolling_service/env_tests.py
+++ b/examples/example_unrolling_service/env_tests.py
@@ -2,7 +2,7 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-"""Tests for the example CompilerGym service."""
+"""Tests for the unrolling CompilerGym service example."""
 import logging
 import subprocess
 from pathlib import Path
@@ -22,7 +22,7 @@ from tests.test_main import main
 
 # Given that the C++ and Python service implementations have identical
 # featuresets, we can parameterize the tests and run them against both backends.
-EXAMPLE_ENVIRONMENTS = ["example-py-v0"]
+EXAMPLE_ENVIRONMENTS = ["unrolling-py-v0"]
 
 
 @pytest.fixture(scope="function", params=EXAMPLE_ENVIRONMENTS)
@@ -35,7 +35,7 @@ def env(request) -> CompilerEnv:
 @pytest.fixture(
     scope="module",
     params=[example.EXAMPLE_PY_SERVICE_BINARY],
-    ids=["example-py-v0"],
+    ids=["unrolling-py-v0"],
 )
 def bin(request) -> Path:
     yield request.param
@@ -130,7 +130,7 @@ def test_reward_before_reset(env: CompilerEnv):
 def test_reset_invalid_benchmark(env: CompilerEnv):
     """Test requesting a specific benchmark."""
     with pytest.raises(LookupError) as ctx:
-        env.reset(benchmark="example-v0/foobar")
+        env.reset(benchmark="unrolling-v0/foobar")
     assert str(ctx.value) == "Unknown program name"
 
 
@@ -211,8 +211,8 @@ def test_rewards(env: CompilerEnv):
 
 def test_benchmarks(env: CompilerEnv):
     assert list(env.datasets.benchmark_uris()) == [
-        "benchmark://example-v0/foo",
-        "benchmark://example-v0/bar",
+        "benchmark://unrolling-v0/foo",
+        "benchmark://unrolling-v0/bar",
     ]
 
 

--- a/examples/example_unrolling_service/env_tests.py
+++ b/examples/example_unrolling_service/env_tests.py
@@ -13,7 +13,7 @@ import pytest
 from gym.spaces import Box
 
 import compiler_gym
-import examples.example_unrolling_service as example
+import examples.example_unrolling_service as unrolling_service
 from compiler_gym.envs import CompilerEnv
 from compiler_gym.service import SessionNotFound
 from compiler_gym.spaces import NamedDiscrete, Scalar, Sequence
@@ -34,7 +34,7 @@ def env(request) -> CompilerEnv:
 
 @pytest.fixture(
     scope="module",
-    params=[example.UNROLLING_PY_SERVICE_BINARY],
+    params=[unrolling_service.UNROLLING_PY_SERVICE_BINARY],
     ids=["unrolling-py-v0"],
 )
 def bin(request) -> Path:

--- a/examples/example_unrolling_service/env_tests.py
+++ b/examples/example_unrolling_service/env_tests.py
@@ -34,7 +34,7 @@ def env(request) -> CompilerEnv:
 
 @pytest.fixture(
     scope="module",
-    params=[example.EXAMPLE_PY_SERVICE_BINARY],
+    params=[example.UNROLLING_PY_SERVICE_BINARY],
     ids=["unrolling-py-v0"],
 )
 def bin(request) -> Path:

--- a/examples/example_unrolling_service/env_tests.py
+++ b/examples/example_unrolling_service/env_tests.py
@@ -211,8 +211,8 @@ def test_rewards(env: CompilerEnv):
 
 def test_benchmarks(env: CompilerEnv):
     assert list(env.datasets.benchmark_uris()) == [
-        "benchmark://unrolling-v0/foo",
-        "benchmark://unrolling-v0/bar",
+        "benchmark://unrolling-v0/offsets1",
+        "benchmark://unrolling-v0/conv2d",
     ]
 
 

--- a/examples/example_unrolling_service/example.py
+++ b/examples/example_unrolling_service/example.py
@@ -1,4 +1,5 @@
 import compiler_gym
+import examples.example_unrolling_service as unrolling_service
 
 env = compiler_gym.make(
     "unrolling-py-v0",
@@ -6,6 +7,8 @@ env = compiler_gym.make(
     observation_space="ir",
     reward_space="runtime",
 )
+
+print(unrolling_service.UNROLLING_PY_SERVICE_BINARY)
 
 observation = env.reset()
 

--- a/examples/example_unrolling_service/example.py
+++ b/examples/example_unrolling_service/example.py
@@ -1,14 +1,24 @@
 import compiler_gym
-import examples.example_unrolling_service as unrolling_service
+import examples.example_unrolling_service as unrolling_service  # noqa Register environments.
+
+# temporary hack to avoid "isort" pre-hook error
+# TODO: remove this line
+print(unrolling_service.UNROLLING_PY_SERVICE_BINARY)
+
+# TODO: avoid using hard-coded paths for benchmark files
+# benchmark = compiler_gym.envs.llvm.llvm_env.make_benchmark("/Users/melhoushi/CompilerGym-Playground/dataset/offsets1.c")
+# benchmark = compiler_gym.datasets.benchmark.Benchmark.from_file("unrolling-example-for-now", "/Users/melhoushi/CompilerGym-Playground/dataset/offsets1.c")
+# benchmark = compiler_gym.datasets.benchmark.BenchmarkWithSource.create("unrolling-example-for-now", "/Users/melhoushi/CompilerGym-Playground/dataset/offsets1.c")
+benchmark = compiler_gym.envs.llvm.llvm_benchmark.make_benchmark(
+    "/Users/melhoushi/CompilerGym-Playground/dataset/offsets1.c"
+)
 
 env = compiler_gym.make(
     "unrolling-py-v0",
-    benchmark="unrolling-v0/foo",
+    benchmark=benchmark,  # "unrolling-v0/foo"
     observation_space="ir",
     reward_space="runtime",
 )
-
-print(unrolling_service.UNROLLING_PY_SERVICE_BINARY)
 
 observation = env.reset()
 
@@ -19,4 +29,5 @@ print("reward: ", reward)
 print("done: ", done)
 print("info: ", info)
 
+# TODO: implement write_bitcode(..)
 # env.write_bitcode("/tmp/output.bc")

--- a/examples/example_unrolling_service/example.py
+++ b/examples/example_unrolling_service/example.py
@@ -1,0 +1,19 @@
+import compiler_gym
+
+env = compiler_gym.make(
+    "unrolling-py-v0",
+    benchmark="unrolling-v0/foo",
+    observation_space="ir",
+    reward_space="runtime",
+)
+
+observation = env.reset()
+
+observation, reward, done, info = env.step(env.action_space.sample())
+
+print("observation: ", observation)
+print("reward: ", reward)
+print("done: ", done)
+print("info: ", info)
+
+# env.write_bitcode("/tmp/output.bc")

--- a/examples/example_unrolling_service/example.py
+++ b/examples/example_unrolling_service/example.py
@@ -3,13 +3,23 @@ import examples.example_unrolling_service as unrolling_service  # noqa Register 
 
 env = compiler_gym.make(
     "unrolling-py-v0",
-    benchmark="unrolling-v0/conv2d",
+    benchmark="unrolling-v0/offsets1",
     observation_space="features",
     reward_space="runtime",
 )
 
 observation = env.reset()
 print("observation: ", observation)
+
+print()
+
+observation, reward, done, info = env.step(env.action_space.sample())
+print("observation: ", observation)
+print("reward: ", reward)
+print("done: ", done)
+print("info: ", info)
+
+print()
 
 observation, reward, done, info = env.step(env.action_space.sample())
 print("observation: ", observation)

--- a/examples/example_unrolling_service/example.py
+++ b/examples/example_unrolling_service/example.py
@@ -7,6 +7,7 @@ env = compiler_gym.make(
     observation_space="features",
     reward_space="runtime",
 )
+compiler_gym.set_debug_level(4)  # TODO: check why this has no effect
 
 observation = env.reset()
 print("observation: ", observation)
@@ -27,5 +28,5 @@ print("reward: ", reward)
 print("done: ", done)
 print("info: ", info)
 
-# TODO: implement write_bitcode(..)
+# TODO: implement write_bitcode(..) or write_ir(..)
 # env.write_bitcode("/tmp/output.bc")

--- a/examples/example_unrolling_service/example.py
+++ b/examples/example_unrolling_service/example.py
@@ -1,17 +1,11 @@
 import compiler_gym
 import examples.example_unrolling_service as unrolling_service  # noqa Register environments.
 
-# temporary hack to avoid "isort" pre-hook error
-# TODO: remove this line
-
 # TODO: avoid using hard-coded paths for benchmark files
-# benchmark = compiler_gym.envs.llvm.llvm_env.make_benchmark("/Users/melhoushi/CompilerGym-Playground/dataset/offsets1.c")
 benchmark = compiler_gym.datasets.benchmark.Benchmark.from_file(
     "unrolling-example-for-now",
     "/Users/melhoushi/CompilerGym-Playground/dataset/offsets1.c",
 )
-# benchmark = compiler_gym.datasets.benchmark.BenchmarkWithSource.create("unrolling-example-for-now", "/Users/melhoushi/CompilerGym-Playground/dataset/offsets1.c")
-# benchmark = compiler_gym.envs.llvm.llvm_benchmark.make_benchmark("/Users/melhoushi/CompilerGym-Playground/dataset/offsets1.c")
 
 env = compiler_gym.make(
     "unrolling-py-v0",
@@ -21,6 +15,8 @@ env = compiler_gym.make(
 )
 
 observation = env.reset()
+
+print("observation: ", observation)
 
 observation, reward, done, info = env.step(env.action_space.sample())
 

--- a/examples/example_unrolling_service/example.py
+++ b/examples/example_unrolling_service/example.py
@@ -1,16 +1,12 @@
 import compiler_gym
 import examples.example_unrolling_service as unrolling_service  # noqa Register environments.
 
-# TODO: avoid using hard-coded paths for benchmark files
-benchmark = compiler_gym.datasets.benchmark.Benchmark.from_file(
-    "unrolling-example-for-now",
-    "/Users/melhoushi/CompilerGym-Playground/dataset/offsets1.c",
-)
+benchmark = "unrolling-v0/conv2d"
 
 env = compiler_gym.make(
     "unrolling-py-v0",
-    benchmark=benchmark,  # "unrolling-v0/foo"
-    observation_space="ir",
+    benchmark=benchmark,
+    observation_space="features",
     reward_space="runtime",
 )
 

--- a/examples/example_unrolling_service/example.py
+++ b/examples/example_unrolling_service/example.py
@@ -1,21 +1,17 @@
 import compiler_gym
 import examples.example_unrolling_service as unrolling_service  # noqa Register environments.
 
-benchmark = "unrolling-v0/conv2d"
-
 env = compiler_gym.make(
     "unrolling-py-v0",
-    benchmark=benchmark,
+    benchmark="unrolling-v0/conv2d",
     observation_space="features",
     reward_space="runtime",
 )
 
 observation = env.reset()
-
 print("observation: ", observation)
 
 observation, reward, done, info = env.step(env.action_space.sample())
-
 print("observation: ", observation)
 print("reward: ", reward)
 print("done: ", done)

--- a/examples/example_unrolling_service/example.py
+++ b/examples/example_unrolling_service/example.py
@@ -3,15 +3,15 @@ import examples.example_unrolling_service as unrolling_service  # noqa Register 
 
 # temporary hack to avoid "isort" pre-hook error
 # TODO: remove this line
-print(unrolling_service.UNROLLING_PY_SERVICE_BINARY)
 
 # TODO: avoid using hard-coded paths for benchmark files
 # benchmark = compiler_gym.envs.llvm.llvm_env.make_benchmark("/Users/melhoushi/CompilerGym-Playground/dataset/offsets1.c")
-# benchmark = compiler_gym.datasets.benchmark.Benchmark.from_file("unrolling-example-for-now", "/Users/melhoushi/CompilerGym-Playground/dataset/offsets1.c")
-# benchmark = compiler_gym.datasets.benchmark.BenchmarkWithSource.create("unrolling-example-for-now", "/Users/melhoushi/CompilerGym-Playground/dataset/offsets1.c")
-benchmark = compiler_gym.envs.llvm.llvm_benchmark.make_benchmark(
-    "/Users/melhoushi/CompilerGym-Playground/dataset/offsets1.c"
+benchmark = compiler_gym.datasets.benchmark.Benchmark.from_file(
+    "unrolling-example-for-now",
+    "/Users/melhoushi/CompilerGym-Playground/dataset/offsets1.c",
 )
+# benchmark = compiler_gym.datasets.benchmark.BenchmarkWithSource.create("unrolling-example-for-now", "/Users/melhoushi/CompilerGym-Playground/dataset/offsets1.c")
+# benchmark = compiler_gym.envs.llvm.llvm_benchmark.make_benchmark("/Users/melhoushi/CompilerGym-Playground/dataset/offsets1.c")
 
 env = compiler_gym.make(
     "unrolling-py-v0",

--- a/examples/example_unrolling_service/service_py/BUILD
+++ b/examples/example_unrolling_service/service_py/BUILD
@@ -5,7 +5,7 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 
 py_binary(
-    name = "compiler_gym-example-service-py",
+    name = "example-unrolling-service-py",
     srcs = ["example_service.py"],
     main = "example_service.py",
     visibility = ["//visibility:public"],

--- a/examples/example_unrolling_service/service_py/BUILD
+++ b/examples/example_unrolling_service/service_py/BUILD
@@ -1,0 +1,17 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
+py_binary(
+    name = "compiler_gym-example-service-py",
+    srcs = ["example_service.py"],
+    main = "example_service.py",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//compiler_gym/service",
+        "//compiler_gym/service/proto",
+        "//compiler_gym/service/runtime",
+    ],
+)

--- a/examples/example_unrolling_service/service_py/BUILD
+++ b/examples/example_unrolling_service/service_py/BUILD
@@ -13,5 +13,6 @@ py_binary(
         "//compiler_gym/service",
         "//compiler_gym/service/proto",
         "//compiler_gym/service/runtime",
+        "//compiler_gym/third_party/llvm",
     ],
 )

--- a/examples/example_unrolling_service/service_py/example_service.py
+++ b/examples/example_unrolling_service/service_py/example_service.py
@@ -6,14 +6,18 @@
 # LICENSE file in the root directory of this source tree.
 """An example CompilerGym service in python."""
 import logging
+import subprocess
+import sys
 from pathlib import Path
-from typing import Optional, Tuple
+from signal import Signals
+from typing import List, Optional, Tuple
 
 from compiler_gym.service import CompilationSession
 from compiler_gym.service.proto import (
     Action,
     ActionSpace,
     Benchmark,
+    BenchmarkInitError,
     Observation,
     ObservationSpace,
     ScalarLimit,
@@ -84,6 +88,55 @@ class UnrollingCompilationSession(CompilationSession):
     ):
         super().__init__(working_directory, action_space, benchmark)
         logging.info("Started a compilation session for %s", benchmark.uri)
+        self._benchmark = benchmark
+        self._update_observations()
+
+    def _update_observations(self):
+        self._observation = dict()
+        # FIXME: "llvm-dis" path is not found. Should we add its path, or is there another way to obtain the IR?
+        ir = self._run_command(
+            ["llvm-dis", self._benchmark.program.uri, "/dev/stdout"], timeout=5
+        )
+        self._observation["ir"] = Observation(string_value=ir)
+
+        # TODO: update "features" and "runtime" observations
+
+    # _communicate(...) and _run_command(...) have been copied from llvm_benchmark.py
+    # TODO: avoid redundancies and reuse code instead of copying
+    def _communicate(self, process, input=None, timeout=None):
+        """subprocess.communicate() which kills subprocess on timeout."""
+        try:
+            return process.communicate(input=input, timeout=timeout)
+        except subprocess.TimeoutExpired:
+            # kill() was added in Python 3.7.
+            if sys.version_info >= (3, 7, 0):
+                process.kill()
+            else:
+                process.terminate()
+            raise
+
+    def _run_command(self, cmd: List[str], timeout: int):
+        process = subprocess.Popen(
+            cmd,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
+        )
+        stdout, stderr = self._communicate(process, timeout=timeout)
+        if process.returncode:
+            returncode = process.returncode
+            try:
+                # Try and decode the name of a signal. Signal returncodes
+                # are negative.
+                returncode = f"{returncode} ({Signals(abs(returncode)).name})"
+            except ValueError:
+                pass
+            raise BenchmarkInitError(
+                f"Compilation job failed with returncode {returncode}\n"
+                f"Command: {' '.join(cmd)}\n"
+                f"Stderr: {stderr.strip()}"
+            )
+        return stdout
 
     def apply_action(self, action: Action) -> Tuple[bool, Optional[ActionSpace], bool]:
         logging.info("Applied action %d", action.action)
@@ -94,7 +147,7 @@ class UnrollingCompilationSession(CompilationSession):
     def get_observation(self, observation_space: ObservationSpace) -> Observation:
         logging.info("Computing observation from space %s", observation_space)
         if observation_space.name == "ir":
-            return Observation(string_value="Hello, world!")
+            return self._observation["ir"]
         elif observation_space.name == "features":
             observation = Observation()
             observation.int64_list.value[:] = [0, 0, 0]

--- a/examples/example_unrolling_service/service_py/example_service.py
+++ b/examples/example_unrolling_service/service_py/example_service.py
@@ -1,0 +1,109 @@
+#! /usr/bin/env python3
+#
+#  Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""An example CompilerGym service in python."""
+import logging
+from pathlib import Path
+from typing import Optional, Tuple
+
+from compiler_gym.service import CompilationSession
+from compiler_gym.service.proto import (
+    Action,
+    ActionSpace,
+    Benchmark,
+    Observation,
+    ObservationSpace,
+    ScalarLimit,
+    ScalarRange,
+    ScalarRangeList,
+)
+from compiler_gym.service.runtime import create_and_run_compiler_gym_service
+
+
+class ExampleCompilationSession(CompilationSession):
+    """Represents an instance of an interactive compilation session."""
+
+    compiler_version: str = "1.0.0"
+
+    # The list of actions that are supported by this service. This example uses
+    # a static (unchanging) action space, but this could be extended to support
+    # a dynamic action space.
+    action_spaces = [
+        ActionSpace(
+            name="default",
+            action=[
+                "a",
+                "b",
+                "c",
+            ],
+        )
+    ]
+
+    # A list of observation spaces supported by this service. Each of these
+    # ObservationSpace protos describes an observation space.
+    observation_spaces = [
+        ObservationSpace(
+            name="ir",
+            string_size_range=ScalarRange(min=ScalarLimit(value=0)),
+            deterministic=True,
+            platform_dependent=False,
+            default_value=Observation(string_value=""),
+        ),
+        ObservationSpace(
+            name="features",
+            int64_range_list=ScalarRangeList(
+                range=[
+                    ScalarRange(
+                        min=ScalarLimit(value=-100), max=ScalarLimit(value=100)
+                    ),
+                    ScalarRange(
+                        min=ScalarLimit(value=-100), max=ScalarLimit(value=100)
+                    ),
+                    ScalarRange(
+                        min=ScalarLimit(value=-100), max=ScalarLimit(value=100)
+                    ),
+                ]
+            ),
+        ),
+        ObservationSpace(
+            name="runtime",
+            scalar_double_range=ScalarRange(min=ScalarLimit(value=0)),
+            deterministic=False,
+            platform_dependent=True,
+            default_value=Observation(
+                scalar_double=0,
+            ),
+        ),
+    ]
+
+    def __init__(
+        self, working_directory: Path, action_space: ActionSpace, benchmark: Benchmark
+    ):
+        super().__init__(working_directory, action_space, benchmark)
+        logging.info("Started a compilation session for %s", benchmark.uri)
+
+    def apply_action(self, action: Action) -> Tuple[bool, Optional[ActionSpace], bool]:
+        logging.info("Applied action %d", action.action)
+        if action.action < 0 or action.action > len(self.action_spaces[0].action):
+            raise ValueError("Out-of-range")
+        return False, None, False
+
+    def get_observation(self, observation_space: ObservationSpace) -> Observation:
+        logging.info("Computing observation from space %s", observation_space)
+        if observation_space.name == "ir":
+            return Observation(string_value="Hello, world!")
+        elif observation_space.name == "features":
+            observation = Observation()
+            observation.int64_list.value[:] = [0, 0, 0]
+            return observation
+        elif observation_space.name == "runtime":
+            return Observation(scalar_double=0)
+        else:
+            raise KeyError(observation_space.name)
+
+
+if __name__ == "__main__":
+    create_and_run_compiler_gym_service(ExampleCompilationSession)

--- a/examples/example_unrolling_service/service_py/example_service.py
+++ b/examples/example_unrolling_service/service_py/example_service.py
@@ -23,7 +23,7 @@ from compiler_gym.service.proto import (
 from compiler_gym.service.runtime import create_and_run_compiler_gym_service
 
 
-class ExampleCompilationSession(CompilationSession):
+class UnrollingCompilationSession(CompilationSession):
     """Represents an instance of an interactive compilation session."""
 
     compiler_version: str = "1.0.0"
@@ -106,4 +106,4 @@ class ExampleCompilationSession(CompilationSession):
 
 
 if __name__ == "__main__":
-    create_and_run_compiler_gym_service(ExampleCompilationSession)
+    create_and_run_compiler_gym_service(UnrollingCompilationSession)

--- a/examples/example_unrolling_service/service_py/example_service.py
+++ b/examples/example_unrolling_service/service_py/example_service.py
@@ -121,7 +121,11 @@ class UnrollingCompilationSession(CompilationSession):
         )
 
     def apply_action(self, action: Action) -> Tuple[bool, Optional[ActionSpace], bool]:
-        logging.info("Applied action %d", action.action)
+        logging.info(
+            "Applied action %d, equivalent command-line arguments: '%s'",
+            action.action,
+            self._action_space.action[action.action],
+        )
         if action.action < 0 or action.action > len(self.action_spaces[0].action):
             raise ValueError("Out-of-range")
 

--- a/examples/example_unrolling_service/service_py/example_service.py
+++ b/examples/example_unrolling_service/service_py/example_service.py
@@ -101,7 +101,9 @@ class UnrollingCompilationSession(CompilationSession):
         os.makedirs(self._benchmark_log_dir, exist_ok=True)
         self._llvm_path = os.path.join(self._benchmark_log_dir, "version1.ll")
         # FIXME: llvm.clang_path() lead to build errors
-        os.system(f"clang -emit-llvm -S {self._src_path} -o {self._llvm_path}")
+        os.system(
+            f"clang -Xclang -disable-O0-optnone -emit-llvm -S {self._src_path} -o {self._llvm_path}"
+        )
         ir = open(self._llvm_path).read()
 
         self._observation["ir"] = Observation(string_value=ir)
@@ -114,7 +116,7 @@ class UnrollingCompilationSession(CompilationSession):
 
         print("applying action")
         os.system(
-            f"{llvm.opt_path()} --loop-unroll -unroll-count=4 {self._llvm_path} -S -o {self._llvm_path}"
+            f"{llvm.opt_path()} --loop-unroll -unroll-count=16 -unroll-threshold=0 {self._llvm_path} -S -o {self._llvm_path}"
         )
         ir = open(self._llvm_path).read()
         self._observation["ir"] = Observation(string_value=ir)

--- a/examples/example_unrolling_service/service_py/example_service.py
+++ b/examples/example_unrolling_service/service_py/example_service.py
@@ -5,6 +5,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 """An example CompilerGym service in python."""
+import datetime
 import logging
 import os
 from pathlib import Path
@@ -157,10 +158,12 @@ class UnrollingCompilationSession(CompilationSession):
 
         src_uri_p = urlparse(self._benchmark.program.uri)
         self._src_path = os.path.abspath(os.path.join(src_uri_p.netloc, src_uri_p.path))
-        # TODO: populate "timestamp" and "benchmark_name" in the path
+        timestamp = datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
+        benchmark_name = os.path.basename(self._src_path)
         # TODO: add "clean_up" function to remove files and save space
-        self._benchmark_log_dir = (
-            "/tmp/compiler_gym/timestamp/unrolling/benchmark_name/"
+        # TODO: add argument to specify defaut log directory (or use what is used somewhere else in the repo)
+        self._benchmark_log_dir = os.path.join(
+            Path.home(), ".compiler_gym_log", "unrolling", timestamp, benchmark_name
         )
         os.makedirs(self._benchmark_log_dir, exist_ok=True)
         self._llvm_path = os.path.join(self._benchmark_log_dir, "version1.ll")

--- a/examples/example_unrolling_service/service_py/example_service.py
+++ b/examples/example_unrolling_service/service_py/example_service.py
@@ -86,6 +86,7 @@ class UnrollingCompilationSession(CompilationSession):
         super().__init__(working_directory, action_space, benchmark)
         logging.info("Started a compilation session for %s", benchmark.uri)
         self._benchmark = benchmark
+        self._action_space = action_space
         self._update_observations()
 
     def _update_observations(self):
@@ -114,9 +115,8 @@ class UnrollingCompilationSession(CompilationSession):
         if action.action < 0 or action.action > len(self.action_spaces[0].action):
             raise ValueError("Out-of-range")
 
-        print("applying action")
         os.system(
-            f"{llvm.opt_path()} --loop-unroll -unroll-count=16 -unroll-threshold=0 {self._llvm_path} -S -o {self._llvm_path}"
+            f"{llvm.opt_path()} {self._action_space.action[action.action]} {self._llvm_path} -S -o {self._llvm_path}"
         )
         ir = open(self._llvm_path).read()
         self._observation["ir"] = Observation(string_value=ir)

--- a/examples/example_unrolling_service/service_py/example_service.py
+++ b/examples/example_unrolling_service/service_py/example_service.py
@@ -12,6 +12,8 @@ from pathlib import Path
 from typing import Optional, Tuple
 from urllib.parse import urlparse
 
+import utils
+
 import compiler_gym.third_party.llvm as llvm
 from compiler_gym.service import CompilationSession
 from compiler_gym.service.proto import (
@@ -26,64 +28,6 @@ from compiler_gym.service.proto import (
 )
 from compiler_gym.service.runtime import create_and_run_compiler_gym_service
 from compiler_gym.util.timer import Timer
-
-
-# TODO: move to a utils.py file?
-def extract_statistics_from_ir(ir: str):
-    stats = {"control_flow": 0, "arithmetic": 0, "memory": 0}
-    for line in ir.splitlines():
-        tokens = line.split()
-        if len(tokens) > 0:
-            opcode = tokens[0]
-            if opcode in [
-                "br",
-                "call",
-                "ret",
-                "switch",
-                "indirectbr",
-                "invoke",
-                "callbr",
-                "resume",
-                "catchswitch",
-                "catchret",
-                "cleanupret",
-                "unreachable",
-            ]:
-                stats["control_flow"] += 1
-            elif opcode in [
-                "fneg",
-                "add",
-                "fadd",
-                "sub",
-                "fsub",
-                "mul",
-                "fmul",
-                "udiv",
-                "sdiv",
-                "fdiv",
-                "urem",
-                "srem",
-                "frem",
-                "shl",
-                "lshr",
-                "ashr",
-                "and",
-                "or",
-                "xor",
-            ]:
-                stats["arithmetic"] += 1
-            elif opcode in [
-                "alloca",
-                "load",
-                "store",
-                "fence",
-                "cmpxchg",
-                "atomicrmw",
-                "getelementptr",
-            ]:
-                stats["memory"] += 1
-
-    return stats
 
 
 class UnrollingCompilationSession(CompilationSession):
@@ -204,7 +148,7 @@ class UnrollingCompilationSession(CompilationSession):
             return Observation(string_value=ir)
         elif observation_space.name == "features":
             ir = open(self._llvm_path).read()
-            stats = extract_statistics_from_ir(ir)
+            stats = utils.extract_statistics_from_ir(ir)
             observation = Observation()
             observation.int64_list.value[:] = list(stats.values())
             return observation

--- a/examples/example_unrolling_service/service_py/example_service.py
+++ b/examples/example_unrolling_service/service_py/example_service.py
@@ -186,14 +186,17 @@ class UnrollingCompilationSession(CompilationSession):
         new_action_space = None
         return (end_of_session, new_action_space, action_had_no_effect)
 
+    @property
+    def ir(self) -> str:
+        with open(self._llvm_path) as f:
+            return f.read()
+
     def get_observation(self, observation_space: ObservationSpace) -> Observation:
-        logging.info("Computing observation from space %s", observation_space)
+        logging.info("Computing observation from space %s", observation_space.name)
         if observation_space.name == "ir":
-            ir = open(self._llvm_path).read()
-            return Observation(string_value=ir)
+            return Observation(string_value=self.ir)
         elif observation_space.name == "features":
-            ir = open(self._llvm_path).read()
-            stats = utils.extract_statistics_from_ir(ir)
+            stats = utils.extract_statistics_from_ir(self.ir)
             observation = Observation()
             observation.int64_list.value[:] = list(stats.values())
             return observation

--- a/examples/example_unrolling_service/service_py/example_service.py
+++ b/examples/example_unrolling_service/service_py/example_service.py
@@ -15,7 +15,7 @@ from typing import Optional, Tuple
 from urllib.parse import urlparse
 
 import numpy as np
-import utils  # TODO: return back its contents to this file?
+import utils
 
 import compiler_gym.third_party.llvm as llvm
 from compiler_gym.service import CompilationSession
@@ -102,12 +102,11 @@ class UnrollingCompilationSession(CompilationSession):
         src_uri_p = urlparse(self._benchmark.program.uri)
         self._src_path = os.path.abspath(os.path.join(src_uri_p.netloc, src_uri_p.path))
         benchmark_name = os.path.basename(self._src_path).split(".")[0]  # noqa
-        # TODO: assert that the path exists
 
         self._llvm_path = os.path.join(self.working_dir, "{benchmark_name}.ll")
         self._obj_path = os.path.join(self.working_dir, "{benchmark_name}.o")
         self._exe_path = os.path.join(self.working_dir, "{benchmark_name}")
-        # FIXME: llvm.clang_path() lead to build errors
+        # FIXME: llvm.clang_path() lead to build errors if the source file includes a header file
         run_command(
             [
                 "clang",

--- a/examples/example_unrolling_service/service_py/example_service.py
+++ b/examples/example_unrolling_service/service_py/example_service.py
@@ -155,7 +155,8 @@ class UnrollingCompilationSession(CompilationSession):
                 ],
                 timeout=30,
             )
-            os.system(f"clang {self._llvm_path} -O3 -o {self._exe_path}")
+
+            os.system(f"clang {self._obj_path} -O3 -o {self._exe_path}")
             # Running 5 times and taking the average
             with Timer() as exec_time:
                 os.system(
@@ -168,7 +169,7 @@ class UnrollingCompilationSession(CompilationSession):
             os.system(
                 f"{llvm.llc_path()} -filetype=obj {self._llvm_path} -o {self._obj_path}"
             )
-            os.system(f"clang {self._llvm_path} -Oz -o {self._exe_path}")
+            os.system(f"clang {self._obj_path} -Oz -o {self._exe_path}")
             binary_size = os.path.getsize(self._exe_path)
             return Observation(scalar_double=binary_size)
         else:

--- a/examples/example_unrolling_service/service_py/example_service.py
+++ b/examples/example_unrolling_service/service_py/example_service.py
@@ -18,6 +18,7 @@ import numpy as np
 import utils
 
 import compiler_gym.third_party.llvm as llvm
+from compiler_gym.datasets import BenchmarkInitError
 from compiler_gym.service import CompilationSession
 from compiler_gym.service.proto import (
     Action,
@@ -31,7 +32,6 @@ from compiler_gym.service.proto import (
 )
 from compiler_gym.service.runtime import create_and_run_compiler_gym_service
 from compiler_gym.util.commands import run_command
-from compiler_gym.util.timer import Timer
 
 
 class UnrollingCompilationSession(CompilationSession):
@@ -177,16 +177,22 @@ class UnrollingCompilationSession(CompilationSession):
                 timeout=30,
             )
 
-            # TODO: use more accurate methods to measure time
+            # TODO: add documentation that benchmarks need print out execution time
             # Running 5 times and taking the average of middle 3
             exec_times = []
             for _ in range(5):
-                with Timer() as exec_time:
-                    run_command(
-                        [self._exe_path],
-                        timeout=30,
+                stdout = run_command(
+                    [self._exe_path],
+                    timeout=30,
+                )
+                try:
+                    exec_times.append(int(stdout))
+                except ValueError:
+                    raise BenchmarkInitError(
+                        f"Error in parsing execution time from output of command\n"
+                        f"Please ensure that the source code of the benchmark measures execution time and prints to stdout\n"
+                        f"Stdout of the program: {stdout}"
                     )
-                exec_times.append(exec_time.time)
             exec_times = np.sort(exec_times)
             avg_exec_time = np.mean(exec_times[1:4])
             return Observation(scalar_double=avg_exec_time)

--- a/examples/example_unrolling_service/service_py/example_service.py
+++ b/examples/example_unrolling_service/service_py/example_service.py
@@ -158,12 +158,18 @@ class UnrollingCompilationSession(CompilationSession):
 
         src_uri_p = urlparse(self._benchmark.program.uri)
         self._src_path = os.path.abspath(os.path.join(src_uri_p.netloc, src_uri_p.path))
-        timestamp = datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
+        current_date = datetime.datetime.now().strftime("%Y-%m-%d")
+        current_time = datetime.datetime.now().strftime("%H-%M-%S")
         benchmark_name = os.path.basename(self._src_path)
         # TODO: add "clean_up" function to remove files and save space
         # TODO: add argument to specify defaut log directory (or use what is used somewhere else in the repo)
         self._benchmark_log_dir = os.path.join(
-            Path.home(), ".compiler_gym_log", "unrolling", timestamp, benchmark_name
+            Path.home(),
+            ".compiler_gym_log",
+            "unrolling",
+            current_date,
+            current_time,
+            benchmark_name,
         )
         os.makedirs(self._benchmark_log_dir, exist_ok=True)
         self._llvm_path = os.path.join(self._benchmark_log_dir, "version1.ll")

--- a/examples/example_unrolling_service/service_py/example_service.py
+++ b/examples/example_unrolling_service/service_py/example_service.py
@@ -91,10 +91,17 @@ class UnrollingCompilationSession(CompilationSession):
 
     def _update_observations(self):
         self._observation = dict()
-        p = urlparse(self._benchmark.program.uri)
-        final_path = os.path.abspath(os.path.join(p.netloc, p.path))
-        ir = open(final_path).read()
-        print("ir: ", ir)
+
+        src_uri_p = urlparse(self._benchmark.program.uri)
+        src_path = os.path.abspath(os.path.join(src_uri_p.netloc, src_uri_p.path))
+        # TODO: populate "timestamp" and "benchmark_name" in the path
+        # TODO: add "clean_up" function to remove files and save space
+        benchmark_log_dir = "/tmp/compiler_gym/timestamp/unrolling/benchmark_name/"
+        os.makedirs(benchmark_log_dir, exist_ok=True)
+        llvm_path = os.path.join(benchmark_log_dir, "version1.ll")
+        os.system(f"clang -emit-llvm -S {src_path} -o {llvm_path}")
+        ir = open(llvm_path).read()
+
         self._observation["ir"] = Observation(string_value=ir)
         # TODO: update "features" and "runtime" observations
 

--- a/examples/example_unrolling_service/service_py/example_service.py
+++ b/examples/example_unrolling_service/service_py/example_service.py
@@ -97,12 +97,12 @@ class UnrollingCompilationSession(CompilationSession):
 
         src_uri_p = urlparse(self._benchmark.program.uri)
         self._src_path = os.path.abspath(os.path.join(src_uri_p.netloc, src_uri_p.path))
+        benchmark_name = os.path.basename(self._src_path).split(".")[0]  # noqa
         # TODO: assert that the path exists
 
-        # TODO: use a counter to suffix IR and obj files? Or remove the suffix?
-        self._llvm_path = os.path.join(self.working_dir, "version1.ll")
-        self._obj_path = os.path.join(self.working_dir, "version1.o")
-        self._exe_path = os.path.join(self.working_dir, "version1")
+        self._llvm_path = os.path.join(self.working_dir, "{benchmark_name}.ll")
+        self._obj_path = os.path.join(self.working_dir, "{benchmark_name}.o")
+        self._exe_path = os.path.join(self.working_dir, "{benchmark_name}")
         # FIXME: llvm.clang_path() lead to build errors
         # TODO: throw exception if any command fails
         os.system(

--- a/examples/example_unrolling_service/service_py/example_service.py
+++ b/examples/example_unrolling_service/service_py/example_service.py
@@ -93,9 +93,6 @@ class UnrollingCompilationSession(CompilationSession):
         logging.info("Started a compilation session for %s", benchmark.uri)
         self._benchmark = benchmark
         self._action_space = action_space
-        self.reset()
-
-    def reset(self):
         self._observation = dict()
 
         src_uri_p = urlparse(self._benchmark.program.uri)

--- a/examples/example_unrolling_service/service_py/example_service.py
+++ b/examples/example_unrolling_service/service_py/example_service.py
@@ -7,7 +7,6 @@
 """An example CompilerGym service in python."""
 import logging
 import os
-import time
 from pathlib import Path
 from typing import Optional, Tuple
 from urllib.parse import urlparse
@@ -25,6 +24,7 @@ from compiler_gym.service.proto import (
     ScalarRangeList,
 )
 from compiler_gym.service.runtime import create_and_run_compiler_gym_service
+from compiler_gym.util.timer import Timer
 
 
 # TODO: move to a utils.py file?
@@ -203,10 +203,12 @@ class UnrollingCompilationSession(CompilationSession):
             os.system(
                 f"clang {self._llvm_path} -o {self._exe_path}"
             )  # TODO: use -O3 here?
-            # FIXME: this is a very inaccurate way to measure time
-            start_time = time.time()
-            os.system(f"{self._exe_path}")
-            exec_time = time.time() - start_time
+            # Running 5 times and taking the average
+            with Timer() as exec_time:
+                os.system(
+                    f"{self._exe_path}; {self._exe_path}; {self._exe_path}; {self._exe_path}; {self._exe_path}"
+                )
+            exec_time = exec_time.time / 5
             return Observation(scalar_double=exec_time)
         elif observation_space.name == "size":
             # TODO: refactor code so that you don't redo code compilation here?

--- a/examples/example_unrolling_service/service_py/example_service.py
+++ b/examples/example_unrolling_service/service_py/example_service.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Optional, Tuple
 from urllib.parse import urlparse
 
-import utils
+import utils  # TODO: return back its contents to this file?
 
 import compiler_gym.third_party.llvm as llvm
 from compiler_gym.service import CompilationSession
@@ -26,6 +26,7 @@ from compiler_gym.service.proto import (
     ScalarRangeList,
 )
 from compiler_gym.service.runtime import create_and_run_compiler_gym_service
+from compiler_gym.util.commands import run_command
 from compiler_gym.util.timer import Timer
 
 
@@ -105,8 +106,18 @@ class UnrollingCompilationSession(CompilationSession):
         self._exe_path = os.path.join(self.working_dir, "{benchmark_name}")
         # FIXME: llvm.clang_path() lead to build errors
         # TODO: throw exception if any command fails
-        os.system(
-            f"clang -Xclang -disable-O0-optnone -emit-llvm -S {self._src_path} -o {self._llvm_path}"
+        run_command(
+            [
+                "clang",
+                "-Xclang",
+                "-disable-O0-optnone",
+                "-emit-llvm",
+                "-S",
+                self._src_path,
+                "-o",
+                self._llvm_path,
+            ],
+            timeout=20,
         )
 
     def apply_action(self, action: Action) -> Tuple[bool, Optional[ActionSpace], bool]:

--- a/examples/example_unrolling_service/service_py/example_service.py
+++ b/examples/example_unrolling_service/service_py/example_service.py
@@ -7,6 +7,7 @@
 """An example CompilerGym service in python."""
 import logging
 import os
+import time
 from pathlib import Path
 from typing import Optional, Tuple
 from urllib.parse import urlparse
@@ -136,8 +137,10 @@ class UnrollingCompilationSession(CompilationSession):
             )
             os.system(f"clang {self._llvm_path} -o {self._exe_path}")
             # FIXME: this is a very inaccurate way to measure time
+            start_time = time.time()
             os.system(f"{self._exe_path}")
-            return Observation(scalar_double=0)
+            exec_time = time.time() - start_time
+            return Observation(scalar_double=exec_time)
         else:
             raise KeyError(observation_space.name)
 

--- a/examples/example_unrolling_service/service_py/example_service.py
+++ b/examples/example_unrolling_service/service_py/example_service.py
@@ -102,9 +102,9 @@ class UnrollingCompilationSession(CompilationSession):
         self._src_path = os.path.abspath(os.path.join(src_uri_p.netloc, src_uri_p.path))
         benchmark_name = os.path.basename(self._src_path).split(".")[0]  # noqa
 
-        self._llvm_path = os.path.join(self.working_dir, "{benchmark_name}.ll")
-        self._obj_path = os.path.join(self.working_dir, "{benchmark_name}.o")
-        self._exe_path = os.path.join(self.working_dir, "{benchmark_name}")
+        self._llvm_path = os.path.join(self.working_dir, f"{benchmark_name}.ll")
+        self._obj_path = os.path.join(self.working_dir, f"{benchmark_name}.o")
+        self._exe_path = os.path.join(self.working_dir, f"{benchmark_name}")
         # FIXME: llvm.clang_path() lead to build errors if the source file includes a header file
         run_command(
             [

--- a/examples/example_unrolling_service/service_py/example_service.py
+++ b/examples/example_unrolling_service/service_py/example_service.py
@@ -129,10 +129,20 @@ class UnrollingCompilationSession(CompilationSession):
         llvm_path_before = tempfile.NamedTemporaryFile().name
         shutil.copyfile(self._llvm_path, llvm_path_before)
 
-        os.system(
-            f"{llvm.opt_path()} {self._action_space.action[action.action]} {self._llvm_path} -S -o {self._llvm_path}"
-        )
+        # separate arguments string to list of string, because `run_command` requires each argument to be passed as a separate item in a list
+        action_arguments_list = self._action_space.action[action.action].split()
 
+        run_command(
+            [
+                str(llvm.opt_path()),
+                *action_arguments_list,
+                self._llvm_path,
+                "-S",
+                "-o",
+                self._llvm_path,
+            ],
+            timeout=30,
+        )
         end_of_session = False  # TODO: this needs investigation: for how long can we apply loop unrolling? e.g., detect if there are no more loops in the IR?
         new_action_space = None
         action_had_no_effect = filecmp.cmp(

--- a/examples/example_unrolling_service/service_py/example_service.py
+++ b/examples/example_unrolling_service/service_py/example_service.py
@@ -5,7 +5,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 """An example CompilerGym service in python."""
-import datetime
 import logging
 import os
 from pathlib import Path
@@ -101,27 +100,12 @@ class UnrollingCompilationSession(CompilationSession):
 
         src_uri_p = urlparse(self._benchmark.program.uri)
         self._src_path = os.path.abspath(os.path.join(src_uri_p.netloc, src_uri_p.path))
-        current_date = datetime.datetime.now().strftime("%Y-%m-%d")
-        current_time = datetime.datetime.now().strftime("%H-%M-%S")
         # TODO: assert that the path exists
-        benchmark_name = os.path.basename(self._src_path)
 
-        # TODO: add "clean_up" function to remove files and save space
-        # TODO: add argument to specify defaut log directory (or use what is used somewhere else in the repo)
-        # maybe use `with tempfile.TemporaryDirectory() as d:`
-        self._benchmark_log_dir = os.path.join(
-            Path.home(),
-            ".compiler_gym_log",
-            "unrolling",
-            current_date,
-            current_time,
-            benchmark_name,
-        )
-        os.makedirs(self._benchmark_log_dir, exist_ok=True)
         # TODO: use a counter to suffix IR and obj files? Or remove the suffix?
-        self._llvm_path = os.path.join(self._benchmark_log_dir, "version1.ll")
-        self._obj_path = os.path.join(self._benchmark_log_dir, "version1.o")
-        self._exe_path = os.path.join(self._benchmark_log_dir, "version1")
+        self._llvm_path = os.path.join(self.working_dir, "version1.ll")
+        self._obj_path = os.path.join(self.working_dir, "version1.o")
+        self._exe_path = os.path.join(self.working_dir, "version1")
         # FIXME: llvm.clang_path() lead to build errors
         # TODO: throw exception if any command fails
         os.system(

--- a/examples/example_unrolling_service/service_py/example_service.py
+++ b/examples/example_unrolling_service/service_py/example_service.py
@@ -159,9 +159,12 @@ class UnrollingCompilationSession(CompilationSession):
         self._src_path = os.path.abspath(os.path.join(src_uri_p.netloc, src_uri_p.path))
         current_date = datetime.datetime.now().strftime("%Y-%m-%d")
         current_time = datetime.datetime.now().strftime("%H-%M-%S")
+        # TODO: assert that the path exists
         benchmark_name = os.path.basename(self._src_path)
+
         # TODO: add "clean_up" function to remove files and save space
         # TODO: add argument to specify defaut log directory (or use what is used somewhere else in the repo)
+        # maybe use `with tempfile.TemporaryDirectory() as d:`
         self._benchmark_log_dir = os.path.join(
             Path.home(),
             ".compiler_gym_log",

--- a/examples/example_unrolling_service/service_py/example_service.py
+++ b/examples/example_unrolling_service/service_py/example_service.py
@@ -18,7 +18,6 @@ import numpy as np
 import utils
 
 import compiler_gym.third_party.llvm as llvm
-from compiler_gym.datasets import BenchmarkInitError
 from compiler_gym.service import CompilationSession
 from compiler_gym.service.proto import (
     Action,
@@ -188,7 +187,7 @@ class UnrollingCompilationSession(CompilationSession):
                 try:
                     exec_times.append(int(stdout))
                 except ValueError:
-                    raise BenchmarkInitError(
+                    raise ValueError(
                         f"Error in parsing execution time from output of command\n"
                         f"Please ensure that the source code of the benchmark measures execution time and prints to stdout\n"
                         f"Stdout of the program: {stdout}"

--- a/examples/example_unrolling_service/service_py/example_service.py
+++ b/examples/example_unrolling_service/service_py/example_service.py
@@ -95,7 +95,6 @@ class UnrollingCompilationSession(CompilationSession):
         logging.info("Started a compilation session for %s", benchmark.uri)
         self._benchmark = benchmark
         self._action_space = action_space
-        self._observation = dict()
 
         src_uri_p = urlparse(self._benchmark.program.uri)
         self._src_path = os.path.abspath(os.path.join(src_uri_p.netloc, src_uri_p.path))
@@ -128,9 +127,6 @@ class UnrollingCompilationSession(CompilationSession):
         os.system(
             f"{llvm.opt_path()} {self._action_space.action[action.action]} {self._llvm_path} -S -o {self._llvm_path}"
         )
-        ir = open(self._llvm_path).read()
-        # TODO: it seems that we don't need an _observation dictionary. Perhapse "ir" string is enough
-        self._observation["ir"] = Observation(string_value=ir)
         return False, None, False  # TODO: return correct values
 
     def get_observation(self, observation_space: ObservationSpace) -> Observation:

--- a/examples/example_unrolling_service/service_py/utils.py
+++ b/examples/example_unrolling_service/service_py/utils.py
@@ -1,0 +1,61 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+def extract_statistics_from_ir(ir: str):
+    stats = {"control_flow": 0, "arithmetic": 0, "memory": 0}
+    for line in ir.splitlines():
+        tokens = line.split()
+        if len(tokens) > 0:
+            opcode = tokens[0]
+            if opcode in [
+                "br",
+                "call",
+                "ret",
+                "switch",
+                "indirectbr",
+                "invoke",
+                "callbr",
+                "resume",
+                "catchswitch",
+                "catchret",
+                "cleanupret",
+                "unreachable",
+            ]:
+                stats["control_flow"] += 1
+            elif opcode in [
+                "fneg",
+                "add",
+                "fadd",
+                "sub",
+                "fsub",
+                "mul",
+                "fmul",
+                "udiv",
+                "sdiv",
+                "fdiv",
+                "urem",
+                "srem",
+                "frem",
+                "shl",
+                "lshr",
+                "ashr",
+                "and",
+                "or",
+                "xor",
+            ]:
+                stats["arithmetic"] += 1
+            elif opcode in [
+                "alloca",
+                "load",
+                "store",
+                "fence",
+                "cmpxchg",
+                "atomicrmw",
+                "getelementptr",
+            ]:
+                stats["memory"] += 1
+
+    return stats


### PR DESCRIPTION
## Summary
Simple example service that:
- has different unrolling factors as actions
- creates a simple dataset with 2 .c files
- we use a `BENCH` C function within the benchmarks that prints the measured time to stdout and it gets parsed to measure the reward. 
 
`BENCH` is used in famous benchmakrs like gcc-loops and TSVC, so hopefully that is a nice way to reuse benchmarking tools already existing out there.

## TODOs
To complete the PR, I need to update the README in the unrolling example directory with details on how to run the example, how to modify it, and how to create benchmarks.

## Issues
It seems that `clang` or `opt` are ignoring the unrolling factor when we pass `-unroll-count=<NUMBER>`. The only way to force an unrolling factor is to add it as `#pragma` statement in the C code before the loop. 
So we have different options to deal with this:
1. Continue debugging and find a way to pass the unrolling factor to the command-line
2. Modify `apply_action` to insert the #pragma into the source file. I think that is what https://github.com/intel/neuro-vectorizer has done. The advantage is that it will allow users to have fine grain control on each loop in the code. The disadvantage is that it will make the example too complicated. Maybe that could be a separate project or separate PR.
3. Look for another pass whose parameters can be controlled from a command-line option

## Future
We can either enhance this example, or create new examples by:
1. Adding more loop transformations with their parameters. (Use the recently added feature of composable actions)
2. Allowing fine grain control on loops by inserting #pragma statments into the source code
3. Add observations that are related to loop transformations, such as polyhedral access matrices