### PR TITLE
[tests] Regression and unit tests for env.fork()

### DIFF
--- a/tests/llvm/BUILD
+++ b/tests/llvm/BUILD
@@ -127,6 +127,17 @@ py_test(
 )
 
 py_test(
+    name = "fork_regression_test",
+    timeout = "long",
+    srcs = ["fork_regression_test.py"],
+    deps = [
+        "//compiler_gym/envs",
+        "//tests:test_main",
+        "//tests/pytest_plugins:llvm",
+    ],
+)
+
+py_test(
     name = "fresh_environment_observation_reward_test",
     timeout = "long",
     srcs = ["fresh_environment_observation_reward_test.py"],

--- a/tests/llvm/fork_regression_test.py
+++ b/tests/llvm/fork_regression_test.py
@@ -1,0 +1,73 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Regression tests for LlvmEnv.fork() identified by hand or through fuzzing."""
+
+from typing import NamedTuple
+
+import pytest
+from flaky import flaky
+
+from compiler_gym.envs import LlvmEnv
+from tests.test_main import main
+
+pytest_plugins = ["tests.pytest_plugins.llvm"]
+
+
+class ForkRegressionTest(NamedTuple):
+    benchmark: str
+    pre_fork: str
+    post_fork: str
+    reward_space: str = "IrInstructionCount"
+
+
+@flaky
+@pytest.mark.parametrize(
+    "test",
+    [
+        ForkRegressionTest(
+            benchmark="benchmark://cbench-v1/tiff2bw",
+            pre_fork="-loop-unswitch -name-anon-globals -attributor -correlated-propagation -loop-unroll-and-jam -reg2mem -break-crit-edges -globalopt -inline",
+            post_fork="-cross-dso-cfi -gvn-hoist",
+        ),
+        ForkRegressionTest(
+            benchmark="benchmark://cbench-v1/bzip2",
+            pre_fork="-loop-deletion -argpromotion -callsite-splitting -mergeicmps -deadargelim -instsimplify -mem2reg -instcombine -rewrite-statepoints-for-gc -insert-gcov-profiling",
+            post_fork="-partially-inline-libcalls -loop-guard-widening",
+        ),
+        ForkRegressionTest(
+            benchmark="benchmark://cbench-v1/jpeg-d",
+            pre_fork="-bdce -loop-guard-widening -loop-reduce -globaldce -sroa -partially-inline-libcalls -loop-deletion -forceattrs -flattencfg -simple-loop-unswitch",
+            post_fork="-mergefunc -dse -load-store-vectorizer -sroa -mldst-motion -hotcoldsplit -loop-versioning-licm -loop-rotate",
+        ),
+    ],
+)
+def test_fork_regression_test(env: LlvmEnv, test: ForkRegressionTest):
+    """Run the fork regression test:
+
+    1. Initialize an environment.
+    2. Apply a "pre_fork" sequence of actions.
+    3. Create a fork of the environment.
+    4. Apply a "post_fork" sequence of actions in both the fork and parent.
+    5. Verify that the environment states have gone out of sync.
+    """
+    env.reward_space = test.reward_space
+    env.reset(test.benchmark)
+    pre_fork = [env.action_space[f] for f in test.pre_fork.split()]
+    post_fork = [env.action_space[f] for f in test.post_fork.split()]
+
+    _, _, done, info = env.step(pre_fork)
+    assert not done, info
+
+    with env.fork() as fkd:
+        assert env.state == fkd.state  # Sanity check
+
+        env.step(post_fork)
+        fkd.step(post_fork)
+        # Verify that the environment states no longer line up.
+        assert env.state != fkd.state
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
* Adds a test that using fork() in a `with` statement works as expected (i.e. the environment is closed at the end of the scope), and refactors the unit tests to use this syntax.
* Adds a set of tests for combinations of benchmarks and actions that have been found to produce diverging states in forked environments.

Fixes #362.
