### PR TITLE
[llvm] Add a wrapper class to use runtime as reward.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -149,7 +149,7 @@ jobs:
               run: python -m pip install -r tests/requirements.txt
 
             - name: Run the test suite
-              run: make install-test-cov PYTEST_ARGS="--ignore tests/llvm --ignore tests/gcc"
+              run: make install-test-cov PYTEST_ARGS="--ignore tests/llvm --ignore tests/gcc --ignore tests/loop_tool"
 
             - name: Upload coverage report to Codecov
               uses: codecov/codecov-action@v2

--- a/compiler_gym/envs/llvm/llvm_env.py
+++ b/compiler_gym/envs/llvm/llvm_env.py
@@ -520,9 +520,11 @@ class LlvmEnv(CompilerEnv):
 
     @runtime_observation_count.setter
     def runtime_observation_count(self, n: int) -> None:
-        self._runtimes_per_observation_count = n
         if self.in_episode:
             self.send_param("llvm.set_runtimes_per_observation_count", str(n))
+        # NOTE(cummins): Keep this after the send_param() call because
+        # send_param() will raise an error if the valid is invalid.
+        self._runtimes_per_observation_count = n
 
     @property
     def runtime_warmup_runs_count(self) -> int:
@@ -554,11 +556,13 @@ class LlvmEnv(CompilerEnv):
 
     @runtime_warmup_runs_count.setter
     def runtime_warmup_runs_count(self, n: int) -> None:
-        self._runtimes_warmup_per_observation_count = n
         if self.in_episode:
             self.send_param(
                 "llvm.set_warmup_runs_count_per_runtime_observation", str(n)
             )
+        # NOTE(cummins): Keep this after the send_param() call because
+        # send_param() will raise an error if the valid is invalid.
+        self._runtimes_warmup_per_observation_count = n
 
     def fork(self):
         fkd = super().fork()

--- a/compiler_gym/wrappers/BUILD
+++ b/compiler_gym/wrappers/BUILD
@@ -11,6 +11,7 @@ py_library(
         "commandline.py",
         "core.py",
         "datasets.py",
+        "llvm.py",
         "time_limit.py",
     ],
     visibility = ["//visibility:public"],

--- a/compiler_gym/wrappers/__init__.py
+++ b/compiler_gym/wrappers/__init__.py
@@ -19,6 +19,7 @@ from compiler_gym.wrappers.datasets import (
     IterateOverBenchmarks,
     RandomOrderBenchmarks,
 )
