### PR TITLE
[requirements] Pin gym at < 0.21.

### DIFF
--- a/compiler_gym/requirements.txt
+++ b/compiler_gym/requirements.txt
@@ -3,7 +3,7 @@ deprecated>=1.2.12
 docker>=4.0.0
 fasteners>=0.15
 grpcio>=1.32.0
-gym>=0.18.0
+gym>=0.18.0,<0.21
 humanize>=2.6.0
 loop_tool_py==0.0.7
 networkx>=2.5


### PR DESCRIPTION
Fixes #456.

Note that this is a quick mitigation of the test failures to get our CI back on its feet. Long term we need to make CompilerGym compatible with gym >= 0.21