### PR TITLE
[datasets] Add a weighted implementation of random_benchmark().

### DIFF
--- a/tests/datasets/datasets_test.py
+++ b/tests/datasets/datasets_test.py
@@ -245,8 +245,10 @@ def test_benchmarks_iter_deprecated():
     ]
 
 
-def test_random_benchmark(mocker):
+@pytest.mark.parametrize("weight_datasets_by_size", [False, True])
+def test_random_benchmark(mocker, weight_datasets_by_size: bool):
     da = MockDataset("benchmark://foo-v0")
+    da.size = 10
     ba = MockBenchmark(uri="benchmark://foo-v0/abc")
     da.benchmark_values.append(ba)
     datasets = Datasets([da])
@@ -256,7 +258,13 @@ def test_random_benchmark(mocker):
     num_benchmarks = 5
     rng = np.random.default_rng(0)
     random_benchmarks = {
-        b.uri for b in (datasets.random_benchmark(rng) for _ in range(num_benchmarks))
+        b.uri
+        for b in (
+            datasets.random_benchmark(
+                rng, weight_datasets_by_size=weight_datasets_by_size
+            )
+            for _ in range(num_benchmarks)
+        )
     }
 
     assert da.random_benchmark.call_count == num_benchmarks

--- a/tests/datasets/datasets_test.py
+++ b/tests/datasets/datasets_test.py
@@ -245,8 +245,8 @@ def test_benchmarks_iter_deprecated():
     ]
 
 
-@pytest.mark.parametrize("weight_datasets_by_size", [False, True])
-def test_random_benchmark(mocker, weight_datasets_by_size: bool):
+@pytest.mark.parametrize("weighted", [False, True])
+def test_random_benchmark(mocker, weighted: bool):
     da = MockDataset("benchmark://foo-v0")
     da.size = 10
     ba = MockBenchmark(uri="benchmark://foo-v0/abc")
@@ -260,9 +260,7 @@ def test_random_benchmark(mocker, weight_datasets_by_size: bool):
     random_benchmarks = {
         b.uri
         for b in (
-            datasets.random_benchmark(
-                rng, weight_datasets_by_size=weight_datasets_by_size
-            )
+            datasets.random_benchmark(rng, weighted=weighted)
             for _ in range(num_benchmarks)
         )
     }


### PR DESCRIPTION
By default datasets are selected uniformly randomly in
Datasets.random_benchmark(). This means that datasets with a small
number of benchmarks will be overrepresented compared to datasets with
many benchmarks. To correct for this bias this patch adds a
weight_datasets_by_size argument which is equivalent to weighting the
dataset choice by the number of benchmarks in each dataset:

    >>> random.choices(datasets, weights=[len(p) for p in datasets])

Weighting the choice of datasets by their size means that datasets with
infinite sizes (such as random program generators) will be excluded from
sampling as their size is 0.

Fixes #422.