### PR TITLE
Restrict setuptools version

### DIFF
--- a/.github/actions/install-build-dependencies/action.yaml
+++ b/.github/actions/install-build-dependencies/action.yaml
@@ -15,7 +15,7 @@ runs:
                   sudo apt-get install -y clang-9 patchelf
               fi
               python -m pip install -U pip wheel
-              python -m pip install -r compiler_gym/requirements.txt
+              python -m pip install -r compiler_gym/requirements_build.txt
           shell: bash
           env:
               LDFLAGS: -L/usr/local/opt/zlib/lib

--- a/.github/workflows/pre_commit.yaml
+++ b/.github/workflows/pre_commit.yaml
@@ -51,7 +51,6 @@ jobs:
 
             - name: Install Python dependencies
               run: |
-                  sudo apt-get install python3-setuptools
                   python3 -m pip install --upgrade wheel
                   python3 -m pip install -r requirements_pre_commit.txt
                   python3 -m isort --version

--- a/compiler_gym/requirements.txt
+++ b/compiler_gym/requirements.txt
@@ -3,7 +3,6 @@ deprecated>=1.2.12
 docker>=4.0.0
 fasteners>=0.15
 grpcio>=1.32.0
-grpcio_tools>=1.32.0
 gym>=0.18.0,<0.21
 humanize>=2.6.0
 loop_tool_py==0.0.7

--- a/compiler_gym/requirements_build.txt
+++ b/compiler_gym/requirements_build.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+grpcio_tools>=1.32.0
+setuptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+-r compiler_gym/requirements_build.txt
 -r compiler_gym/requirements.txt
 -r docs/requirements.txt
 -r examples/requirements.txt

--- a/requirements_pre_commit.txt
+++ b/requirements_pre_commit.txt
@@ -2,3 +2,4 @@ black==19.10b0
 flake8==3.9.2
 isort==4.3.21
 pre-commit>=2.12.1
+setuptools

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -9,3 +9,4 @@ pytest-stress==1.0.1
 pytest-sugar==0.9.4
 pytest-timeout==1.4.2
 pytest-xdist==2.4.0
+setuptools<59 # v59 causes pkg_resources.require in test_setuptools_version to fail


### PR DESCRIPTION
Fixes failing `test_setuptools_version` where `pkg_resources.require(...)` raises an exception with `setuptools` v59.

[log-build-2021-12-15T01-06-01Z-failed-tests.txt](https://github.com/facebookresearch/CompilerGym/files/7730424/log-build-2021-12-15T01-06-01Z-failed-tests.txt)

I don't know what is the reason for the failure. I don't see a misuse of setuptools's API.