### PR TITLE
[llvm] Fix invalid use of BitcodeWriter API.

### DIFF
--- a/compiler_gym/envs/llvm/service/BUILD
+++ b/compiler_gym/envs/llvm/service/BUILD
@@ -308,7 +308,7 @@ cc_binary(
 genrule(
     name = "strip-optnone-bin",
     srcs = [":strip-optnone-attribute-prelinked"],
-    outs = ["strip-optnone"],
+    outs = ["strip-optnone-attribute"],
     cmd = select({
         "@llvm//:darwin": (
             "cp $(location :strip-optnone-attribute-prelinked) $@"

--- a/compiler_gym/envs/llvm/service/Benchmark.cc
+++ b/compiler_gym/envs/llvm/service/Benchmark.cc
@@ -34,12 +34,15 @@ namespace {
 
 BenchmarkHash getModuleHash(const llvm::Module& module) {
   BenchmarkHash hash;
-  llvm::SmallVector<char, 256> buffer;
+  Bitcode bitcode;
+
   // Writing the entire bitcode to a buffer that is then discarded is
   // inefficient.
-  llvm::BitcodeWriter writer(buffer);
-  writer.writeModule(module, /*ShouldPreserveUseListOrder=*/false,
-                     /*Index=*/nullptr, /*GenerateHash=*/true, &hash);
+  llvm::raw_svector_ostream ostream(bitcode);
+  llvm::WriteBitcodeToFile(module, ostream,
+                           /*ShouldPreserveUseListOrder=*/false,
+                           /*Index=*/nullptr, /*GenerateHash=*/true, &hash);
+
   return hash;
 }
 

--- a/compiler_gym/envs/llvm/service/StripOptNoneAttribute.cc
+++ b/compiler_gym/envs/llvm/service/StripOptNoneAttribute.cc
@@ -9,8 +9,6 @@
 #include <iostream>
 
 #include "compiler_gym/envs/llvm/service/BenchmarkFactory.h"
-#include "compiler_gym/envs/llvm/service/Observation.h"
-#include "compiler_gym/envs/llvm/service/ObservationSpaces.h"
 #include "compiler_gym/service/proto/compiler_gym_service.pb.h"
 #include "compiler_gym/util/GrpcStatusMacros.h"
 #include "llvm/IR/Module.h"


### PR DESCRIPTION
Use the `WriteBitcodeToFile()` function rather than `BitcodeWriter::writeMethod()` method to prevent a debugging assertion. Thanks @sogartar for reporting this.

Fixes #514.