### PR TITLE
[datasets] Make the `site_data_base` path optional.

### DIFF
--- a/compiler_gym/envs/loop_tool/__init__.py
+++ b/compiler_gym/envs/loop_tool/__init__.py
@@ -9,7 +9,7 @@ from typing import Iterable
 from compiler_gym.datasets import Benchmark, Dataset, benchmark
 from compiler_gym.spaces import Reward
 from compiler_gym.util.registration import register
-from compiler_gym.util.runfiles_path import runfiles_path, site_data_path
+from compiler_gym.util.runfiles_path import runfiles_path
 
 LOOP_TOOL_SERVICE_BINARY: Path = runfiles_path(
     "compiler_gym/envs/loop_tool/service/compiler_gym-loop_tool-service"
@@ -56,7 +56,6 @@ class LoopToolCUDADataset(Dataset):
             name="benchmark://loop_tool-cuda-v0",
             license="MIT",
             description="loop_tool dataset",
-            site_data_base=site_data_path("loop_tool_dataset"),
         )
 
     def benchmark_uris(self) -> Iterable[str]:
@@ -72,7 +71,6 @@ class LoopToolCPUDataset(Dataset):
             name="benchmark://loop_tool-cpu-v0",
             license="MIT",
             description="loop_tool dataset",
-            site_data_base=site_data_path("loop_tool_dataset"),
         )
 
     def benchmark_uris(self) -> Iterable[str]:

--- a/examples/example_compiler_gym_service/__init__.py
+++ b/examples/example_compiler_gym_service/__init__.py
@@ -9,7 +9,7 @@ from typing import Iterable
 from compiler_gym.datasets import Benchmark, Dataset
 from compiler_gym.spaces import Reward
 from compiler_gym.util.registration import register
-from compiler_gym.util.runfiles_path import runfiles_path, site_data_path
+from compiler_gym.util.runfiles_path import runfiles_path
 
 EXAMPLE_CC_SERVICE_BINARY: Path = runfiles_path(
     "examples/example_compiler_gym_service/service_cc/compiler_gym-example-service-cc"
@@ -58,7 +58,6 @@ class ExampleDataset(Dataset):
             name="benchmark://example-v0",
             license="MIT",
             description="An example dataset",
-            site_data_base=site_data_path("example_dataset"),
         )
         self._benchmarks = {
             "benchmark://example-v0/foo": Benchmark.from_file_contents(

--- a/examples/example_compiler_gym_service/demo_without_bazel.py
+++ b/examples/example_compiler_gym_service/demo_without_bazel.py
@@ -19,7 +19,6 @@ from compiler_gym.datasets import Benchmark, Dataset
 from compiler_gym.spaces import Reward
 from compiler_gym.util.logging import init_logging
 from compiler_gym.util.registration import register
-from compiler_gym.util.runfiles_path import site_data_path
 
 EXAMPLE_PY_SERVICE_BINARY: Path = Path(
     "example_compiler_gym_service/service_py/example_service.py"
@@ -65,7 +64,6 @@ class ExampleDataset(Dataset):
             name="benchmark://example-v0",
             license="MIT",
             description="An example dataset",
-            site_data_base=site_data_path("example_dataset"),
         )
         self._benchmarks = {
             "benchmark://example-v0/foo": Benchmark.from_file_contents(

--- a/tests/datasets/dataset_test.py
+++ b/tests/datasets/dataset_test.py
@@ -243,5 +243,30 @@ def test_logger_is_deprecated():
         dataset.logger
 
 
+def test_with_site_data():
+    """Test the dataset property values."""
+    dataset = Dataset(
+        name="benchmark://test-v0",
+        description="A test dataset",
+        license="MIT",
+        site_data_base="test",
+    )
+    assert dataset.has_site_data
+
+
+def test_without_site_data():
+    """Test the dataset property values."""
+    dataset = Dataset(
+        name="benchmark://test-v0",
+        description="A test dataset",
+        license="MIT",
+    )
+    assert not dataset.has_site_data
+    with pytest.raises(
+        ValueError, match=r"^Dataset has no site data path: benchmark://test-v0$"
+    ):
+        dataset.site_data_path  # noqa
+
+
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This allows datasets to be specified without needing to pass a `site_data_base` argument. The purpose of `site_data_base` to provide an on-disk cache for persistent files, but not all datasets need such a cache.
