### PR TITLE
[llvm] Add a new Bitcode observation space.

### DIFF
--- a/compiler_gym/envs/llvm/service/Observation.cc
+++ b/compiler_gym/envs/llvm/service/Observation.cc
@@ -59,6 +59,13 @@ Status setObservation(LlvmObservationSpace space, const fs::path& workingDirecto
       reply.set_string_value(ss.str());
       break;
     }
+    case LlvmObservationSpace::BITCODE: {
+      std::string bitcode;
+      llvm::raw_string_ostream outbuffer(bitcode);
+      llvm::WriteBitcodeToFile(benchmark.module(), outbuffer);
+      reply.set_binary_value(outbuffer.str());
+      break;
+    }
     case LlvmObservationSpace::BITCODE_FILE: {
       // Generate an output path with 16 bits of randomness.
       const auto outpath = fs::unique_path(workingDirectory / "module-%%%%%%%%.bc");

--- a/compiler_gym/envs/llvm/service/ObservationSpaces.cc
+++ b/compiler_gym/envs/llvm/service/ObservationSpaces.cc
@@ -32,14 +32,12 @@ std::vector<ObservationSpace> getLlvmObservationSpaceList() {
     space.set_name(util::enumNameToPascalCase<LlvmObservationSpace>(value));
     switch (value) {
       case LlvmObservationSpace::IR: {
-        ScalarRange irSize;
         space.mutable_string_size_range()->mutable_min()->set_value(0);
         space.set_deterministic(true);
         space.set_platform_dependent(false);
         break;
       }
       case LlvmObservationSpace::IR_SHA1: {
-        ScalarRange sha1Size;
         space.mutable_string_size_range()->mutable_min()->set_value(40);
         space.mutable_string_size_range()->mutable_max()->set_value(40);
         space.set_deterministic(true);
@@ -53,7 +51,6 @@ std::vector<ObservationSpace> getLlvmObservationSpaceList() {
         break;
       }
       case LlvmObservationSpace::BITCODE_FILE: {
-        ScalarRange pathLength;
         space.mutable_string_size_range()->mutable_min()->set_value(0);
         // 4096 is the maximum path length for most filesystems.
         space.mutable_string_size_range()->mutable_max()->set_value(kMaximumPathLength);
@@ -95,10 +92,8 @@ std::vector<ObservationSpace> getLlvmObservationSpaceList() {
       }
       case LlvmObservationSpace::PROGRAML: {
         // ProGraML serializes the graph to JSON.
-        ScalarRange encodedSize;
-        encodedSize.mutable_min()->set_value(0);
         space.set_opaque_data_format("json://networkx/MultiDiGraph");
-        *space.mutable_string_size_range() = encodedSize;
+        space.mutable_string_size_range()->mutable_min()->set_value(0);
         space.set_deterministic(true);
         space.set_platform_dependent(false);
         programl::ProgramGraph graph;
@@ -110,10 +105,8 @@ std::vector<ObservationSpace> getLlvmObservationSpaceList() {
       }
       case LlvmObservationSpace::PROGRAML_JSON: {
         // ProGraML serializes the graph to JSON.
-        ScalarRange encodedSize;
-        encodedSize.mutable_min()->set_value(0);
         space.set_opaque_data_format("json://");
-        *space.mutable_string_size_range() = encodedSize;
+        space.mutable_string_size_range()->mutable_min()->set_value(0);
         space.set_deterministic(true);
         space.set_platform_dependent(false);
         programl::ProgramGraph graph;
@@ -125,10 +118,8 @@ std::vector<ObservationSpace> getLlvmObservationSpaceList() {
       }
       case LlvmObservationSpace::CPU_INFO: {
         // Hardware info is returned as a JSON
-        ScalarRange encodedSize;
-        encodedSize.mutable_min()->set_value(0);
         space.set_opaque_data_format("json://");
-        *space.mutable_string_size_range() = encodedSize;
+        space.mutable_string_size_range()->mutable_min()->set_value(0);
         space.set_deterministic(true);
         space.set_platform_dependent(true);
         *space.mutable_default_value()->mutable_string_value() = "{}";

--- a/compiler_gym/envs/llvm/service/ObservationSpaces.cc
+++ b/compiler_gym/envs/llvm/service/ObservationSpaces.cc
@@ -46,6 +46,12 @@ std::vector<ObservationSpace> getLlvmObservationSpaceList() {
         space.set_platform_dependent(false);
         break;
       }
+      case LlvmObservationSpace::BITCODE: {
+        space.mutable_binary_size_range()->mutable_min()->set_value(0);
+        space.set_deterministic(true);
+        space.set_platform_dependent(false);
+        break;
+      }
       case LlvmObservationSpace::BITCODE_FILE: {
         ScalarRange pathLength;
         space.mutable_string_size_range()->mutable_min()->set_value(0);

--- a/compiler_gym/envs/llvm/service/ObservationSpaces.h
+++ b/compiler_gym/envs/llvm/service/ObservationSpaces.h
@@ -30,6 +30,8 @@ enum class LlvmObservationSpace {
   IR,
   /** The 40-digit hex SHA1 checksum of the LLVM module. */
   IR_SHA1,
+  /** Get the bitcode as a bytes array. */
+  BITCODE,
   /** Write the bitcode to a file and return its path as a string. */
   BITCODE_FILE,
   /** The counts of all instructions in a program. */

--- a/compiler_gym/spaces/sequence.py
+++ b/compiler_gym/spaces/sequence.py
@@ -79,9 +79,18 @@ class Sequence(Space):
         upper_bound = float("inf") if self.size_range[1] is None else self.size_range[1]
         if not (lower_bound <= len(x) <= upper_bound):
             return False
-        for element in x:
-            if not isinstance(element, self.dtype):
+
+        # TODO(cummins): The dtype API is inconsistent. When dtype=str or
+        # dtype=bytes, we expect this to be the type of the entire sequence. But
+        # for dtype=int, we expect this to be the type of each element. We
+        # should distinguish these differences better.
+        if self.dtype in {str, bytes}:
+            if not isinstance(x, self.dtype):
                 return False
+        else:
+            for element in x:
+                if not isinstance(element, self.dtype):
+                    return False
 
         # Run the bounds check on every scalar element, if there is a scalar
         # range specified.

--- a/tests/spaces/sequence_test.py
+++ b/tests/spaces/sequence_test.py
@@ -54,5 +54,12 @@ def test_contains_with_float_scalar_range():
     assert not space.contains([0.0, 0])  # wrong shape
 
 
+def test_bytes_contains():
+    space = Sequence(size_range=(0, None), dtype=bytes)
+    assert space.contains(b"Hello, world!")
+    assert space.contains(b"")
+    assert not space.contains("Hello, world!")
+
+
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This adds a Bitcode observation space that returns the bitcode of an
LLVM module directly as a byte array, without having to go via an
intermediate file.

Fixes #426.