+from compiler_gym.wrappers.llvm import RuntimePointEstimateReward
 from compiler_gym.wrappers.time_limit import TimeLimit
 
 __all__ = [
@@ -28,6 +29,7 @@ __all__ = [
     "ConstrainedCommandline",
     "CycleOverBenchmarks",
     "IterateOverBenchmarks",
+    "RuntimePointEstimateReward",
     "ObservationWrapper",
     "RandomOrderBenchmarks",
     "RewardWrapper",

--- a/compiler_gym/wrappers/llvm.py
+++ b/compiler_gym/wrappers/llvm.py
@@ -1,0 +1,130 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Wrapper classes for the LLVM environments."""
+from typing import Callable, Iterable, List, Optional
+
+import numpy as np
+
+from compiler_gym.datasets.benchmark import BenchmarkInitError
+from compiler_gym.envs.llvm import LlvmEnv
+from compiler_gym.service.connection import ServiceError
+from compiler_gym.spaces import Reward
+from compiler_gym.util.gym_type_hints import ObservationType
+from compiler_gym.wrappers import CompilerEnvWrapper
+
+
+class RuntimePointEstimateReward(CompilerEnvWrapper):
+    """LLVM wrapper that uses a point estimate of program runtime as reward.
+
+    This class wraps an LLVM environment and registers a new runtime reward
+    space. Runtime is estimated from one or more runtime measurements, after
+    optionally running one or more warmup runs. At each step, reward is the
+    change in runtime estimate from the runtime estimate at the previous step.
+    """
+
+    class RuntimeReward(Reward):
+        def __init__(
+            self,
+            runtime_count: int,
+            warmup_count: int,
+            estimator: Callable[[Iterable[float]], float],
+        ):
+            super().__init__(
+                id="runtime",
+                observation_spaces=["Runtime"],
+                default_value=0,
+                min=None,
+                max=None,
+                default_negates_returns=True,
+                deterministic=False,
+                platform_dependent=True,
+            )
+            self.runtime_count = runtime_count
+            self.warmup_count = warmup_count
+            self.starting_runtime: Optional[float] = None
+            self.previous_runtime: Optional[float] = None
+            self.current_benchmark: Optional[str] = None
+            self.estimator = estimator
+
+        def reset(self, benchmark, observation_view) -> None:
+            # If we are changing the benchmark then check that it is runnable.
+            if benchmark != self.current_benchmark:
+                if not observation_view["IsRunnable"]:
+                    raise BenchmarkInitError(f"Benchmark is not runnable: {benchmark}")
+                self.current_benchmark = benchmark
+                self.starting_runtime = None
+
+            # Compute initial runtime if required, else use previously computed
+            # value.
+            if self.starting_runtime is None:
+                self.starting_runtime = self.estimator(observation_view["Runtime"])
+
+            self.previous_runtime = self.starting_runtime
+
+        def update(
+            self,
+            actions: List[int],
+            observations: List[ObservationType],
+            observation_view,
+        ) -> float:
+            del actions  # unused
+            del observation_view  # unused
+            runtimes = observations[0]
+            if len(runtimes) != self.runtime_count:
+                raise ServiceError(
+                    f"Expected {self.runtime_count} runtimes but received {len(runtimes)}"
+                )
+            runtime = self.estimator(runtimes)
+
+            reward = self.previous_runtime - runtime
+            self.previous_runtime = runtime
+            return reward
+
+    def __init__(
+        self,
+        env: LlvmEnv,
+        runtime_count: int = 30,
+        warmup_count: int = 0,
+        estimator: Callable[[Iterable[float]], float] = np.median,
+    ):
+        """Constructor.
+
+        :param env: The environment to wrap.
+
+        :param runtime_count: The number of times to execute the binary when
+            estimating the runtime.
+
+        :param warmup_count: The number of warmup runs of the binary to perform
+            before measuring the runtime.
+
+        :param estimator: A function that takes a list of runtime measurements
+            and produces a point estimate.
+        """
+        super().__init__(env)
+
+        self.env.unwrapped.reward.add_space(
+            self.RuntimeReward(
+                runtime_count=runtime_count,
+                warmup_count=warmup_count,
+                estimator=estimator,
+            )
+        )
+        self.env.unwrapped.reward_space = "runtime"
+
+        self.env.unwrapped.runtime_observation_count = runtime_count
+        self.env.unwrapped.runtime_warmup_runs_count = warmup_count
+
+    def fork(self) -> "RuntimePointEstimateReward":
+        fkd = self.env.fork()
+        # Remove the original "runtime" space so that we that new
+        # RuntimePointEstimateReward wrapper instance does not attempt to
+        # redefine, raising a warning.
+        del fkd.unwrapped.reward.spaces["runtime"]
+        return RuntimePointEstimateReward(
+            env=fkd,
+            runtime_count=self.reward.spaces["runtime"].runtime_count,
+            warmup_count=self.reward.spaces["runtime"].warmup_count,
+            estimator=self.reward.spaces["runtime"].estimator,
+        )

--- a/docs/source/compiler_gym/wrappers.rst
+++ b/docs/source/compiler_gym/wrappers.rst
@@ -66,3 +66,11 @@ Datasets wrappers
 .. autoclass:: RandomOrderBenchmarks
 
     .. automethod:: __init__
+
+
+LLVM Environment wrappers
+-------------------------
+
+.. autoclass:: RuntimePointEstimateReward
+
+    .. automethod:: __init__

--- a/tests/llvm/runtime_test.py
+++ b/tests/llvm/runtime_test.py
@@ -149,5 +149,47 @@ def test_invalid_runtime_count(env: LlvmEnv):
         env.runtime_observation_count = -1
 
 
+def test_runtime_observation_count_before_reset(env: LlvmEnv):
+    """Test setting property before reset() is called."""
+    env.runtime_observation_count = 10
+    assert env.runtime_observation_count == 10
+    env.reset()
+    assert env.runtime_observation_count == 10
+
+
+def test_runtime_warmup_runs_count_before_reset(env: LlvmEnv):
+    """Test setting property before reset() is called."""
+    env.runtime_warmup_runs_count = 10
+    assert env.runtime_warmup_runs_count == 10
+    env.reset()
+    assert env.runtime_warmup_runs_count == 10
+
+
+def test_runtime_observation_count_fork(env: LlvmEnv):
+    """Test that custom count properties propagate on fork()."""
+    env.runtime_observation_count = 2
+    env.runtime_warmup_runs_count = 1
+
+    with env.fork() as fkd:
+        assert fkd.runtime_observation_count == 2
+        assert fkd.runtime_warmup_runs_count == 1
+
+    env.reset()
+    with env.fork() as fkd:
+        assert fkd.runtime_observation_count == 2
+        assert fkd.runtime_warmup_runs_count == 1
+
+
+def test_default_runtime_observation_count_fork(env: LlvmEnv):
+    """Test that default property values propagate on fork()."""
+    env.reset()
+    rc = env.runtime_observation_count
+    wc = env.runtime_warmup_runs_count
+
+    with env.fork() as fkd:
+        assert fkd.runtime_observation_count == rc
+        assert fkd.runtime_warmup_runs_count == wc
+
+
 if __name__ == "__main__":
     main()

--- a/tests/wrappers/BUILD
+++ b/tests/wrappers/BUILD
@@ -38,6 +38,18 @@ py_test(
 )
 
 py_test(
+    name = "llvm_test",
+    timeout = "long",
+    srcs = ["llvm_test.py"],
+    deps = [
+        "//compiler_gym/envs/llvm",
+        "//compiler_gym/wrappers",
+        "//tests:test_main",
+        "//tests/pytest_plugins:llvm",
+    ],
+)
+
+py_test(
     name = "time_limit_wrappers_test",
     timeout = "short",
     srcs = ["time_limit_wrappers_test.py"],

--- a/tests/wrappers/llvm_test.py
+++ b/tests/wrappers/llvm_test.py
@@ -3,6 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 """Unit tests for compiler_gym.wrappers.llvm."""
+import sys
+
 import numpy as np
 import pytest
 from flaky import flaky
@@ -52,6 +54,11 @@ def test_fork(env: LlvmEnv):
         assert fkd.reward_space_spec.id == "runtime"
 
 
+@pytest.mark.xfail(
+    sys.platform == "darwin",
+    strict=True,
+    reason="github.com/facebookresearch/CompilerGym/issues/459",
+)
 @pytest.mark.parametrize("runtime_count", [1, 3, 5])
 @pytest.mark.parametrize("warmup_count", [0, 1, 3])
 @pytest.mark.parametrize("estimator", [np.median, min])

--- a/tests/wrappers/llvm_test.py
+++ b/tests/wrappers/llvm_test.py
@@ -1,0 +1,83 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Unit tests for compiler_gym.wrappers.llvm."""
+import numpy as np
+import pytest
+from flaky import flaky
+
+from compiler_gym.datasets.benchmark import BenchmarkInitError
+from compiler_gym.envs.llvm import LlvmEnv
+from compiler_gym.wrappers import RuntimePointEstimateReward
+from tests.test_main import main
+
+pytest_plugins = ["tests.pytest_plugins.llvm"]
+
+
+def test_invalid_runtime_count(env: LlvmEnv):
+    env = RuntimePointEstimateReward(env, runtime_count=-10)
+    with pytest.raises(
+        ValueError, match="runtimes_per_observation_count must be >= 1. Received: -10"
+    ):
+        env.reset()
+
+
+def test_invalid_warmup_count(env: LlvmEnv):
+    env = RuntimePointEstimateReward(env, warmup_count=-10)
+    with pytest.raises(
+        ValueError,
+        match="warmup_runs_count_per_runtime_observation must be >= 0. Received: -10",
+    ):
+        env.reset()
+
+
+def test_reward_range(env: LlvmEnv):
+    env = RuntimePointEstimateReward(env, runtime_count=3)
+    assert env.reward_range == (-float("inf"), float("inf"))
+
+
+def test_reward_range_not_runnable_benchmark(env: LlvmEnv):
+    env = RuntimePointEstimateReward(env, runtime_count=3)
+
+    with pytest.raises(
+        BenchmarkInitError, match=r"^Benchmark is not runnable: benchmark://npb-v0/1$"
+    ):
+        env.reset(benchmark="benchmark://npb-v0/1")
+
+
+def test_fork(env: LlvmEnv):
+    env = RuntimePointEstimateReward(env)
+    with env.fork() as fkd:
+        assert fkd.reward_space_spec.id == "runtime"
+
+
+@pytest.mark.parametrize("runtime_count", [1, 3, 5])
+@pytest.mark.parametrize("warmup_count", [0, 1, 3])
+@pytest.mark.parametrize("estimator", [np.median, min])
+@flaky  # Runtime can fail
+def test_reward_values(env: LlvmEnv, runtime_count, warmup_count, estimator):
+    env = RuntimePointEstimateReward(
+        env, runtime_count=runtime_count, warmup_count=warmup_count, estimator=estimator
+    )
+    env.reset()
+
+    assert env.reward_space_spec.runtime_count == runtime_count
+    assert env.reward_space_spec.warmup_count == warmup_count
+    assert env.reward_space_spec.estimator == estimator
+
+    _, reward_a, done, info = env.step(env.action_space.sample())
+    assert not done, info
+
+    _, reward_b, done, info = env.step(env.action_space.sample())
+    assert not done, info
+
+    _, reward_c, done, info = env.step(env.action_space.sample())
+    assert not done, info
+
+    assert env.episode_reward == reward_a + reward_b + reward_c
+    assert reward_a or reward_b or reward_c
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/wrappers/llvm_test.py
+++ b/tests/wrappers/llvm_test.py
@@ -17,6 +17,11 @@ from tests.test_main import main
 pytest_plugins = ["tests.pytest_plugins.llvm"]
 
 
+@pytest.mark.xfail(
+    sys.platform == "darwin",
+    strict=True,
+    reason="github.com/facebookresearch/CompilerGym/issues/459",
+)
 def test_invalid_runtime_count(env: LlvmEnv):
     env = RuntimePointEstimateReward(env, runtime_count=-10)
     with pytest.raises(
@@ -25,6 +30,11 @@ def test_invalid_runtime_count(env: LlvmEnv):
         env.reset()
 
 
+@pytest.mark.xfail(
+    sys.platform == "darwin",
+    strict=True,
+    reason="github.com/facebookresearch/CompilerGym/issues/459",
+)
 def test_invalid_warmup_count(env: LlvmEnv):
     env = RuntimePointEstimateReward(env, warmup_count=-10)
     with pytest.raises(
@@ -48,6 +58,11 @@ def test_reward_range_not_runnable_benchmark(env: LlvmEnv):
         env.reset(benchmark="benchmark://npb-v0/1")
 
 
+@pytest.mark.xfail(
+    sys.platform == "darwin",
+    strict=True,
+    reason="github.com/facebookresearch/CompilerGym/issues/459",
+)
 def test_fork(env: LlvmEnv):
     env = RuntimePointEstimateReward(env)
     with env.fork() as fkd:

--- a/tests/wrappers/time_limit_wrappers_test.py
+++ b/tests/wrappers/time_limit_wrappers_test.py
@@ -5,8 +5,6 @@
 """Unit tests for //compiler_gym/wrappers."""
 from compiler_gym.envs.llvm import LlvmEnv
 from compiler_gym.wrappers import TimeLimit
-
-# from gym.wrappers import TimeLimit
 from tests.test_main import main
 
 pytest_plugins = ["tests.pytest_plugins.llvm"]


### PR DESCRIPTION
This class wraps an LLVM environment and registers a new runtime reward space. Runtime is estimated from one or more runtime measurements, after optionally running one or more warmup runs. At each step, reward is the change in runtime estimate from the runtime estimate at the previous step.

Issue #370.