### PR TITLE
Make derived observation spaces compatible with constructor.

### DIFF
--- a/compiler_gym/envs/compiler_env.py
+++ b/compiler_gym/envs/compiler_env.py
@@ -159,6 +159,7 @@ class CompilerEnv(gym.Env):
         observation_space: Optional[Union[str, ObservationSpaceSpec]] = None,
         reward_space: Optional[Union[str, Reward]] = None,
         action_space: Optional[str] = None,
+        derived_observation_spaces: Optional[List[Dict[str, Any]]] = None,
         connection_settings: Optional[ConnectionOpts] = None,
         service_connection: Optional[CompilerGymServiceConnection] = None,
         logger: Optional[logging.Logger] = None,
@@ -204,6 +205,10 @@ class CompilerEnv(gym.Env):
 
         :param action_space: The name of the action space to use. If not
             specified, the default action space for this compiler is used.
+
+        :param derived_observation_spaces: An optional list of arguments to be
+            passed to :meth:`env.observation.add_derived_space()
+            <compiler_gym.views.observation.Observation.add_derived_space>`.
 
         :param connection_settings: The settings used to establish a connection
             with the remote service.
@@ -298,6 +303,11 @@ class CompilerEnv(gym.Env):
             spaces=self.service.observation_spaces,
         )
         self.reward = self._reward_view_type(rewards, self.observation)
+
+        # Register any derived observation spaces now so that the observation
+        # space can be set below.
+        for derived_observation_space in derived_observation_spaces or []:
+            self.observation.add_derived_space_internal(**derived_observation_space)
 
         # Lazily evaluated version strings.
         self._versions: Optional[GetVersionReply] = None

--- a/compiler_gym/views/observation.py
+++ b/compiler_gym/views/observation.py
@@ -4,6 +4,8 @@
 # LICENSE file in the root directory of this source tree.
 from typing import Callable, Dict, List
 
+from deprecated.sphinx import deprecated
+
 from compiler_gym.service.connection import ServiceError
 from compiler_gym.service.proto import ObservationSpace
 from compiler_gym.util.gym_type_hints import (
@@ -93,6 +95,13 @@ class ObservationView:
         # env.observation.FooBar().
         setattr(self, space.id, lambda: self[space.id])
 
+    @deprecated(
+        version="0.2.1",
+        reason=(
+            "Use the derived_observation_spaces argument to CompilerEnv constructor. "
+            "See <https://github.com/facebookresearch/CompilerGym/issues/461>."
+        ),
+    )
     def add_derived_space(
         self,
         id: str,

--- a/compiler_gym/views/observation.py
+++ b/compiler_gym/views/observation.py
@@ -135,5 +135,18 @@ class ObservationView:
         base_space = self.spaces[base_id]
         self._add_space(base_space.make_derived_space(id=id, **kwargs))
 
+    # NOTE(github.com/facebookresearch/CompilerGym/issues/461): This method will
+    # be renamed to add_derived_space() once the current method with that name
+    # is removed.
+    def add_derived_space_internal(
+        self,
+        id: str,
+        base_id: str,
+        **kwargs,
+    ) -> None:
+        """Internal API for adding a new observation space."""
+        base_space = self.spaces[base_id]
+        self._add_space(base_space.make_derived_space(id=id, **kwargs))
+
     def __repr__(self):
         return f"ObservationView[{', '.join(sorted(self.spaces.keys()))}]"

--- a/tests/llvm/observation_spaces_test.py
+++ b/tests/llvm/observation_spaces_test.py
@@ -1379,12 +1379,15 @@ def test_is_buildable_observation_space_not_buildable(env: LlvmEnv):
 
 def test_add_derived_space(env: LlvmEnv):
     env.reset()
-    env.observation.add_derived_space(
-        id="IrLen",
-        base_id="Ir",
-        space=Box(name="IrLen", low=0, high=float("inf"), shape=(1,), dtype=int),
-        translate=lambda base: [15],
-    )
+    with pytest.deprecated_call(
+        match="Use the derived_observation_spaces argument to CompilerEnv constructor."
+    ):
+        env.observation.add_derived_space(
+            id="IrLen",
+            base_id="Ir",
+            space=Box(name="IrLen", low=0, high=float("inf"), shape=(1,), dtype=int),
+            translate=lambda base: [15],
+        )
 
     value = env.observation["IrLen"]
     assert isinstance(value, list)

--- a/tests/llvm/observation_spaces_test.py
+++ b/tests/llvm/observation_spaces_test.py
@@ -7,6 +7,7 @@ import os
 import sys
 from typing import Any, Dict, List
 
+import gym
 import networkx as nx
 import numpy as np
 import pytest
@@ -1397,6 +1398,20 @@ def test_add_derived_space(env: LlvmEnv):
     value = env.observation.IrLen()
     assert isinstance(value, list)
     assert value == [15]
+
+
+def test_derived_space_constructor():
+    """Test that derived observation space can be specified at construction
+    time.
+    """
+    with gym.make("llvm-v0") as env:
+        env.observation_space = "AutophaseDict"
+        a = env.reset()
+
+    with gym.make("llvm-v0", observation_space="AutophaseDict") as env:
+        b = env.reset()
+
+    assert a == b
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This deprecates `env.observation.add_derived_space()` in favor of a `derived_observation_spaces` argument to the CompilerEnv constructor. This enabled derived spaces to be used in `gym.make(...)` invocations.

Fixes #461.
