### PR TITLE
[Makefile] Run `pip uninstall` before `pip install`.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -354,7 +354,10 @@ post-install-test:
 # Installation #
 ################
 
-pip-install:
+# We run uninstall as a dependency of install to prevent conflicting
+# CompilerGym versions co-existing in the same Python environment.
+
+pip-install: uninstall
 	$(PYTHON) setup.py install
 
 install: |  init-runtime-requirements bazel-build pip-install


### PR DESCRIPTION
This is to reduce the risk of a pip-installed version of CompilerGym
from co-existing with the version installed by `make install`. This can
lead to the incorrect version being used and cryptic errors, for example
see #483.
