### PR TITLE
[llvm] Don't use fully-qualified module imports for codegen scripts.

### DIFF
--- a/compiler_gym/envs/llvm/service/passes/BUILD
+++ b/compiler_gym/envs/llvm/service/passes/BUILD
@@ -1,5 +1,8 @@
 # This package contains scripts for extracting passes from the LLVM source tree
 # and converting them to an action space for reinforcement learning.
+#
+# These scripts are used to programatically generate C++ headers and sources
+# that are then used to compiler the C++ LLVM compiler service.
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 
 genrule(

--- a/compiler_gym/envs/llvm/service/passes/config.py
+++ b/compiler_gym/envs/llvm/service/passes/config.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 """Configuration for building an action space from a list of LLVM passes."""
-from compiler_gym.envs.llvm.service.passes.common import Pass
+from common import Pass
 
 # A set of headers that must be included.
 EXTRA_LLVM_HEADERS = {

--- a/compiler_gym/envs/llvm/service/passes/extract_passes_from_llvm_source_tree.py
+++ b/compiler_gym/envs/llvm/service/passes/extract_passes_from_llvm_source_tree.py
@@ -33,8 +33,8 @@ import sys
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional, Tuple
 
-from compiler_gym.envs.llvm.service.passes.common import Pass
-from compiler_gym.envs.llvm.service.passes.config import CREATE_PASS_NAME_MAP
+from common import Pass
+from config import CREATE_PASS_NAME_MAP
 
 logger = logging.getLogger(__name__)
 

--- a/compiler_gym/envs/llvm/service/passes/filter_action_space.py
+++ b/compiler_gym/envs/llvm/service/passes/filter_action_space.py
@@ -12,8 +12,8 @@ import logging
 import sys
 from typing import Iterable
 
-from compiler_gym.envs.llvm.service.passes import config
-from compiler_gym.envs.llvm.service.passes.common import Pass
+import config
+from common import Pass
 
 logger = logging.getLogger(__name__)
 

--- a/compiler_gym/envs/llvm/service/passes/make_action_space_genfiles.py
+++ b/compiler_gym/envs/llvm/service/passes/make_action_space_genfiles.py
@@ -81,8 +81,8 @@ import logging
 import sys
 from pathlib import Path
 
-from compiler_gym.envs.llvm.service.passes.common import Pass
-from compiler_gym.envs.llvm.service.passes.config import EXTRA_LLVM_HEADERS
+from common import Pass
+from config import EXTRA_LLVM_HEADERS
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
The files compiler_gym/envs/llvm/service/passes/*.py are used to
generate files that are used during the compiler_gym build. Don't use
fully-qualified module paths to emphasize this.

Issue #488.
