### PR TITLE
[WIP] Trying to Dump IR or Line Numbers of Loops

### DIFF
--- a/examples/example_unrolling_service/loop_unroller/BUILD
+++ b/examples/example_unrolling_service/loop_unroller/BUILD
@@ -6,18 +6,33 @@
 # This package exposes the LLVM optimization pipeline as a CompilerGym service.
 load("@rules_cc//cc:defs.bzl", "cc_binary")
 
+genrule(
+    name = "libLLVMRuntimeDyld",
+    srcs = [
+        "@clang-llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04//:all_files",
+        "@clang-llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04//:clang",
+    ],
+    outs = ["libLLVMRuntimeDyld.a"],
+    cmd = "cp $$(dirname $(location @clang-llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04//:clang))/../lib/libLLVMRuntimeDyld.a $@",
+    visibility = ["//visibility:public"],
+)
+
 cc_binary(
     name = "loop_unroller",
     srcs = [
         "loop_unroller.cc",
+        #"@clang-llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04//:lib/libLLVMRuntimeDyld.a",
+        ":libLLVMRuntimeDyld",
     ],
     copts = [
         "-Wall",
         "-fdiagnostics-color=always",
         "-fno-rtti",
+        "-force_load",
     ],
     visibility = ["//visibility:public"],
     deps = [
         "@llvm//10.0.0",
+        #":libLLVMRuntimeDyld",
     ],
 )


### PR DESCRIPTION
I have been trying to print line numbers of loops, or print the IR content of loops (in order to extract loop features separately) using these statements:
```
      L->getLoopID()->dump();
      L->dump();
      L->getLocRange().getStart().dump();
      L->getLocRange().getEnd().dump();
      L->getStartLoc().getLine();
```

but they all lead to this error:
```
dyld: lazy symbol binding failed: Symbol not found: __ZNK4llvm8Metadata4dumpEv
  Referenced from: /private/var/tmp/_bazel_melhoushi/29d44ffac89bbd569101bd339ac68a0b/execroot/CompilerGym/bazel-out/darwin-fastbuild/bin/examples/example_unrolling_service/loop_unroller/loop_unroller
  Expected in: flat namespace

dyld: Symbol not found: __ZNK4llvm8Metadata4dumpEv
  Referenced from: /private/var/tmp/_bazel_melhoushi/29d44ffac89bbd569101bd339ac68a0b/execroot/CompilerGym/bazel-out/darwin-fastbuild/bin/examples/example_unrolling_service/loop_unroller/loop_unroller
  Expected in: flat namespace
```

I have tried to add `libLLVMRuntimeDyld` as a TARGET to the build system as shown in this pull request but it didn't work. Perhaps I have added it the wrong way. Can @ChrisCummins  please take a look?