### PR TITLE
Bump the node-notifier version.

### DIFF
--- a/www/frontends/compiler_gym/package-lock.json
+++ b/www/frontends/compiler_gym/package-lock.json
@@ -7521,7 +7521,7 @@
         "jest-snapshot": "^20.0.3",
         "jest-util": "^20.0.3",
         "micromatch": "^2.3.11",
-        "node-notifier": "^5.0.2",
+        "node-notifier": "^8.01",
         "pify": "^2.3.0",
         "slash": "^1.0.0",
         "string-length": "^1.0.1",


### PR DESCRIPTION
GitHub has detected that a package defined in the
www/frontends/compiler_gym/package-lock.json file of the
facebookresearch/CompilerGym repository contains a security vulnerability.

Package name: node-notifier
Affected versions: < 8.0.1
Fixed in version: 8.0.1
Severity: MODERATE