### PR TITLE
Add a new benchmark URI parser and support for all 20 datasets to cBench

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -278,10 +278,10 @@ doxygen-rst:
 	cd docs && $(PYTHON) generate_cc_rst.py
 
 docs: gendocs bazel-build doxygen
-	PYTHONPATH=$(ROOT)/bazel-bin/package.runfiles/CompilerGym sphinx-build -M html docs/source docs/build $(SPHINXOPTS)
+	cd docs/source && PYTHONPATH=$(ROOT)/bazel-bin/package.runfiles/CompilerGym sphinx-build -M html . ../build $(SPHINXOPTS)
 
 livedocs: gendocs doxygen
-	PYTHONPATH=$(ROOT)/bazel-bin/package.runfiles/CompilerGym sphinx-autobuild docs/source docs/build $(SPHINXOPTS) --pre-build 'make gendocs bazel-build doxygen' --watch compiler_gym
+	cd docs/source && PYTHONPATH=$(ROOT)/bazel-bin/package.runfiles/CompilerGym sphinx-autobuild . ../build $(SPHINXOPTS) --pre-build 'make -C ../.. gendocs bazel-build doxygen' --watch ../../compiler_gym
 
 
 .PHONY: doxygen doxygen-rst

--- a/compiler_gym/bin/manual_env.py
+++ b/compiler_gym/bin/manual_env.py
@@ -329,9 +329,12 @@ The 'tutorial' command will give a step by step guide."""
 
     def set_prompt(self):
         """Set the prompt - shows the benchmark name"""
-        benchmark_name = self.env.benchmark.uri
-        if benchmark_name.startswith("benchmark://"):
-            benchmark_name = benchmark_name[len("benchmark://") :]
+        uri = self.env.benchmark.uri
+        benchmark_name = (
+            f"{uri.dataset}{uri.path}"
+            if uri.scheme == "benchmark"
+            else f"{uri.scheme}://{uri.dataset}{uri.path}"
+        )
         prompt = f"compiler_gym:{benchmark_name}>"
         self.prompt = f"\n{emph(prompt)} "
 

--- a/compiler_gym/bin/manual_env.py
+++ b/compiler_gym/bin/manual_env.py
@@ -291,7 +291,7 @@ The 'tutorial' command will give a step by step guide."""
             self.benchmarks += islice(dataset.benchmark_uris(), 50)
         self.benchmarks.sort()
 
-        # Strip default benchmark:// protocol.
+        # Strip default benchmark:// scheme.
         for i, benchmark in enumerate(self.benchmarks):
             if benchmark.startswith("benchmark://"):
                 self.benchmarks[i] = benchmark[len("benchmark://") :]

--- a/compiler_gym/compiler_env_state.py
+++ b/compiler_gym/compiler_env_state.py
@@ -9,6 +9,7 @@ from typing import Iterable, List, Optional, TextIO
 
 from pydantic import BaseModel, Field, validator
 
+from compiler_gym.datasets.uri import BenchmarkUri
 from compiler_gym.util.truncate import truncate
 
 
@@ -47,6 +48,12 @@ class CompilerEnvState(BaseModel):
         if v is not None:
             assert v >= 0, "Walltime cannot be negative"
         return v
+
+    @validator("benchmark", pre=True)
+    def validate_benchmark(cls, value):
+        if isinstance(value, BenchmarkUri):
+            return str(value)
+        return value
 
     @property
     def has_reward(self) -> bool:

--- a/compiler_gym/compiler_env_state.py
+++ b/compiler_gym/compiler_env_state.py
@@ -9,7 +9,6 @@ from typing import Iterable, List, Optional, TextIO
 
 from pydantic import BaseModel, Field, validator
 
-from compiler_gym.datasets.uri import BENCHMARK_URI_PATTERN
 from compiler_gym.util.truncate import truncate
 
 
@@ -23,7 +22,6 @@ class CompilerEnvState(BaseModel):
 
     benchmark: str = Field(
         allow_mutation=False,
-        regex=BENCHMARK_URI_PATTERN,
         examples=[
             "benchmark://cbench-v1/crc32",
             "generator://csmith-v0/0",

--- a/compiler_gym/datasets/__init__.py
+++ b/compiler_gym/datasets/__init__.py
@@ -19,12 +19,14 @@ from compiler_gym.datasets.dataset import (
 from compiler_gym.datasets.datasets import Datasets
 from compiler_gym.datasets.files_dataset import FilesDataset
 from compiler_gym.datasets.tar_dataset import TarDataset, TarDatasetWithManifest
+from compiler_gym.datasets.uri import BenchmarkUri
 
 __all__ = [
     "activate",
     "Benchmark",
     "BenchmarkInitError",
     "BenchmarkSource",
+    "BenchmarkUri",
     "Dataset",
     "DatasetInitError",
     "Datasets",

--- a/compiler_gym/datasets/benchmark.py
+++ b/compiler_gym/datasets/benchmark.py
@@ -103,7 +103,7 @@ class Benchmark:
         return hash(self.uri)
 
     @property
-    def uri(self) -> str:
+    def uri(self) -> BenchmarkUri:
         """The URI of the benchmark.
 
         Benchmark URIs should be unique, that is, that two URIs with the same
@@ -113,7 +113,7 @@ class Benchmark:
 
         :return: A URI string. :type: string
         """
-        return self._proto.uri
+        return BenchmarkUri.from_string(self._proto.uri)
 
     @property
     def proto(self) -> BenchmarkProto:

--- a/compiler_gym/datasets/benchmark.py
+++ b/compiler_gym/datasets/benchmark.py
@@ -6,6 +6,7 @@ from concurrent.futures import as_completed
 from pathlib import Path
 from typing import Callable, Iterable, List, NamedTuple, Optional, Union
 
+from compiler_gym.datasets.uri import BenchmarkUri
 from compiler_gym.service.proto import Benchmark as BenchmarkProto
 from compiler_gym.service.proto import File
 from compiler_gym.util import thread_pool
@@ -263,7 +264,7 @@ class Benchmark:
         return len(uniq_paths)
 
     @classmethod
-    def from_file(cls, uri: str, path: Path):
+    def from_file(cls, uri: Union[str, BenchmarkUri], path: Path):
         """Construct a benchmark from a file.
 
         :param uri: The URI of the benchmark.
@@ -284,10 +285,10 @@ class Benchmark:
         # don't share a filesystem.
         with open(path, "rb") as f:
             contents = f.read()
-        return cls(proto=BenchmarkProto(uri=uri, program=File(contents=contents)))
+        return cls(proto=BenchmarkProto(uri=str(uri), program=File(contents=contents)))
 
     @classmethod
-    def from_file_contents(cls, uri: str, data: bytes):
+    def from_file_contents(cls, uri: Union[str, BenchmarkUri], data: bytes):
         """Construct a benchmark from raw data.
 
         :param uri: The URI of the benchmark.
@@ -295,7 +296,7 @@ class Benchmark:
         :param data: An array of bytes that will be passed to the compiler
             service.
         """
-        return cls(proto=BenchmarkProto(uri=uri, program=File(contents=data)))
+        return cls(proto=BenchmarkProto(uri=str(uri), program=File(contents=data)))
 
     def __eq__(self, other: Union[str, "Benchmark"]):
         if isinstance(other, Benchmark):

--- a/compiler_gym/datasets/dataset.py
+++ b/compiler_gym/datasets/dataset.py
@@ -10,7 +10,9 @@ from pathlib import Path
 from typing import Dict, Iterable, Optional, Union
 
 import numpy as np
-from deprecated.sphinx import deprecated
+
+# The "deprecated" name is used as a constructor argument to Dataset, so rename
+# this import to prevent shadowing.
 from deprecated.sphinx import deprecated as mark_deprecated
 
 from compiler_gym.datasets.benchmark import Benchmark
@@ -127,7 +129,7 @@ class Dataset:
         return self.name
 
     @property
-    @deprecated(
+    @mark_deprecated(
         version="0.2.1",
         reason=(
             "The `Dataset.logger` attribute is deprecated. All Dataset "

--- a/compiler_gym/datasets/dataset.py
+++ b/compiler_gym/datasets/dataset.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 import logging
 import os
+import re
 import shutil
 import warnings
 from pathlib import Path
@@ -16,7 +17,7 @@ import numpy as np
 from deprecated.sphinx import deprecated as mark_deprecated
 
 from compiler_gym.datasets.benchmark import Benchmark
-from compiler_gym.datasets.uri import DATASET_NAME_RE
+from compiler_gym.datasets.uri import BenchmarkUri
 
 logger = logging.getLogger(__name__)
 
@@ -24,6 +25,9 @@ logger = logging.getLogger(__name__)
 # deprecated Dataset.logger attribute. This can be removed once the logger
 # attribute is removed, scheduled for release 0.2.3.
 _logger = logger
+
+_DATASET_VERSION_PATTERN = r"[a-zA-z0-9-_]+-v(?P<version>[0-9]+)"
+_DATASET_VERSION_RE = re.compile(_DATASET_VERSION_PATTERN)
 
 
 class Dataset:
@@ -56,8 +60,8 @@ class Dataset:
     ):
         """Constructor.
 
-        :param name: The name of the dataset. Must conform to the pattern
-            :code:`{{protocol}}://{{name}}-v{{version}}`.
+        :param name: The name of the dataset, in the format:
+            :code:`scheme://name`.
 
         :param description: A short human-readable description of the dataset.
 
@@ -101,16 +105,15 @@ class Dataset:
         :raises ValueError: If :code:`name` does not match the expected type.
         """
         self._name = name
-        components = DATASET_NAME_RE.match(name)
-        if not components:
-            raise ValueError(
-                f"Invalid dataset name: '{name}'. "
-                "Dataset name must be in the form: '{{protocol}}://{{name}}-v{{version}}'"
-            )
+
+        uri = BenchmarkUri.from_string(name)
+
         self._description = description
         self._license = license
-        self._protocol = components.group("dataset_protocol")
-        self._version = int(components.group("dataset_version"))
+        self._scheme = uri.scheme
+
+        match = _DATASET_VERSION_RE.match(uri.dataset)
+        self._version = int(match.group("version") if match else 0)
         self._references = references or {}
         self._deprecation_message = deprecated
         self._validatable = validatable
@@ -120,9 +123,8 @@ class Dataset:
 
         # Set up the site data name.
         if site_data_base:
-            basename = components.group("dataset_name")
             self._site_data_path = (
-                Path(site_data_base).resolve() / self.protocol / basename
+                Path(site_data_base).resolve() / uri.scheme / uri.dataset
             )
 
     def __repr__(self):
@@ -168,16 +170,27 @@ class Dataset:
         return self._license
 
     @property
+    @mark_deprecated(
+        version="0.2.2", reason="The `protocol` attribute has been renamed `scheme`"
+    )
     def protocol(self) -> str:
-        """The URI protocol that is used to identify benchmarks in this dataset.
+        """The URI scheme that is used to identify benchmarks in this dataset.
 
         :type: str
         """
-        return self._protocol
+        return self.scheme
+
+    @property
+    def scheme(self) -> str:
+        """The URI scheme that is used to identify benchmarks in this dataset.
+
+        :type: str
+        """
+        return self._scheme
 
     @property
     def version(self) -> int:
-        """The version tag for this dataset.
+        """The version tag for this dataset. Defaults to zero.
 
         :type: int
         """
@@ -395,6 +408,24 @@ class Dataset:
         """
         raise NotImplementedError("abstract class")
 
+    def benchmark_from_parsed_uri(self, uri: BenchmarkUri) -> Benchmark:
+        """Select a benchmark.
+
+        Subclasses must implement this method. Implementors may assume that the
+        URI is well formed and that the :code:`scheme` and :code:`dataset`
+        components are correct.
+
+        :param uri: The parsed URI of the benchmark to return.
+
+        :return: A :class:`Benchmark <compiler_gym.datasets.Benchmark>`
+            instance.
+
+        :raise LookupError: If :code:`uri` is not found.
+
+        :raise ValueError: If the URI is invalid.
+        """
+        raise NotImplementedError("abstract class")
+
     def benchmark(self, uri: str) -> Benchmark:
         """Select a benchmark.
 
@@ -404,8 +435,10 @@ class Dataset:
             instance.
 
         :raise LookupError: If :code:`uri` is not found.
+
+        :raise ValueError: If the URI is invalid.
         """
-        raise NotImplementedError("abstract class")
+        return self.benchmark_from_parsed_uri(BenchmarkUri.from_string(uri))
 
     def random_benchmark(
         self, random_state: Optional[np.random.Generator] = None

--- a/compiler_gym/datasets/datasets.py
+++ b/compiler_gym/datasets/datasets.py
@@ -9,7 +9,7 @@ import numpy as np
 
 from compiler_gym.datasets.benchmark import Benchmark
 from compiler_gym.datasets.dataset import Dataset
-from compiler_gym.datasets.uri import BENCHMARK_URI_RE, BenchmarkUri
+from compiler_gym.datasets.uri import BenchmarkUri
 
 T = TypeVar("T")
 
@@ -131,13 +131,33 @@ class Datasets:
 
         :raises LookupError: If :code:`dataset` is not found.
         """
-        uri = BenchmarkUri.from_string(dataset)
-        key = f"{uri.scheme}://{uri.dataset}"
+        return self.dataset_from_parsed_uri(BenchmarkUri.from_string(dataset))
+
+    def dataset_from_parsed_uri(self, uri: BenchmarkUri) -> Dataset:
+        """Get a dataset.
+
+        Return the corresponding :meth:`Dataset
+        <compiler_gym.datasets.Dataset>`. Name lookup will succeed whether or
+        not the dataset is deprecated.
+
+        :param uri: A parsed URI.
+
+        :return: A :meth:`Dataset <compiler_gym.datasets.Dataset>` instance.
+
+        :raises LookupError: If :code:`dataset` is not found.
+        """
+        key = self._dataset_key_from_uri(uri)
 
         if key not in self._datasets:
             raise LookupError(f"Dataset not found: {key}")
 
         return self._datasets[key]
+
+    @staticmethod
+    def _dataset_key_from_uri(uri: BenchmarkUri) -> str:
+        if not (uri.scheme and uri.dataset):
+            raise ValueError(f"Invalid benchmark URI: '{uri}'")
+        return f"{uri.scheme}://{uri.dataset}"
 
     def __getitem__(self, dataset: str) -> Dataset:
         """Lookup a dataset.
@@ -156,11 +176,11 @@ class Datasets:
         :param key: The name of the dataset.
         :param dataset: The dataset to add.
         """
-        dataset_name = BenchmarkUri.canonicalize(key)
+        key = self._dataset_key_from_uri(BenchmarkUri.from_string(key))
 
-        self._datasets[dataset_name] = dataset
+        self._datasets[key] = dataset
         if not dataset.deprecated:
-            self._visible_datasets.add(dataset_name)
+            self._visible_datasets.add(key)
 
     def __delitem__(self, dataset: str):
         """Remove a dataset from the collection.
@@ -174,10 +194,11 @@ class Datasets:
         :return: :code:`True` if the dataset was removed, :code:`False` if it
             was already removed.
         """
-        dataset_name = BenchmarkUri.canonicalize(dataset)
-        if dataset_name in self._visible_datasets:
-            self._visible_datasets.remove(dataset_name)
-        del self._datasets[dataset_name]
+        key = self._dataset_key_from_uri(BenchmarkUri.from_string(dataset))
+
+        if key in self._visible_datasets:
+            self._visible_datasets.remove(key)
+        del self._datasets[key]
 
     def __contains__(self, dataset: str) -> bool:
         """Returns whether the dataset is contained."""
@@ -243,16 +264,22 @@ class Datasets:
         :return: A :class:`Benchmark <compiler_gym.datasets.Benchmark>`
             instance.
         """
-        uri = BenchmarkUri.canonicalize(uri)
+        return self.benchmark_from_parsed_uri(BenchmarkUri.from_string(uri))
 
-        match = BENCHMARK_URI_RE.match(uri)
-        if not match:
-            raise ValueError(f"Invalid benchmark URI: '{uri}'")
+    def benchmark_from_parsed_uri(self, uri: BenchmarkUri) -> Benchmark:
+        """Select a benchmark.
 
-        dataset_name = match.group("dataset")
-        dataset = self._datasets[dataset_name]
+        Returns the corresponding :class:`Benchmark
+        <compiler_gym.datasets.Benchmark>`, regardless of whether the containing
+        dataset is installed or deprecated.
 
-        return dataset.benchmark(uri)
+        :param uri: The parsed URI of the benchmark to return.
+
+        :return: A :class:`Benchmark <compiler_gym.datasets.Benchmark>`
+            instance.
+        """
+        dataset = self.dataset_from_parsed_uri(uri)
+        return dataset.benchmark_from_parsed_uri(uri)
 
     def random_benchmark(
         self,

--- a/compiler_gym/datasets/datasets.py
+++ b/compiler_gym/datasets/datasets.py
@@ -9,7 +9,7 @@ import numpy as np
 
 from compiler_gym.datasets.benchmark import Benchmark
 from compiler_gym.datasets.dataset import Dataset
-from compiler_gym.datasets.uri import BENCHMARK_URI_RE, resolve_uri_protocol
+from compiler_gym.datasets.uri import BENCHMARK_URI_RE, BenchmarkUri
 
 T = TypeVar("T")
 
@@ -131,12 +131,13 @@ class Datasets:
 
         :raises LookupError: If :code:`dataset` is not found.
         """
-        dataset_name = resolve_uri_protocol(dataset)
+        uri = BenchmarkUri.from_string(dataset)
+        key = f"{uri.scheme}://{uri.dataset}"
 
-        if dataset_name not in self._datasets:
-            raise LookupError(f"Dataset not found: {dataset_name}")
+        if key not in self._datasets:
+            raise LookupError(f"Dataset not found: {key}")
 
-        return self._datasets[dataset_name]
+        return self._datasets[key]
 
     def __getitem__(self, dataset: str) -> Dataset:
         """Lookup a dataset.
@@ -155,7 +156,7 @@ class Datasets:
         :param key: The name of the dataset.
         :param dataset: The dataset to add.
         """
-        dataset_name = resolve_uri_protocol(key)
+        dataset_name = BenchmarkUri.canonicalize(key)
 
         self._datasets[dataset_name] = dataset
         if not dataset.deprecated:
@@ -173,7 +174,7 @@ class Datasets:
         :return: :code:`True` if the dataset was removed, :code:`False` if it
             was already removed.
         """
-        dataset_name = resolve_uri_protocol(dataset)
+        dataset_name = BenchmarkUri.canonicalize(dataset)
         if dataset_name in self._visible_datasets:
             self._visible_datasets.remove(dataset_name)
         del self._datasets[dataset_name]
@@ -242,7 +243,7 @@ class Datasets:
         :return: A :class:`Benchmark <compiler_gym.datasets.Benchmark>`
             instance.
         """
-        uri = resolve_uri_protocol(uri)
+        uri = BenchmarkUri.canonicalize(uri)
 
         match = BENCHMARK_URI_RE.match(uri)
         if not match:

--- a/compiler_gym/datasets/uri.py
+++ b/compiler_gym/datasets/uri.py
@@ -5,6 +5,8 @@
 """This module contains utility code for working with URIs."""
 import re
 
+from deprecated.sphinx import deprecated
+
 # Regular expression that matches the full two-part URI prefix of a dataset:
 #     {{protocol}}://{{dataset}}
 #
@@ -22,6 +24,10 @@ BENCHMARK_URI_PATTERN = r"(?P<dataset>(?P<dataset_protocol>[a-zA-z0-9-_]+)://(?P
 BENCHMARK_URI_RE = re.compile(BENCHMARK_URI_PATTERN)
 
 
+@deprecated(
+    version="0.2.2",
+    reason=("Use the new compiler_gym.datasets.BenchmarkUri class to parse URIs"),
+)
 def resolve_uri_protocol(uri: str) -> str:
     """Require that the URI has a protocol by applying a default "benchmark"
     protocol if none is set."""

--- a/compiler_gym/datasets/uri.py
+++ b/compiler_gym/datasets/uri.py
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 """This module contains utility code for working with URIs."""
 import re
-from typing import Dict, List
+from typing import Dict, List, Union
 from urllib.parse import ParseResult, parse_qs, urlencode, urlparse, urlunparse
 
 from deprecated.sphinx import deprecated
@@ -141,3 +141,12 @@ class BenchmarkUri(BaseModel):
 
     def __str__(self) -> str:
         return repr(self)
+
+    def __hash__(self) -> int:
+        return hash(str(self))
+
+    def __eq__(self, other: Union["BenchmarkUri", str]) -> bool:
+        return str(self) == str(other)
+
+    def __lt__(self, other: Union["BenchmarkUri", str]) -> bool:
+        return str(self) < str(other)

--- a/compiler_gym/datasets/uri.py
+++ b/compiler_gym/datasets/uri.py
@@ -48,11 +48,14 @@ def resolve_uri_protocol(uri: str) -> str:
 
 
 class BenchmarkUri(BaseModel):
-    """A URI string used to look up a benchmark.
+    """A URI used to identify a benchmark, and optionally a set of parameters
+    for the benchmark.
 
-    A benchmark URI has the following format:
+    A URI has the following format:
 
-    :code:`scheme://dataset/path?params#fragment`
+    .. code-block::
+
+        scheme://dataset/path?params#fragment
 
     where:
 
@@ -81,11 +84,11 @@ class BenchmarkUri(BaseModel):
 
     A benchmark URI may resolve to zero or more benchmarks, for example:
 
-    * :code:`csmith-v0` resolves to any benchmark from the
+    * :code:`benchmark://csmith-v0` resolves to any benchmark from the
       :code:`benchmark://csmith-v0` dataset.
 
-    * :code:`benchmark://cbench-v0/qsort` resolves to the path :code:`/qsort`
-      within the dataset :code:`benchmark://cbench-v0`.
+    * :code:`cbench-v0/qsort` resolves to the path :code:`/qsort`
+      within the dataset :code:`benchmark://cbench-v0` using the default scheme.
 
     * :code:`benchmark://cbench-v0/qsort?debug=true` also resolves to the path
       :code:`/qsort` within the dataset :code:`benchmark://cbench-v0`, but with

--- a/compiler_gym/datasets/uri.py
+++ b/compiler_gym/datasets/uri.py
@@ -4,11 +4,20 @@
 # LICENSE file in the root directory of this source tree.
 """This module contains utility code for working with URIs."""
 import re
+from typing import Dict, List
+from urllib.parse import ParseResult, parse_qs, urlencode, urlparse, urlunparse
 
 from deprecated.sphinx import deprecated
+from pydantic import BaseModel
+
+# === BEGIN DEPRECATED DECLARATIONS ===
+#
+# The following regular expression definitions have been deprecated and will be
+# removed in a future release! Please update your code to use the new
+# BenchmarkUri class defined in this file.
 
 # Regular expression that matches the full two-part URI prefix of a dataset:
-#     {{protocol}}://{{dataset}}
+#     {{scheme}}://{{dataset}}
 #
 # An optional trailing slash is permitted.
 #
@@ -17,20 +26,118 @@ DATASET_NAME_PATTERN = r"(?P<dataset>(?P<dataset_protocol>[a-zA-z0-9-_]+)://(?P<
 DATASET_NAME_RE = re.compile(DATASET_NAME_PATTERN)
 
 # Regular expression that matches the full three-part format of a benchmark URI:
-#     {{protocol}}://{{dataset}}/{{id}}
+#     {{sceme}}://{{dataset}}/{{id}}
 #
 # Example matches: "benchmark://foo-v0/foo" or "generator://bar-v1/foo/bar.txt".
 BENCHMARK_URI_PATTERN = r"(?P<dataset>(?P<dataset_protocol>[a-zA-z0-9-_]+)://(?P<dataset_name>[a-zA-z0-9-_]+-v(?P<dataset_version>[0-9]+)))/(?P<benchmark_name>.+)$"
 BENCHMARK_URI_RE = re.compile(BENCHMARK_URI_PATTERN)
 
+# === END DEPRECATED DECLARATIONS ===
+
 
 @deprecated(
     version="0.2.2",
-    reason=("Use the new compiler_gym.datasets.BenchmarkUri class to parse URIs"),
+    reason=("Use compiler_gym.datasets.BenchmarkUri.canonicalize()"),
 )
 def resolve_uri_protocol(uri: str) -> str:
-    """Require that the URI has a protocol by applying a default "benchmark"
-    protocol if none is set."""
+    """Require that the URI has a scheme by applying a default "benchmark"
+    scheme if none is set."""
     if "://" not in uri:
         return f"benchmark://{uri}"
     return uri
+
+
+class BenchmarkUri(BaseModel):
+    """A URI string used to look up a benchmark.
+
+    A benchmark URI has the following format:
+
+    :code:`scheme://dataset/path?params#fragment`
+
+    where:
+
+    * :code:`scheme` (optional, default :code:`benchmark`): An arbitrary string
+      used to group datasets, for example :code:`generator` if the dataset is a
+      benchmark generator.
+
+    * :code:`dataset`: The name of a dataset, optionally with a version tag, for
+      example :code:`linux-v0`.
+
+    * :code:`path` (optional, default empty string): The path of a benchmark
+      within a dataset.
+
+    * :code:`params` (optional, default empty dictionary): A set of query
+      parameters for the benchmark. This is parsed a dictionary of string keys
+      to a list of string values. For example :code:`dataset=1&debug=true` which
+      will be parsed as :code:`{"dataset": ["1"], "debug": ["true"]}`.
+
+    * :code:`fragment` (optional, default empty string): An optional fragment
+      within the benchmark.
+
+    The :code:`scheme` and :code:`dataset` components are used to resolve a
+    :class:`Dataset <compiler_gym.datasets.Dataset>` class that can serve the
+    benchmark. The :meth:`Dataset.benchmark_from_parsed_uri()` method is then
+    used to interpret the remainder of the URI components.
+
+    A benchmark URI may resolve to zero or more benchmarks, for example:
+
+    * :code:`csmith-v0` resolves to any benchmark from the
+      :code:`benchmark://csmith-v0` dataset.
+
+    * :code:`benchmark://cbench-v0/qsort` resolves to the path :code:`/qsort`
+      within the dataset :code:`benchmark://cbench-v0`.
+
+    * :code:`benchmark://cbench-v0/qsort?debug=true` also resolves to the path
+      :code:`/qsort` within the dataset :code:`benchmark://cbench-v0`, but with
+      an additional parameter :code:`debug=true`.
+    """
+
+    scheme: str
+    """The benchmark scheme. Defaults to :code:`benchmark`."""
+
+    dataset: str
+    """The name of the dataset."""
+
+    path: str
+    """The path of the benchmark. Empty string if not set."""
+
+    params: Dict[str, List[str]] = {}
+    """A dictionary of query parameters. Empty dictionary if not set."""
+
+    fragment: str = ""
+    """The URL fragment. Empty string if not set."""
+
+    @staticmethod
+    def canonicalize(uri: str):
+        return str(BenchmarkUri.from_string(uri))
+
+    @classmethod
+    def from_string(cls, uri: str) -> "BenchmarkUri":
+        components = urlparse(uri)
+
+        # Add the default "benchmark://" scheme if required.
+        if not components.scheme and not components.netloc:
+            components = urlparse(f"benchmark://{uri}")
+
+        return cls(
+            scheme=components.scheme,
+            dataset=components.netloc,
+            path=components.path,
+            params=parse_qs(components.query),
+            fragment=components.fragment,
+        )
+
+    def __repr__(self):
+        return urlunparse(
+            ParseResult(
+                scheme=self.scheme,
+                netloc=self.dataset,
+                path=self.path,
+                query=urlencode(self.params, doseq=True),
+                fragment=self.fragment,
+                params="",  # Field not used.
+            )
+        )
+
+    def __str__(self) -> str:
+        return repr(self)

--- a/compiler_gym/envs/compiler_env.py
+++ b/compiler_gym/envs/compiler_env.py
@@ -28,6 +28,7 @@ from compiler_gym.service import (
     ServiceTransportError,
     SessionNotFound,
 )
+from compiler_gym.service.connection import ServiceIsClosed
 from compiler_gym.service.proto import Action, AddBenchmarkRequest
 from compiler_gym.service.proto import Benchmark as BenchmarkProto
 from compiler_gym.service.proto import (
@@ -686,6 +687,10 @@ class CompilerEnv(gym.Env):
                 # not kill it.
                 if reply.remaining_sessions:
                     close_service = False
+            except ServiceIsClosed:
+                # This error can be safely ignored as it means that the service
+                # is already offline.
+                pass
             except Exception as e:
                 logger.warning(
                     "Failed to end active compiler session on close(): %s (%s)",

--- a/compiler_gym/envs/compiler_env.py
+++ b/compiler_gym/envs/compiler_env.py
@@ -811,7 +811,7 @@ class CompilerEnv(gym.Env):
         if self.service.opts.always_send_benchmark_on_reset:
             self._benchmark_in_use_proto = self._benchmark_in_use.proto
         else:
-            self._benchmark_in_use_proto.uri = self._benchmark_in_use.uri
+            self._benchmark_in_use_proto.uri = str(self._benchmark_in_use.uri)
 
         start_session_request = StartSessionRequest(
             benchmark=self._benchmark_in_use_proto,

--- a/compiler_gym/envs/compiler_env.py
+++ b/compiler_gym/envs/compiler_env.py
@@ -20,6 +20,7 @@ from gym.spaces import Space
 
 from compiler_gym.compiler_env_state import CompilerEnvState
 from compiler_gym.datasets import Benchmark, Dataset, Datasets
+from compiler_gym.datasets.uri import BenchmarkUri
 from compiler_gym.service import (
     CompilerGymServiceConnection,
     ConnectionOpts,
@@ -462,7 +463,7 @@ class CompilerEnv(gym.Env):
         return self._benchmark_in_use
 
     @benchmark.setter
-    def benchmark(self, benchmark: Union[str, Benchmark]):
+    def benchmark(self, benchmark: Union[str, Benchmark, BenchmarkUri]):
         if self.in_episode:
             warnings.warn(
                 "Changing the benchmark has no effect until reset() is called"
@@ -474,6 +475,10 @@ class CompilerEnv(gym.Env):
         elif isinstance(benchmark, Benchmark):
             logger.debug("Setting benchmark: %s", benchmark.uri)
             self._next_benchmark = benchmark
+        elif isinstance(benchmark, BenchmarkUri):
+            benchmark_object = self.datasets.benchmark_from_parsed_uri(benchmark)
+            logger.debug("Setting benchmark by name: %s", benchmark_object)
+            self._next_benchmark = benchmark_object
         else:
             raise TypeError(
                 f"Expected a Benchmark or str, received: '{type(benchmark).__name__}'"

--- a/compiler_gym/envs/gcc/datasets/csmith.py
+++ b/compiler_gym/envs/gcc/datasets/csmith.py
@@ -15,6 +15,7 @@ from fasteners import InterProcessLock
 
 from compiler_gym.datasets import Benchmark, BenchmarkSource, Dataset
 from compiler_gym.datasets.benchmark import BenchmarkWithSource
+from compiler_gym.datasets.uri import BenchmarkUri
 from compiler_gym.envs.gcc.gcc import Gcc
 from compiler_gym.util.decorators import memoized_property
 from compiler_gym.util.runfiles_path import runfiles_path
@@ -139,8 +140,8 @@ class CsmithDataset(Dataset):
     def benchmark_uris(self) -> Iterable[str]:
         return (f"{self.name}/{i}" for i in range(UINT_MAX))
 
-    def benchmark(self, uri: str) -> CsmithBenchmark:
-        return self.benchmark_from_seed(int(uri.split("/")[-1]))
+    def benchmark_from_parsed_uri(self, uri: BenchmarkUri) -> CsmithBenchmark:
+        return self.benchmark_from_seed(int(uri.path[1:]))
 
     def _random_benchmark(self, random_state: np.random.Generator) -> Benchmark:
         seed = random_state.integers(UINT_MAX)

--- a/compiler_gym/envs/llvm/datasets/anghabench.py
+++ b/compiler_gym/envs/llvm/datasets/anghabench.py
@@ -10,6 +10,7 @@ from typing import Optional
 
 from compiler_gym.datasets import Benchmark, TarDatasetWithManifest
 from compiler_gym.datasets.benchmark import BenchmarkWithSource
+from compiler_gym.datasets.uri import BenchmarkUri
 from compiler_gym.envs.llvm.llvm_benchmark import ClangInvocation
 from compiler_gym.util import thread_pool
 from compiler_gym.util.filesystem import atomic_file_write
@@ -80,10 +81,10 @@ class AnghaBenchDataset(TarDatasetWithManifest):
             deprecated=deprecated,
         )
 
-    def benchmark(self, uri: str) -> Benchmark:
+    def benchmark_from_parsed_uri(self, uri: BenchmarkUri) -> Benchmark:
         self.install()
 
-        benchmark_name = uri[len(self.name) + 1 :]
+        benchmark_name = uri.path[1:]
         if not benchmark_name:
             raise LookupError(f"No benchmark specified: {uri}")
 

--- a/compiler_gym/envs/llvm/datasets/cbench.py
+++ b/compiler_gym/envs/llvm/datasets/cbench.py
@@ -27,7 +27,6 @@ from compiler_gym.util.commands import Popen
 from compiler_gym.util.download import download
 from compiler_gym.util.runfiles_path import cache_path, site_data_path
 from compiler_gym.util.timer import Timer
-from compiler_gym.util.truncate import truncate
 from compiler_gym.validation_result import ValidationError
 
 logger = logging.getLogger(__name__)
@@ -409,7 +408,7 @@ def _make_cBench_validator(
                 pass
             logger.warning(
                 "Validation callback failed (%s), attempt=%d/%d",
-                truncate(str(error), max_line_len=50, max_lines=1),
+                error.type,
                 j,
                 flakiness,
             )

--- a/compiler_gym/envs/llvm/datasets/cbench.py
+++ b/compiler_gym/envs/llvm/datasets/cbench.py
@@ -26,6 +26,7 @@ from compiler_gym.third_party import llvm
 from compiler_gym.util.download import download
 from compiler_gym.util.runfiles_path import cache_path, site_data_path
 from compiler_gym.util.timer import Timer
+from compiler_gym.util.truncate import truncate
 from compiler_gym.validation_result import ValidationError
 
 logger = logging.getLogger(__name__)
@@ -419,7 +420,12 @@ def _make_cBench_validator(
                 # Timeout errors can be raised by the environment in case of a
                 # slow step / observation, and should be retried.
                 pass
-            logger.warning("Validation callback failed, attempt=%d/%d", j, flakiness)
+            logger.warning(
+                "Validation callback failed (%s), attempt=%d/%d",
+                truncate(str(error), max_line_len=50, max_lines=1),
+                j,
+                flakiness,
+            )
         return error
 
     return flaky_wrapped_cb

--- a/compiler_gym/envs/llvm/datasets/chstone.py
+++ b/compiler_gym/envs/llvm/datasets/chstone.py
@@ -9,6 +9,7 @@ from typing import Iterable
 
 from compiler_gym.datasets import Benchmark, TarDatasetWithManifest
 from compiler_gym.datasets.benchmark import BenchmarkWithSource
+from compiler_gym.datasets.uri import BenchmarkUri
 from compiler_gym.envs.llvm.llvm_benchmark import ClangInvocation
 from compiler_gym.util import thread_pool
 from compiler_gym.util.filesystem import atomic_file_write
@@ -74,10 +75,10 @@ class CHStoneDataset(TarDatasetWithManifest):
     def benchmark_uris(self) -> Iterable[str]:
         yield from URIS
 
-    def benchmark(self, uri: str) -> Benchmark:
+    def benchmark_from_parsed_uri(self, uri: BenchmarkUri) -> Benchmark:
         self.install()
 
-        benchmark_name = uri[len(self.name) + 1 :]
+        benchmark_name = uri.path[1:]
         if not benchmark_name:
             raise LookupError(f"No benchmark specified: {uri}")
 

--- a/compiler_gym/envs/llvm/datasets/clgen.py
+++ b/compiler_gym/envs/llvm/datasets/clgen.py
@@ -15,6 +15,7 @@ from fasteners import InterProcessLock
 
 from compiler_gym.datasets import Benchmark, BenchmarkInitError, TarDatasetWithManifest
 from compiler_gym.datasets.benchmark import BenchmarkWithSource
+from compiler_gym.datasets.uri import BenchmarkUri
 from compiler_gym.envs.llvm.llvm_benchmark import ClangInvocation
 from compiler_gym.util.download import download
 from compiler_gym.util.filesystem import atomic_file_write
@@ -117,10 +118,10 @@ class CLgenDataset(TarDatasetWithManifest):
 
             self._opencl_headers_installed_marker.touch()
 
-    def benchmark(self, uri: str) -> Benchmark:
+    def benchmark_from_parsed_uri(self, uri: BenchmarkUri) -> Benchmark:
         self.install()
 
-        benchmark_name = uri[len(self.name) + 1 :]
+        benchmark_name = uri.path[1:]
         if not benchmark_name:
             raise LookupError(f"No benchmark specified: {uri}")
 

--- a/compiler_gym/envs/llvm/datasets/clgen.py
+++ b/compiler_gym/envs/llvm/datasets/clgen.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 import io
 import logging
+import os
 import shutil
 import subprocess
 import tarfile
@@ -126,7 +127,7 @@ class CLgenDataset(TarDatasetWithManifest):
             raise LookupError(f"No benchmark specified: {uri}")
 
         # The absolute path of the file, without an extension.
-        path_stem = self.dataset_root / uri[len(self.name) + 1 :]
+        path_stem = os.path.normpath(f"{self.dataset_root}/{uri.path}")
 
         bc_path, cl_path = Path(f"{path_stem}.bc"), Path(f"{path_stem}.cl")
 

--- a/compiler_gym/envs/llvm/datasets/csmith.py
+++ b/compiler_gym/envs/llvm/datasets/csmith.py
@@ -11,6 +11,7 @@ import numpy as np
 
 from compiler_gym.datasets import Benchmark, BenchmarkSource, Dataset
 from compiler_gym.datasets.benchmark import BenchmarkInitError, BenchmarkWithSource
+from compiler_gym.datasets.uri import BenchmarkUri
 from compiler_gym.envs.llvm.llvm_benchmark import ClangInvocation
 from compiler_gym.service.proto import BenchmarkDynamicConfig, Command
 from compiler_gym.util.decorators import memoized_property
@@ -149,8 +150,9 @@ class CsmithDataset(Dataset):
     def benchmark_uris(self) -> Iterable[str]:
         return (f"{self.name}/{i}" for i in range(UINT_MAX))
 
-    def benchmark(self, uri: str) -> CsmithBenchmark:
-        return self.benchmark_from_seed(int(uri.split("/")[-1]))
+    def benchmark_from_parsed_uri(self, uri: BenchmarkUri) -> CsmithBenchmark:
+        seed = int(uri.path[1:])
+        return self.benchmark_from_seed(seed)
 
     def _random_benchmark(self, random_state: np.random.Generator) -> Benchmark:
         seed = random_state.integers(UINT_MAX)

--- a/compiler_gym/envs/llvm/datasets/csmith.py
+++ b/compiler_gym/envs/llvm/datasets/csmith.py
@@ -14,6 +14,7 @@ from compiler_gym.datasets.benchmark import BenchmarkInitError, BenchmarkWithSou
 from compiler_gym.datasets.uri import BenchmarkUri
 from compiler_gym.envs.llvm.llvm_benchmark import ClangInvocation
 from compiler_gym.service.proto import BenchmarkDynamicConfig, Command
+from compiler_gym.util.commands import Popen, communicate
 from compiler_gym.util.decorators import memoized_property
 from compiler_gym.util.runfiles_path import runfiles_path
 from compiler_gym.util.shell_format import plural
@@ -183,43 +184,48 @@ class CsmithDataset(Dataset):
         # Run csmith with the given seed and pipe the output to clang to
         # assemble a bitcode.
         logger.debug("Exec csmith --seed %d", seed)
-        csmith = subprocess.Popen(
-            [str(self.csmith_bin_path), "--seed", str(seed)],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )
+        try:
+            with Popen(
+                [str(self.csmith_bin_path), "--seed", str(seed)],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            ) as csmith:
+                # Generate the C source.
+                src, stderr = communicate(csmith, timeout=300)
+                if csmith.returncode:
+                    try:
+                        stderr = "\n".join(
+                            truncate(
+                                stderr.decode("utf-8"), max_line_len=200, max_lines=20
+                            )
+                        )
+                        logger.warning("Csmith failed with seed %d: %s", seed, stderr)
+                    except UnicodeDecodeError:
+                        # Failed to interpret the stderr output, generate a generic
+                        # error message.
+                        logger.warning("Csmith failed with seed %d", seed)
+                    return self.benchmark_from_seed(
+                        seed, max_retries=max_retries, retry_count=retry_count + 1
+                    )
 
-        # Generate the C source.
-        src, stderr = csmith.communicate(timeout=300)
-        if csmith.returncode:
-            try:
-                stderr = "\n".join(
-                    truncate(stderr.decode("utf-8"), max_line_len=200, max_lines=20)
-                )
-                logger.warning("Csmith failed with seed %d: %s", seed, stderr)
-            except UnicodeDecodeError:
-                # Failed to interpret the stderr output, generate a generic
-                # error message.
-                logger.warning("Csmith failed with seed %d", seed)
-            return self.benchmark_from_seed(
-                seed, max_retries=max_retries, retry_count=retry_count + 1
-            )
-
-        # Compile to IR.
-        clang = subprocess.Popen(
-            self.clang_compile_command,
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
-        )
-        stdout, _ = clang.communicate(src, timeout=300)
-
-        if clang.returncode:
-            compile_cmd = " ".join(self.clang_compile_command)
+            # Compile to IR.
+            with Popen(
+                self.clang_compile_command,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+            ) as clang:
+                stdout, _ = communicate(clang, input=src, timeout=300)
+                if clang.returncode:
+                    compile_cmd = " ".join(self.clang_compile_command)
+                    raise BenchmarkInitError(
+                        f"Compilation job failed!\n"
+                        f"Csmith seed: {seed}\n"
+                        f"Command: {compile_cmd}\n"
+                    )
+        except subprocess.TimeoutExpired:
             raise BenchmarkInitError(
-                f"Compilation job failed!\n"
-                f"Csmith seed: {seed}\n"
-                f"Command: {compile_cmd}\n"
+                f"Benchmark generation using seed {seed} timed out"
             )
 
         return self.benchmark_class.create(f"{self.name}/{seed}", stdout, src)

--- a/compiler_gym/envs/llvm/datasets/llvm_stress.py
+++ b/compiler_gym/envs/llvm/datasets/llvm_stress.py
@@ -12,6 +12,7 @@ from compiler_gym.datasets import Benchmark, Dataset
 from compiler_gym.datasets.benchmark import BenchmarkInitError
 from compiler_gym.datasets.uri import BenchmarkUri
 from compiler_gym.third_party import llvm
+from compiler_gym.util.commands import Popen
 
 # The maximum value for the --seed argument to llvm-stress.
 UINT_MAX = (2 ** 32) - 1
@@ -75,21 +76,23 @@ class LlvmStressDataset(Dataset):
 
         # Run llvm-stress with the given seed and pipe the output to llvm-as to
         # assemble a bitcode.
-        llvm_stress = subprocess.Popen(
-            [str(llvm.llvm_stress_path()), f"--seed={seed}"],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )
-        llvm_as = subprocess.Popen(
-            [str(llvm.llvm_as_path()), "-"],
-            stdin=llvm_stress.stdout,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )
-
-        stdout, _ = llvm_as.communicate(timeout=60)
-        llvm_stress.communicate(timeout=60)
-        if llvm_stress.returncode or llvm_as.returncode:
-            raise BenchmarkInitError("Failed to generate benchmark")
+        try:
+            with Popen(
+                [str(llvm.llvm_stress_path()), f"--seed={seed}"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            ) as llvm_stress:
+                with Popen(
+                    [str(llvm.llvm_as_path()), "-"],
+                    stdin=llvm_stress.stdout,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                ) as llvm_as:
+                    stdout, _ = llvm_as.communicate(timeout=60)
+                    llvm_stress.communicate(timeout=60)
+                    if llvm_stress.returncode or llvm_as.returncode:
+                        raise BenchmarkInitError("Failed to generate benchmark")
+        except subprocess.TimeoutExpired:
+            raise BenchmarkInitError("Benchmark generation timed out")
 
         return Benchmark.from_file_contents(f"{self.name}/{seed}", stdout)

--- a/compiler_gym/envs/llvm/datasets/llvm_stress.py
+++ b/compiler_gym/envs/llvm/datasets/llvm_stress.py
@@ -10,6 +10,7 @@ import numpy as np
 
 from compiler_gym.datasets import Benchmark, Dataset
 from compiler_gym.datasets.benchmark import BenchmarkInitError
+from compiler_gym.datasets.uri import BenchmarkUri
 from compiler_gym.third_party import llvm
 
 # The maximum value for the --seed argument to llvm-stress.
@@ -55,8 +56,9 @@ class LlvmStressDataset(Dataset):
     def benchmark_uris(self) -> Iterable[str]:
         return (f"{self.name}/{i}" for i in range(UINT_MAX))
 
-    def benchmark(self, uri: str) -> Benchmark:
-        return self.benchmark_from_seed(int(uri.split("/")[-1]))
+    def benchmark_from_parsed_uri(self, uri: BenchmarkUri) -> Benchmark:
+        seed = int(uri.path[1:])
+        return self.benchmark_from_seed(seed)
 
     def _random_benchmark(self, random_state: np.random.Generator) -> Benchmark:
         seed = random_state.integers(UINT_MAX)

--- a/compiler_gym/envs/llvm/datasets/poj104.py
+++ b/compiler_gym/envs/llvm/datasets/poj104.py
@@ -3,6 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 import logging
+import os
 import subprocess
 import sys
 from concurrent.futures import as_completed
@@ -74,11 +75,9 @@ class POJ104Dataset(TarDatasetWithManifest):
 
     def benchmark_from_parsed_uri(self, uri: BenchmarkUri) -> Benchmark:
         self.install()
-        if uri is None or len(uri) <= len(self.name) + 1:
-            return self._get_benchmark_by_index(self.random.integers(self.size))
 
         # The absolute path of the file, without an extension.
-        path_stem = self.dataset_root / uri[len(self.name) + 1 :]
+        path_stem = os.path.normpath(f"{self.dataset_root}/{uri.path}")
 
         # If the file does not exist, compile it on-demand.
         bitcode_path = Path(f"{path_stem}.bc")

--- a/compiler_gym/envs/llvm/datasets/poj104.py
+++ b/compiler_gym/envs/llvm/datasets/poj104.py
@@ -118,11 +118,14 @@ class POJ104Dataset(TarDatasetWithManifest):
             if clang.returncode:
                 compile_cmd = " ".join(compile_cmd)
                 error = truncate(stderr.decode("utf-8"), max_lines=20, max_line_len=100)
+                if tmp_bitcode_path.is_file():
+                    tmp_bitcode_path.unlink()
                 raise BenchmarkInitError(
                     f"Compilation job failed!\n"
                     f"Command: {compile_cmd}\n"
                     f"Error: {error}"
                 )
+
             if not bitcode_path.is_file():
                 raise BenchmarkInitError(
                     f"Compilation job failed to produce output file!\nCommand: {compile_cmd}"

--- a/compiler_gym/envs/llvm/datasets/poj104.py
+++ b/compiler_gym/envs/llvm/datasets/poj104.py
@@ -9,8 +9,11 @@ from concurrent.futures import as_completed
 from pathlib import Path
 from typing import Optional
 
+import numpy as np
+
 from compiler_gym.datasets import Benchmark, BenchmarkInitError, TarDatasetWithManifest
 from compiler_gym.datasets.benchmark import BenchmarkWithSource
+from compiler_gym.datasets.uri import BenchmarkUri
 from compiler_gym.envs.llvm.llvm_benchmark import ClangInvocation
 from compiler_gym.util import thread_pool
 from compiler_gym.util.download import download
@@ -69,7 +72,7 @@ class POJ104Dataset(TarDatasetWithManifest):
             sort_order=sort_order,
         )
 
-    def benchmark(self, uri: Optional[str] = None) -> Benchmark:
+    def benchmark_from_parsed_uri(self, uri: BenchmarkUri) -> Benchmark:
         self.install()
         if uri is None or len(uri) <= len(self.name) + 1:
             return self._get_benchmark_by_index(self.random.integers(self.size))
@@ -127,6 +130,12 @@ class POJ104Dataset(TarDatasetWithManifest):
                 )
 
         return BenchmarkWithSource.create(uri, bitcode_path, "source.cc", cc_file_path)
+
+    def random_benchmark(
+        self, random_state: Optional[np.random.Generator] = None
+    ) -> Benchmark:
+        random_state = random_state or np.random.default_rng()
+        return self._get_benchmark_by_index(random_state.integers(self.size))
 
     @staticmethod
     def preprocess_poj104_source(src: str) -> str:

--- a/compiler_gym/envs/llvm/service/BenchmarkFactory.cc
+++ b/compiler_gym/envs/llvm/service/BenchmarkFactory.cc
@@ -70,11 +70,11 @@ Status BenchmarkFactory::getBenchmark(const BenchmarkProto& benchmarkMessage,
     }
     case compiler_gym::File::DataCase::kUri: {
       VLOG(3) << "LLVM benchmark cache miss, read from URI: " << benchmarkMessage.uri();
-      // Check the protocol of the benchmark URI.
+      // Check the scheme of the benchmark URI.
       if (programFile.uri().find("file:///") != 0) {
         return Status(StatusCode::INVALID_ARGUMENT,
                       fmt::format("Invalid benchmark data URI. "
-                                  "Only the file:/// protocol is supported: \"{}\"",
+                                  "Only the file:/// scheme is supported: \"{}\"",
                                   programFile.uri()));
       }
 

--- a/compiler_gym/envs/loop_tool/__init__.py
+++ b/compiler_gym/envs/loop_tool/__init__.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Iterable
 
 from compiler_gym.datasets import Benchmark, Dataset, benchmark
+from compiler_gym.datasets.uri import BenchmarkUri
 from compiler_gym.spaces import Reward
 from compiler_gym.util.registration import register
 from compiler_gym.util.runfiles_path import runfiles_path
@@ -61,8 +62,8 @@ class LoopToolCUDADataset(Dataset):
     def benchmark_uris(self) -> Iterable[str]:
         return (f"loop_tool-cuda-v0/{i}" for i in range(1, 1024 * 1024 * 8))
 
-    def benchmark(self, uri: str) -> Benchmark:
-        return Benchmark(proto=benchmark.BenchmarkProto(uri=uri))
+    def benchmark_from_parsed_uri(self, uri: BenchmarkUri) -> Benchmark:
+        return Benchmark(proto=benchmark.BenchmarkProto(uri=str(uri)))
 
 
 class LoopToolCPUDataset(Dataset):
@@ -76,8 +77,8 @@ class LoopToolCPUDataset(Dataset):
     def benchmark_uris(self) -> Iterable[str]:
         return (f"loop_tool-cpu-v0/{i}" for i in range(1, 1024 * 1024 * 8))
 
-    def benchmark(self, uri: str) -> Benchmark:
-        return Benchmark(proto=benchmark.BenchmarkProto(uri=uri))
+    def benchmark_from_parsed_uri(self, uri: BenchmarkUri) -> Benchmark:
+        return Benchmark(proto=benchmark.BenchmarkProto(uri=str(uri)))
 
 
 register(

--- a/compiler_gym/random_search.py
+++ b/compiler_gym/random_search.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 """Simple parallelized random search."""
 import json
+import os
 from multiprocessing import cpu_count
 from pathlib import Path
 from threading import Thread
@@ -155,8 +156,9 @@ def random_search(
 
         benchmark_uri = env.benchmark.uri
         if not outdir:
-            sanitized_benchmark_uri = "/".join(benchmark_uri.split("/")[-2:])
-            outdir = create_logging_dir(f"random/{sanitized_benchmark_uri}")
+            outdir = create_logging_dir(
+                os.path.normpath(f"random/{benchmark_uri.scheme}/{benchmark_uri.path}")
+            )
         outdir = Path(outdir)
 
         if not env.reward_space:
@@ -177,7 +179,7 @@ def random_search(
         # Write a metadata file.
         metadata = {
             "env": env.spec.id if env.spec else "",
-            "benchmark": benchmark_uri,
+            "benchmark": str(benchmark_uri),
             "reward": reward_space_name,
             "patience": patience,
         }

--- a/compiler_gym/util/commands.py
+++ b/compiler_gym/util/commands.py
@@ -5,28 +5,30 @@
 
 import subprocess
 import sys
+from contextlib import contextmanager
 from signal import Signals
+from subprocess import Popen as _Popen
 from typing import List
 
 
 def run_command(cmd: List[str], timeout: int):
-    process = subprocess.Popen(
+    with Popen(
         cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True
-    )
-    stdout, stderr = communicate(process, timeout=timeout)
-    if process.returncode:
-        returncode = process.returncode
-        try:
-            # Try and decode the name of a signal. Signal returncodes
-            # are negative.
-            returncode = f"{returncode} ({Signals(abs(returncode)).name})"
-        except ValueError:
-            pass
-        raise OSError(
-            f"Compilation job failed with returncode {returncode}\n"
-            f"Command: {' '.join(cmd)}\n"
-            f"Stderr: {stderr.strip()}"
-        )
+    ) as process:
+        stdout, stderr = process.communicate(timeout=timeout)
+        if process.returncode:
+            returncode = process.returncode
+            try:
+                # Try and decode the name of a signal. Signal returncodes
+                # are negative.
+                returncode = f"{returncode} ({Signals(abs(returncode)).name})"
+            except ValueError:
+                pass
+            raise OSError(
+                f"Compilation job failed with returncode {returncode}\n"
+                f"Command: {' '.join(cmd)}\n"
+                f"Stderr: {stderr.strip()}"
+            )
     return stdout
 
 
@@ -40,5 +42,30 @@ def communicate(process, input=None, timeout=None):
             process.kill()
         else:
             process.terminate()
-        process.communicate(timeout=timeout)  # Wait for shutdown to complete.
+        # Wait for shutdown to complete.
+        try:
+            process.communicate(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            pass  # Stubborn process won't die, nothing can be done.
         raise
+
+
+@contextmanager
+def Popen(*args, **kwargs):
+    """subprocess.Popen() with resilient process termination at end of scope."""
+    with _Popen(*args, **kwargs) as process:
+        try:
+            yield process
+        finally:
+            # Process has not yet terminated, kill it.
+            if process.poll() is None:
+                # kill() was added in Python 3.7.
+                if sys.version_info >= (3, 7, 0):
+                    process.kill()
+                else:
+                    process.terminate()
+                # Wait for shutdown to complete.
+                try:
+                    process.communicate(timeout=60)
+                except subprocess.TimeoutExpired:
+                    pass  # Stubborn process won't die, nothing can be done.

--- a/compiler_gym/util/executor.py
+++ b/compiler_gym/util/executor.py
@@ -108,7 +108,7 @@ class Executor(BaseModel):
                 gpus_per_node=self.gpus,
                 slurm_partition=self.slurm_partition,
             )
-            name = self.slurm_partition
+            name = self.slurm_partition or "slurm"  # default value for logging
         elif self.type == self.Type.LOCAL:
             executor, name = (
                 LocalParallelExecutor(

--- a/compiler_gym/util/flags/benchmark_from_flags.py
+++ b/compiler_gym/util/flags/benchmark_from_flags.py
@@ -13,9 +13,9 @@ from compiler_gym.datasets import Benchmark
 flags.DEFINE_string(
     "benchmark",
     None,
-    "The URI of the benchmark to use. Use the benchmark:// protocol to "
-    "reference named benchmarks, or the file:/// protocol to reference paths "
-    "to program data. If no protocol is specified, benchmark:// is implied.",
+    "The URI of the benchmark to use. Use the benchmark:// scheme to "
+    "reference named benchmarks, or the file:/// scheme to reference paths "
+    "to program data. If no scheme is specified, benchmark:// is implied.",
 )
 
 FLAGS = flags.FLAGS

--- a/compiler_gym/validation_result.py
+++ b/compiler_gym/validation_result.py
@@ -113,8 +113,8 @@ class ValidationResult(BaseModel):
         )
 
     def __repr__(self):
-        # Remove default-protocol prefix to improve output readability.
-        benchmark = re.sub(r"^benchmark://", "", self.state.benchmark)
+        # Remove default-scheme prefix to improve output readability.
+        benchmark = re.sub(r"^benchmark://", "", str(self.state.benchmark))
 
         if not self.okay():
             msg = ", ".join(self.error_details.strip().split("\n"))

--- a/docs/source/compiler_gym/datasets.rst
+++ b/docs/source/compiler_gym/datasets.rst
@@ -12,6 +12,13 @@ that can be installed and made available for use.
 .. currentmodule:: compiler_gym.datasets
 
 
+BenchmarkUri
+------------
+
+.. autoclass:: BenchmarkUri
+  :members:
+
+
 Benchmark
 ---------
 

--- a/examples/brute_force.py
+++ b/examples/brute_force.py
@@ -25,6 +25,7 @@ import itertools
 import json
 import logging
 import math
+import os
 import sys
 from pathlib import Path
 from queue import Queue
@@ -180,7 +181,7 @@ def run_brute_force(
         reward_space_name = env.reward_space.id
 
         actions = [env.action_space.names.index(a) for a in action_names]
-        benchmark_uri = env.benchmark.uri
+        benchmark_uri = str(env.benchmark)
 
         meta = {
             "env": env.spec.id,
@@ -307,10 +308,12 @@ def main(argv):
 
     with env_from_flags(benchmark) as env:
         env.reset()
-        sanitized_benchmark_uri = "/".join(str(env.benchmark).split("/")[-2:])
-    logs_dir = Path(
-        FLAGS.output_dir or create_logging_dir(f"brute_force/{sanitized_benchmark_uri}")
-    )
+        logs_dir = Path(
+            FLAGS.output_dir
+            or create_logging_dir(
+                f'brute_force/{os.path.normpath(f"random/{env.benchmark.uri.scheme}/{env.benchmark.uri.path}")}'
+            )
+        )
 
     run_brute_force(
         make_env=lambda: env_from_flags(benchmark_from_flags()),

--- a/examples/example_compiler_gym_service/__init__.py
+++ b/examples/example_compiler_gym_service/__init__.py
@@ -70,7 +70,7 @@ class ExampleDataset(Dataset):
         }
 
     def benchmark_uris(self) -> Iterable[str]:
-        yield from self._benchmarks.keys()
+        yield from (f"benchmark://example-v0{k}" for k in self._benchmarks.keys())
 
     def benchmark_from_parsed_uris(self, uri: BenchmarkUri) -> Benchmark:
         if uri.path in self._benchmarks:

--- a/examples/example_compiler_gym_service/__init__.py
+++ b/examples/example_compiler_gym_service/__init__.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Iterable
 
 from compiler_gym.datasets import Benchmark, Dataset
+from compiler_gym.datasets.uri import BenchmarkUri
 from compiler_gym.spaces import Reward
 from compiler_gym.util.registration import register
 from compiler_gym.util.runfiles_path import runfiles_path
@@ -60,10 +61,10 @@ class ExampleDataset(Dataset):
             description="An example dataset",
         )
         self._benchmarks = {
-            "benchmark://example-v0/foo": Benchmark.from_file_contents(
+            "/foo": Benchmark.from_file_contents(
                 "benchmark://example-v0/foo", "Ir data".encode("utf-8")
             ),
-            "benchmark://example-v0/bar": Benchmark.from_file_contents(
+            "/bar": Benchmark.from_file_contents(
                 "benchmark://example-v0/bar", "Ir data".encode("utf-8")
             ),
         }
@@ -71,8 +72,8 @@ class ExampleDataset(Dataset):
     def benchmark_uris(self) -> Iterable[str]:
         yield from self._benchmarks.keys()
 
-    def benchmark(self, uri: str) -> Benchmark:
-        if uri in self._benchmarks:
+    def benchmark_from_parsed_uris(self, uri: BenchmarkUri) -> Benchmark:
+        if uri.path in self._benchmarks:
             return self._benchmarks[uri]
         else:
             raise LookupError("Unknown program name")

--- a/examples/example_compiler_gym_service/demo_without_bazel.py
+++ b/examples/example_compiler_gym_service/demo_without_bazel.py
@@ -67,18 +67,18 @@ class ExampleDataset(Dataset):
             description="An example dataset",
         )
         self._benchmarks = {
-            "benchmark://example-v0/foo": Benchmark.from_file_contents(
+            "/foo": Benchmark.from_file_contents(
                 "benchmark://example-v0/foo", "Ir data".encode("utf-8")
             ),
-            "benchmark://example-v0/bar": Benchmark.from_file_contents(
+            "/bar": Benchmark.from_file_contents(
                 "benchmark://example-v0/bar", "Ir data".encode("utf-8")
             ),
         }
 
     def benchmark_uris(self) -> Iterable[str]:
-        yield from self._benchmarks.keys()
+        yield from (f"benchmark://example-v0{k}" for k in self._benchmarks.keys())
 
-    def benchmark_from_parsed_uris(self, uri: BenchmarkUri) -> Benchmark:
+    def benchmark_from_parsed_uri(self, uri: BenchmarkUri) -> Benchmark:
         if uri.path in self._benchmarks:
             return self._benchmarks[uri.path]
         else:

--- a/examples/example_compiler_gym_service/demo_without_bazel.py
+++ b/examples/example_compiler_gym_service/demo_without_bazel.py
@@ -16,6 +16,7 @@ from typing import Iterable
 import gym
 
 from compiler_gym.datasets import Benchmark, Dataset
+from compiler_gym.datasets.uri import BenchmarkUri
 from compiler_gym.spaces import Reward
 from compiler_gym.util.logging import init_logging
 from compiler_gym.util.registration import register
@@ -77,9 +78,9 @@ class ExampleDataset(Dataset):
     def benchmark_uris(self) -> Iterable[str]:
         yield from self._benchmarks.keys()
 
-    def benchmark(self, uri: str) -> Benchmark:
-        if uri in self._benchmarks:
-            return self._benchmarks[uri]
+    def benchmark_from_parsed_uris(self, uri: BenchmarkUri) -> Benchmark:
+        if uri.path in self._benchmarks:
+            return self._benchmarks[uri.path]
         else:
             raise LookupError("Unknown program name")
 

--- a/examples/example_unrolling_service/__init__.py
+++ b/examples/example_unrolling_service/__init__.py
@@ -123,7 +123,7 @@ class UnrollingDataset(Dataset):
         )
 
     def benchmark_uris(self) -> Iterable[str]:
-        yield from self._benchmarks.keys()
+        yield from (f"benchmark://unrolling-v0{k}" for k in self._benchmarks.keys())
 
     def benchmark_from_parsed_uri(self, uri: BenchmarkUri) -> Benchmark:
         if uri.path in self._benchmarks:

--- a/examples/example_unrolling_service/__init__.py
+++ b/examples/example_unrolling_service/__init__.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Iterable
 
 from compiler_gym.datasets import Benchmark, Dataset
+from compiler_gym.datasets.uri import BenchmarkUri
 from compiler_gym.envs.llvm.llvm_benchmark import get_system_includes
 from compiler_gym.spaces import Reward
 from compiler_gym.third_party import llvm
@@ -89,11 +90,11 @@ class UnrollingDataset(Dataset):
         )
 
         self._benchmarks = {
-            "benchmark://unrolling-v0/offsets1": Benchmark.from_file_contents(
+            "/offsets1": Benchmark.from_file_contents(
                 "benchmark://unrolling-v0/offsets1",
                 self.preprocess(BENCHMARKS_PATH / "offsets1.c"),
             ),
-            "benchmark://unrolling-v0/conv2d": Benchmark.from_file_contents(
+            "/conv2d": Benchmark.from_file_contents(
                 "benchmark://unrolling-v0/conv2d",
                 self.preprocess(BENCHMARKS_PATH / "conv2d.c"),
             ),
@@ -124,9 +125,9 @@ class UnrollingDataset(Dataset):
     def benchmark_uris(self) -> Iterable[str]:
         yield from self._benchmarks.keys()
 
-    def benchmark(self, uri: str) -> Benchmark:
-        if uri in self._benchmarks:
-            return self._benchmarks[uri]
+    def benchmark_from_parsed_uri(self, uri: BenchmarkUri) -> Benchmark:
+        if uri.path in self._benchmarks:
+            return self._benchmarks[uri.path]
         else:
             raise LookupError("Unknown program name")
 

--- a/examples/example_unrolling_service/env_tests.py
+++ b/examples/example_unrolling_service/env_tests.py
@@ -15,6 +15,7 @@ import examples.example_unrolling_service as unrolling_service
 from compiler_gym.envs import CompilerEnv
 from compiler_gym.service import SessionNotFound
 from compiler_gym.spaces import Box, NamedDiscrete, Scalar, Sequence
+from compiler_gym.util.commands import Popen
 from tests.test_main import main
 
 
@@ -34,11 +35,11 @@ def test_invalid_arguments(bin: Path):
     """Test that running the binary with unrecognized arguments is an error."""
 
     def run(cmd):
-        p = subprocess.Popen(
+        with Popen(
             cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True
-        )
-        stdout, stderr = p.communicate(timeout=10)
-        return p.returncode, stdout, stderr
+        ) as p:
+            stdout, stderr = p.communicate(timeout=10)
+            return p.returncode, stdout, stderr
 
     returncode, _, stderr = run([str(bin), "foobar"])
     assert "ERROR:" in stderr

--- a/examples/llvm_autotuning/benchmarks.py
+++ b/examples/llvm_autotuning/benchmarks.py
@@ -7,8 +7,7 @@ from typing import Iterable, List, Union
 
 from pydantic import BaseModel, Field, root_validator, validator
 
-from compiler_gym.datasets import Benchmark
-from compiler_gym.datasets.uri import BENCHMARK_URI_RE, DATASET_NAME_PATTERN
+from compiler_gym.datasets import Benchmark, BenchmarkUri
 from compiler_gym.envs.llvm import LlvmEnv
 
 
@@ -17,7 +16,7 @@ class BenchmarksEntry(BaseModel):
 
     # === Start of fields list. ===
 
-    dataset: str = Field(default=None, allow_mutation=False, regex=DATASET_NAME_PATTERN)
+    dataset: str = Field(default=None, allow_mutation=False)
     """The name of a dataset to iterate over. If set, benchmarks are produced
     by iterating over this dataset in order. If not set, the :code:`uris` list
     must be provided.
@@ -62,9 +61,8 @@ class BenchmarksEntry(BaseModel):
         del kwargs
         del values
         for uri in value:
-            assert BENCHMARK_URI_RE.match(uri) or uri.startswith(
-                "file:///"
-            ), f"Invalid benchmark URI: {uri}"
+            uri = BenchmarkUri.from_string(uri)
+            assert uri.scheme and uri.dataset, f"Invalid benchmark URI: {uri}"
         return list(value)
 
     def _benchmark_iterator(

--- a/examples/llvm_rl/model/benchmarks.py
+++ b/examples/llvm_rl/model/benchmarks.py
@@ -7,8 +7,7 @@ from typing import Iterable, List, Union
 
 from pydantic import BaseModel, Field, root_validator, validator
 
-from compiler_gym.datasets import Benchmark
-from compiler_gym.datasets.uri import BENCHMARK_URI_RE, DATASET_NAME_PATTERN
+from compiler_gym.datasets import Benchmark, BenchmarkUri
 from compiler_gym.envs import CompilerEnv
 
 
@@ -32,7 +31,7 @@ class Benchmarks(BaseModel):
 
     # === Start of fields list. ===
 
-    dataset: str = Field(default=None, allow_mutation=False, regex=DATASET_NAME_PATTERN)
+    dataset: str = Field(default=None, allow_mutation=False)
     """The name of a dataset to iterate over. If set, benchmarks are produced
     by iterating over this dataset in order. If not set, the :code:`uris` list
     must be provided.
@@ -76,7 +75,8 @@ class Benchmarks(BaseModel):
     def validate_uris(cls, value, *, values, **kwargs):
         del kwargs
         for uri in value:
-            assert BENCHMARK_URI_RE.match(uri), f"Invalid benchmark URI: {uri}"
+            uri = BenchmarkUri.from_string(uri)
+            assert uri.scheme and uri.dataset, f"Invalid benchmark URI: {uri}"
         return list(value)
 
     def _benchmark_iterator(

--- a/examples/llvm_rl/model/inference_result.py
+++ b/examples/llvm_rl/model/inference_result.py
@@ -6,11 +6,12 @@ import logging
 from typing import List
 
 import numpy as np
-from pydantic import BaseModel
+from pydantic import BaseModel, validator
 from ray.rllib.agents.dqn import ApexTrainer, R2D2Trainer  # noqa
 from ray.rllib.agents.impala import ImpalaTrainer  # noqa
 from ray.rllib.agents.ppo import PPOTrainer  # noqa
 
+from compiler_gym.datasets import BenchmarkUri
 from compiler_gym.envs import CompilerEnv
 from compiler_gym.util.timer import Timer
 
@@ -118,3 +119,9 @@ class InferenceResult(BaseModel):
             runtime_reduction=np.median(runtimes_o3 or [0])
             / max(np.median(runtimes_final or [0]), 1),
         )
+
+    @validator("benchmark", pre=True)
+    def validate_benchmark(cls, value):
+        if isinstance(value, BenchmarkUri):
+            return str(value)
+        return value

--- a/examples/llvm_rl/tests/benchmarks_test.py
+++ b/examples/llvm_rl/tests/benchmarks_test.py
@@ -36,8 +36,3 @@ uris:
         )
     )
     assert len(cfg.uris) == 1
-
-
-def test_benchmarks_uris_invalid_regex():
-    with pytest.raises(ValidationError):
-        Benchmarks(uris=["bad-uri"])

--- a/tests/compiler_env_state_test.py
+++ b/tests/compiler_env_state_test.py
@@ -22,11 +22,6 @@ def test_state_from_dict_empty():
         CompilerEnvState(**{})
 
 
-def test_state_invalid_benchmark_uri():
-    with pytest.raises(PydanticValidationError, match="benchmark"):
-        CompilerEnvState(benchmark="invalid", walltime=100, reward=1.5, commandline="")
-
-
 def test_state_invalid_walltime():
     with pytest.raises(PydanticValidationError, match="Walltime cannot be negative"):
         CompilerEnvState(
@@ -290,15 +285,6 @@ def test_state_from_csv_invalid_format():
     with pytest.raises(
         ValueError, match=r"Expected 4 columns in the first row of CSV: \['abcdef'\]"
     ):
-        next(iter(reader))
-
-
-def test_state_from_csv_invalid_benchmark_uri():
-    buf = StringIO(
-        "benchmark,reward,walltime,commandline\n" "invalid-uri,2.0,5.0,-a -b -c\n"
-    )
-    reader = CompilerEnvStateReader(buf)
-    with pytest.raises(ValueError, match="string does not match regex"):
         next(iter(reader))
 
 

--- a/tests/compiler_env_test.py
+++ b/tests/compiler_env_test.py
@@ -52,7 +52,7 @@ def test_uri_substring_no_match(env: LlvmEnv):
         env.reset(benchmark="benchmark://cbench-v1/cr")
 
 
-def test_uri_substring_candidate_no_match_infer_protocol(env: LlvmEnv):
+def test_uri_substring_candidate_no_match_infer_scheme(env: LlvmEnv):
     env.reset(benchmark="cbench-v1/crc32")
     assert env.benchmark == "benchmark://cbench-v1/crc32"
 

--- a/tests/datasets/BUILD
+++ b/tests/datasets/BUILD
@@ -46,3 +46,14 @@ py_test(
         "//tests/pytest_plugins:common",
     ],
 )
+
+py_test(
+    name = "uri_test",
+    timeout = "short",
+    srcs = ["uri_test.py"],
+    deps = [
+        "//compiler_gym/datasets",
+        "//tests:test_main",
+        "//tests/pytest_plugins:common",
+    ],
+)

--- a/tests/datasets/benchmark_test.py
+++ b/tests/datasets/benchmark_test.py
@@ -3,108 +3,16 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 """Unit tests for //compiler_gym/datasets:benchmark."""
-import re
 from pathlib import Path
 
 import pytest
 
 from compiler_gym.datasets import Benchmark, BenchmarkSource
-from compiler_gym.datasets.uri import BENCHMARK_URI_RE, DATASET_NAME_RE
 from compiler_gym.service.proto import Benchmark as BenchmarkProto
 from compiler_gym.validation_error import ValidationError
 from tests.test_main import main
 
 pytest_plugins = ["tests.pytest_plugins.common"]
-
-
-def _rgx_match(regex, groupname, string) -> str:
-    """Match the regex and return a named group."""
-    match = re.match(regex, string)
-    assert match, f"Failed to match regex '{regex}' using string '{groupname}'"
-    return match.group(groupname)
-
-
-def test_benchmark_uri_protocol():
-    assert (
-        _rgx_match(DATASET_NAME_RE, "dataset_protocol", "benchmark://cbench-v1/")
-        == "benchmark"
-    )
-    assert (
-        _rgx_match(DATASET_NAME_RE, "dataset_protocol", "Generator13://gen-v11/")
-        == "Generator13"
-    )
-
-
-def test_invalid_benchmark_uris():
-    # Invalid protocol
-    assert not DATASET_NAME_RE.match("B?://cbench-v1/")  # Invalid characters
-    assert not DATASET_NAME_RE.match("cbench-v1/")  # Missing protocol
-
-    # Invalid dataset name
-    assert not BENCHMARK_URI_RE.match("benchmark://cbench?v0/foo")  # Invalid character
-    assert not BENCHMARK_URI_RE.match(
-        "benchmark://cbench/foo"
-    )  # Missing version suffix
-    assert not BENCHMARK_URI_RE.match("benchmark://cbench-v0")  # Missing benchmark ID
-    assert not BENCHMARK_URI_RE.match("benchmark://cbench-v0/")  # Missing benchmark ID
-
-
-def test_benchmark_uri_dataset():
-    assert (
-        _rgx_match(BENCHMARK_URI_RE, "dataset_name", "benchmark://cbench-v1/foo")
-        == "cbench-v1"
-    )
-    assert (
-        _rgx_match(BENCHMARK_URI_RE, "dataset_name", "Generator13://gen-v11/foo")
-        == "gen-v11"
-    )
-
-
-def test_benchmark_dataset_name():
-    assert (
-        _rgx_match(BENCHMARK_URI_RE, "dataset", "benchmark://cbench-v1/foo")
-        == "benchmark://cbench-v1"
-    )
-    assert (
-        _rgx_match(BENCHMARK_URI_RE, "dataset", "Generator13://gen-v11/foo")
-        == "Generator13://gen-v11"
-    )
-
-
-def test_benchmark_uri_id():
-    assert (
-        _rgx_match(BENCHMARK_URI_RE, "benchmark_name", "benchmark://cbench-v1/foo")
-        == "foo"
-    )
-    assert (
-        _rgx_match(BENCHMARK_URI_RE, "benchmark_name", "benchmark://cbench-v1/foo/123")
-        == "foo/123"
-    )
-    assert (
-        _rgx_match(
-            BENCHMARK_URI_RE, "benchmark_name", "benchmark://cbench-v1/foo/123.txt"
-        )
-        == "foo/123.txt"
-    )
-    # Query parameters are allowed in benchmark URIs.
-    assert (
-        _rgx_match(
-            BENCHMARK_URI_RE,
-            "benchmark_name",
-            "benchmark://cbench-v1/foo/123?param=true&false",
-        )
-        == "foo/123?param=true&false"
-    )
-    # Whitespace is allowed in benchmark URIs.
-    assert (
-        _rgx_match(
-            BENCHMARK_URI_RE, "benchmark_name", "benchmark://cbench-v1/ white space"
-        )
-    ) == " white space"
-    # This URI makes no sense, but is valid I suppose.
-    assert (
-        _rgx_match(BENCHMARK_URI_RE, "benchmark_name", "benchmark://cbench-v1/\t")
-    ) == "\t"
 
 
 def test_benchmark_attribute_outside_init():

--- a/tests/datasets/dataset_test.py
+++ b/tests/datasets/dataset_test.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 from compiler_gym.datasets.dataset import Dataset
+from compiler_gym.datasets.uri import BenchmarkUri
 from tests.test_main import main
 
 pytest_plugins = ["tests.pytest_plugins.common"]
@@ -201,11 +202,8 @@ class DatasetForTesting(Dataset):
     def benchmark_uris(self):
         return sorted(self._benchmarks)
 
-    def benchmark(self, uri):
-        if uri:
-            return self._benchmarks[uri]
-        else:
-            return next(iter(self._benchmarks.values()))
+    def benchmark_from_parsed_uri(self, uri: BenchmarkUri):
+        return self._benchmarks[str(uri)]
 
     @property
     def size(self):

--- a/tests/datasets/dataset_test.py
+++ b/tests/datasets/dataset_test.py
@@ -15,27 +15,6 @@ pytest_plugins = ["tests.pytest_plugins.common"]
 # pylint: disable=abstract-method
 
 
-@pytest.mark.parametrize(
-    "invalid_name", ["benchmark://test", "test-v0", "benchmark://v0"]
-)
-def test_dataset__invalid_name(invalid_name: str):
-    """Test that invalid dataset names raise an error on init."""
-
-    with pytest.raises(
-        ValueError,
-        match=(
-            f"Invalid dataset name: '{invalid_name}'. "
-            "Dataset name must be in the form: '{{protocol}}://{{name}}-v{{version}}'"
-        ),
-    ):
-        Dataset(
-            name=invalid_name,
-            description="A test dataset",
-            license="MIT",
-            site_data_base="test",
-        )
-
-
 def test_dataset_properties():
     """Test the dataset property values."""
     dataset = Dataset(
@@ -46,7 +25,7 @@ def test_dataset_properties():
     )
 
     assert dataset.name == "benchmark://test-v0"
-    assert dataset.protocol == "benchmark"
+    assert dataset.scheme == "benchmark"
     assert dataset.description == "A test dataset"
     assert dataset.license == "MIT"
 
@@ -64,6 +43,20 @@ def test_dataset_optional_properties():
     assert not dataset.deprecated
     assert dataset.sort_order == 0
     assert dataset.validatable == "No"
+
+
+def test_dataset_default_version():
+    """Test the dataset property values."""
+    dataset = Dataset(
+        name="benchmark://test",
+        description="A test dataset",
+        license="MIT",
+        site_data_base="test",
+    )
+
+    assert dataset.name == "benchmark://test"
+    assert dataset.scheme == "benchmark"
+    assert dataset.version == 0
 
 
 def test_dataset_optional_properties_explicit_values():
@@ -90,14 +83,14 @@ def test_dataset_optional_properties_explicit_values():
 def test_dataset_inferred_properties():
     """Test the values of inferred dataset properties."""
     dataset = Dataset(
-        name="benchmark://test-v0",
+        name="benchmark://test-v2",
         description="A test dataset",
         license="MIT",
         site_data_base="test",
     )
 
-    assert dataset.protocol == "benchmark"
-    assert dataset.version == 0
+    assert dataset.scheme == "benchmark"
+    assert dataset.version == 2
 
 
 def test_dataset_properties_read_only(tmpwd: Path):

--- a/tests/datasets/datasets_test.py
+++ b/tests/datasets/datasets_test.py
@@ -3,11 +3,14 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 """Unit tests for //compiler_gym/datasets."""
+from pathlib import Path
+
 import numpy as np
 import pytest
 
 from compiler_gym.datasets.datasets import Datasets, round_robin_iterables
 from compiler_gym.datasets.uri import BenchmarkUri
+from compiler_gym.service.proto import Benchmark as BenchmarkProto
 from tests.test_main import main
 
 pytest_plugins = ["tests.pytest_plugins.common"]
@@ -267,6 +270,43 @@ def test_random_benchmark(mocker, weighted: bool):
     assert da.random_benchmark.call_count == num_benchmarks
     assert len(random_benchmarks) == 1
     assert next(iter(random_benchmarks)) == "benchmark://foo-v0/abc"
+
+
+def test_dataset_proto_scheme(tmpdir):
+    """Test the proto:// scheme handler."""
+    tmpdir = Path(tmpdir)
+    datasets = Datasets(datasets={})
+
+    proto = BenchmarkProto(uri="hello world")
+    with open(tmpdir / "file.pb", "wb") as f:
+        f.write(proto.SerializeToString())
+
+    benchmark = datasets.benchmark(f"proto://{tmpdir}/file.pb")
+
+    assert benchmark.proto.uri == "hello world"
+    assert benchmark.uri == "benchmark://hello world"
+
+
+def test_dataset_proto_scheme_file_not_found(tmpdir):
+    tmpdir = Path(tmpdir)
+    datasets = Datasets(datasets={})
+    with pytest.raises(FileNotFoundError):
+        datasets.benchmark(f"proto://{tmpdir}/not_a_file")
+
+
+def test_dataset_file_scheme(tmpdir):
+    """Test the file:// scheme handler."""
+    tmpdir = Path(tmpdir)
+    datasets = Datasets(datasets={})
+
+    with open(tmpdir / "file.dat", "w") as f:
+        f.write("hello, world")
+
+    benchmark = datasets.benchmark(f"file://{tmpdir}/file.dat")
+
+    assert benchmark.proto.uri == f"file://{tmpdir}/file.dat"
+    assert benchmark.proto.program.contents == b"hello, world"
+    assert benchmark.uri == f"file://{tmpdir}/file.dat"
 
 
 if __name__ == "__main__":

--- a/tests/datasets/datasets_test.py
+++ b/tests/datasets/datasets_test.py
@@ -135,7 +135,7 @@ def test_datasets_get_item():
     assert datasets["benchmark://foo-v0"] == da
 
 
-def test_datasets_get_item_default_protocol():
+def test_datasets_get_item_default_scheme():
     da = MockDataset("benchmark://foo-v0")
     datasets = Datasets([da])
 

--- a/tests/datasets/datasets_test.py
+++ b/tests/datasets/datasets_test.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 
 from compiler_gym.datasets.datasets import Datasets, round_robin_iterables
+from compiler_gym.datasets.uri import BenchmarkUri
 from tests.test_main import main
 
 pytest_plugins = ["tests.pytest_plugins.common"]
@@ -34,11 +35,11 @@ class MockDataset:
     def benchmarks(self):
         yield from self.benchmark_values
 
-    def benchmark(self, uri):
+    def benchmark_from_parsed_uri(self, uri: BenchmarkUri):
         for b in self.benchmark_values:
-            if b.uri == uri:
+            if b.uri == str(uri):
                 return b
-        raise KeyError(uri)
+        raise KeyError(str(uri))
 
     def random_benchmark(self, random_state=None):
         return random_state.choice(self.benchmark_values)

--- a/tests/datasets/uri_test.py
+++ b/tests/datasets/uri_test.py
@@ -1,0 +1,99 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Unit tests for compiler_gym.datasets.uri."""
+from compiler_gym.datasets import BenchmarkUri
+from tests.test_main import main
+
+pytest_plugins = ["tests.pytest_plugins.common"]
+
+
+def test_from_string_1():
+    uri = BenchmarkUri.from_string("benchmark://test-v0")
+    assert uri.scheme == "benchmark"
+    assert uri.dataset == "test-v0"
+    assert uri.path == ""
+    assert uri.params == {}
+    assert uri.fragment == ""
+    assert str(uri) == "benchmark://test-v0"
+
+
+def test_from_string_2():
+    uri = BenchmarkUri.from_string("test-v0")
+    assert uri.scheme == "benchmark"
+    assert uri.dataset == "test-v0"
+    assert uri.path == ""
+    assert uri.params == {}
+    assert uri.fragment == ""
+    assert str(uri) == "benchmark://test-v0"
+
+
+def test_from_string_3():
+    uri = BenchmarkUri.from_string("benchmark://test-v0")
+    assert uri.scheme == "benchmark"
+    assert uri.dataset == "test-v0"
+    assert uri.path == ""
+    assert uri.params == {}
+    assert uri.fragment == ""
+    assert str(uri) == "benchmark://test-v0"
+
+
+def test_from_string_4():
+    uri = BenchmarkUri.from_string(
+        "generator://csmith-v0/this path has whitespace/in/it"
+    )
+    assert uri.scheme == "generator"
+    assert uri.dataset == "csmith-v0"
+    assert uri.path == "/this path has whitespace/in/it"
+    assert uri.params == {}
+    assert uri.fragment == ""
+    assert str(uri) == "generator://csmith-v0/this path has whitespace/in/it"
+
+
+def test_from_string_5():
+    uri = BenchmarkUri.from_string("generator://csmith-v0/0")
+    assert uri.scheme == "generator"
+    assert uri.dataset == "csmith-v0"
+    assert uri.path == "/0"
+    assert uri.params == {}
+    assert uri.fragment == ""
+    assert str(uri) == "generator://csmith-v0/0"
+
+
+def test_from_string_6():
+    uri = BenchmarkUri.from_string("generator://csmith-v0?a=b&c=d#foo")
+    assert uri.scheme == "generator"
+    assert uri.dataset == "csmith-v0"
+    assert uri.path == ""
+    assert uri.params == {"a": ["b"], "c": ["d"]}
+    assert uri.fragment == "foo"
+    assert str(uri) == "generator://csmith-v0?a=b&c=d#foo"
+
+
+def test_from_string_7():
+    uri = BenchmarkUri.from_string("")
+    assert uri.scheme == "benchmark"
+    assert uri.dataset == ""
+    assert uri.path == ""
+    assert uri.params == {}
+    assert uri.fragment == ""
+    assert str(uri) == "benchmark:"
+
+
+def test_from_string_8():
+    uri = BenchmarkUri.from_string("generator:")
+    assert uri.scheme == "generator"
+    assert uri.dataset == ""
+    assert uri.path == ""
+    assert uri.params == {}
+    assert uri.fragment == ""
+    assert str(uri) == "generator:"
+
+
+def test_canonicalize_1():
+    assert BenchmarkUri.canonicalize("test-v0") == "benchmark://test-v0"
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/fuzzing/llvm_commandline_opt_equivalence_fuzz_test.py
+++ b/tests/fuzzing/llvm_commandline_opt_equivalence_fuzz_test.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import pytest
 
 from compiler_gym.envs import LlvmEnv
+from compiler_gym.util.commands import Popen
 from tests.pytest_plugins.random_util import apply_random_trajectory
 from tests.test_main import main
 
@@ -52,19 +53,18 @@ def test_fuzz(env: LlvmEnv, tmpwd: Path, llvm_opt: Path, llvm_diff: Path):
     assert Path("output.ll").is_file()
     os.rename("output.ll", "opt.ll")
 
-    diff = subprocess.Popen(
+    with Popen(
         [llvm_diff, "opt.ll", "env.ll"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         universal_newlines=True,
-    )
-    stdout, stderr = diff.communicate(timeout=300)
-
-    if diff.returncode:
-        pytest.fail(
-            f"Opt produced different output to CompilerGym "
-            f"(returncode: {diff.returncode}):\n{stdout}\n{stderr}"
-        )
+    ) as diff:
+        stdout, stderr = diff.communicate(timeout=300)
+        if diff.returncode:
+            pytest.fail(
+                f"Opt produced different output to CompilerGym "
+                f"(returncode: {diff.returncode}):\n{stdout}\n{stderr}"
+            )
 
 
 if __name__ == "__main__":

--- a/tests/gcc/datasets/csmith_test.py
+++ b/tests/gcc/datasets/csmith_test.py
@@ -43,6 +43,9 @@ def test_csmith_random_select(gcc_bin: str, index: int, tmpwd: Path):
         assert (tmpwd / "source.c").is_file()
 
 
+@pytest.mark.xfail(
+    reason="github.com/facebookresearch/CompilerGym/issues/459",
+)
 @with_gcc_support
 def test_random_benchmark(gcc_bin: str):
     with gym.make("gcc-v0", gcc_bin=gcc_bin) as env:

--- a/tests/gcc/datasets/csmith_test.py
+++ b/tests/gcc/datasets/csmith_test.py
@@ -43,9 +43,6 @@ def test_csmith_random_select(gcc_bin: str, index: int, tmpwd: Path):
         assert (tmpwd / "source.c").is_file()
 
 
-@pytest.mark.xfail(
-    reason="github.com/facebookresearch/CompilerGym/issues/459",
-)
 @with_gcc_support
 def test_random_benchmark(gcc_bin: str):
     with gym.make("gcc-v0", gcc_bin=gcc_bin) as env:

--- a/tests/gcc/gcc_env_test.py
+++ b/tests/gcc/gcc_env_test.py
@@ -14,7 +14,7 @@ from compiler_gym.service import SessionNotFound
 from compiler_gym.service.connection import ServiceError
 from compiler_gym.spaces import Scalar, Sequence
 from tests.pytest_plugins.common import with_docker, without_docker
-from tests.pytest_plugins.gcc import docker_is_available, with_gcc_support
+from tests.pytest_plugins.gcc import with_gcc_support
 from tests.test_main import main
 
 pytest_plugins = ["tests.pytest_plugins.gcc"]
@@ -35,10 +35,6 @@ def test_docker_default_action_space():
         assert env.action_spaces[0].names[0] == "-O0"
 
 
-@pytest.mark.xfail(
-    not docker_is_available(),
-    reason="github.com/facebookresearch/CompilerGym/issues/459",
-)
 def test_gcc_bin(gcc_bin: str):
     """Test that the environment reports the service's reward spaces."""
     with gym.make("gcc-v0", gcc_bin=gcc_bin) as env:
@@ -46,10 +42,6 @@ def test_gcc_bin(gcc_bin: str):
         assert env.gcc_spec.gcc.bin == gcc_bin
 
 
-@pytest.mark.xfail(
-    not docker_is_available(),
-    reason="github.com/facebookresearch/CompilerGym/issues/459",
-)
 def test_observation_spaces_failing_because_of_bug(gcc_bin: str):
     """Test that the environment reports the service's observation spaces."""
     with gym.make("gcc-v0", gcc_bin=gcc_bin) as env:

--- a/tests/gcc/gcc_env_test.py
+++ b/tests/gcc/gcc_env_test.py
@@ -14,7 +14,7 @@ from compiler_gym.service import SessionNotFound
 from compiler_gym.service.connection import ServiceError
 from compiler_gym.spaces import Scalar, Sequence
 from tests.pytest_plugins.common import with_docker, without_docker
-from tests.pytest_plugins.gcc import with_gcc_support
+from tests.pytest_plugins.gcc import docker_is_available, with_gcc_support
 from tests.test_main import main
 
 pytest_plugins = ["tests.pytest_plugins.gcc"]
@@ -35,6 +35,10 @@ def test_docker_default_action_space():
         assert env.action_spaces[0].names[0] == "-O0"
 
 
+@pytest.mark.xfail(
+    not docker_is_available(),
+    reason="github.com/facebookresearch/CompilerGym/issues/459",
+)
 def test_gcc_bin(gcc_bin: str):
     """Test that the environment reports the service's reward spaces."""
     with gym.make("gcc-v0", gcc_bin=gcc_bin) as env:
@@ -42,6 +46,10 @@ def test_gcc_bin(gcc_bin: str):
         assert env.gcc_spec.gcc.bin == gcc_bin
 
 
+@pytest.mark.xfail(
+    not docker_is_available(),
+    reason="github.com/facebookresearch/CompilerGym/issues/459",
+)
 def test_observation_spaces_failing_because_of_bug(gcc_bin: str):
     """Test that the environment reports the service's observation spaces."""
     with gym.make("gcc-v0", gcc_bin=gcc_bin) as env:

--- a/tests/gcc/gcc_env_test.py
+++ b/tests/gcc/gcc_env_test.py
@@ -116,7 +116,9 @@ def test_reward_before_reset(gcc_bin: str):
 def test_reset_invalid_benchmark(gcc_bin: str):
     """Test requesting a specific benchmark."""
     with gym.make("gcc-v0", gcc_bin=gcc_bin) as env:
-        with pytest.raises(LookupError, match=r"'benchmark://chstone-v1"):
+        with pytest.raises(
+            LookupError, match=r"Dataset not found: benchmark://chstone-v1"
+        ):
             env.reset(benchmark="chstone-v1/flubbedydubfishface")
 
 

--- a/tests/llvm/custom_benchmarks_test.py
+++ b/tests/llvm/custom_benchmarks_test.py
@@ -32,7 +32,7 @@ EXAMPLE_BITCODE_IR_INSTRUCTION_COUNT = 242
 def test_reset_invalid_benchmark(env: LlvmEnv):
     invalid_benchmark = "an invalid benchmark"
     with pytest.raises(
-        ValueError, match=f"Invalid benchmark URI: 'benchmark://{invalid_benchmark}'"
+        LookupError, match=f"Dataset not found: benchmark://{invalid_benchmark}"
     ):
         env.reset(benchmark=invalid_benchmark)
 

--- a/tests/llvm/custom_benchmarks_test.py
+++ b/tests/llvm/custom_benchmarks_test.py
@@ -83,10 +83,10 @@ def test_invalid_benchmark_path_contents(env: LlvmEnv):
             env.reset(benchmark=benchmark)
 
 
-def test_benchmark_path_invalid_protocol(env: LlvmEnv):
+def test_benchmark_path_invalid_scheme(env: LlvmEnv):
     benchmark = Benchmark(
         BenchmarkProto(
-            uri="benchmark://new", program=File(uri="invalid_protocol://test")
+            uri="benchmark://new", program=File(uri="invalid_scheme://test")
         ),
     )
 
@@ -94,7 +94,7 @@ def test_benchmark_path_invalid_protocol(env: LlvmEnv):
         ValueError,
         match=(
             "Invalid benchmark data URI. "
-            'Only the file:/// protocol is supported: "invalid_protocol://test"'
+            'Only the file:/// scheme is supported: "invalid_scheme://test"'
         ),
     ):
         env.reset(benchmark=benchmark)

--- a/tests/llvm/custom_benchmarks_test.py
+++ b/tests/llvm/custom_benchmarks_test.py
@@ -12,7 +12,6 @@ import gym
 import pytest
 
 from compiler_gym.datasets import Benchmark
-from compiler_gym.datasets.uri import BENCHMARK_URI_RE
 from compiler_gym.envs import LlvmEnv, llvm
 from compiler_gym.service.proto import Benchmark as BenchmarkProto
 from compiler_gym.service.proto import File
@@ -117,7 +116,8 @@ def test_make_benchmark_single_bitcode(env: LlvmEnv):
     benchmark = llvm.make_benchmark(EXAMPLE_BITCODE_FILE)
 
     assert benchmark == f"benchmark://file-v0{EXAMPLE_BITCODE_FILE}"
-    assert BENCHMARK_URI_RE.match(benchmark.uri)
+    assert benchmark.uri.scheme == "benchmark"
+    assert benchmark.uri.dataset == "file-v0"
 
     with open(EXAMPLE_BITCODE_FILE, "rb") as f:
         contents = f.read()
@@ -134,7 +134,8 @@ def test_make_benchmark_single_ll():
     """Test passing a single .ll file into make_benchmark()."""
     benchmark = llvm.make_benchmark(INVALID_IR_PATH)
     assert benchmark.uri.startswith("benchmark://user-v0/")
-    assert BENCHMARK_URI_RE.match(benchmark.uri)
+    assert benchmark.uri.scheme == "benchmark"
+    assert benchmark.uri.dataset == "user-v0"
 
 
 def test_make_benchmark_single_clang_job(env: LlvmEnv):

--- a/tests/llvm/datasets/cbench_test.py
+++ b/tests/llvm/datasets/cbench_test.py
@@ -84,5 +84,22 @@ def test_cbench_v1_deprecation(env: LlvmEnv):
         env.datasets.benchmark("benchmark://cBench-v1/crc32")
 
 
+def test_cbench_v1_dataset_param(env: LlvmEnv):
+    a = env.datasets.benchmark("cbench-v1/qsort?dataset=0")
+    b = env.datasets.benchmark("cbench-v1/qsort?dataset=0")  # same as a
+    c = env.datasets.benchmark("cbench-v1/qsort?dataset=1")
+
+    assert a.proto.dynamic_config == b.proto.dynamic_config  # sanity check
+    assert a.proto.dynamic_config != c.proto.dynamic_config  # sanity check
+
+
+def test_cbench_v1_dataset_out_of_range(env: LlvmEnv):
+    with pytest.raises(ValueError, match="Invalid dataset: 50"):
+        env.datasets.benchmark("cbench-v1/qsort?dataset=50")
+
+    with pytest.raises(ValueError, match="Invalid dataset: abc"):
+        env.datasets.benchmark("cbench-v1/qsort?dataset=abc")
+
+
 if __name__ == "__main__":
     main()

--- a/tests/llvm/llvm_benchmarks_test.py
+++ b/tests/llvm/llvm_benchmarks_test.py
@@ -17,18 +17,18 @@ from tests.test_main import main
 pytest_plugins = ["tests.pytest_plugins.llvm"]
 
 
-def test_add_benchmark_invalid_protocol(env: CompilerEnv):
+def test_add_benchmark_invalid_scheme(env: CompilerEnv):
     with pytest.raises(ValueError) as ctx:
         env.reset(
             benchmark=Benchmark(
                 BenchmarkProto(
-                    uri="benchmark://foo", program=File(uri="https://invalid/protocol")
+                    uri="benchmark://foo", program=File(uri="https://invalid/scheme")
                 ),
             )
         )
     assert str(ctx.value) == (
         "Invalid benchmark data URI. "
-        'Only the file:/// protocol is supported: "https://invalid/protocol"'
+        'Only the file:/// scheme is supported: "https://invalid/scheme"'
     )
 
 

--- a/tests/util/BUILD
+++ b/tests/util/BUILD
@@ -15,6 +15,15 @@ py_test(
 )
 
 py_test(
+    name = "commands_test",
+    srcs = ["commands_test.py"],
+    deps = [
+        "//compiler_gym/util",
+        "//tests:test_main",
+    ],
+)
+
+py_test(
     name = "debug_util_test",
     srcs = ["debug_util_test.py"],
     deps = [

--- a/tests/util/commands_test.py
+++ b/tests/util/commands_test.py
@@ -1,0 +1,28 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Unit tests for compiler_gym.util.commands."""
+import subprocess
+
+import pytest
+
+from compiler_gym.util.commands import Popen, communicate
+from tests.test_main import main
+
+
+def test_communicate_timeout():
+    with pytest.raises(subprocess.TimeoutExpired):
+        with subprocess.Popen(["sleep", "60"]) as process:
+            communicate(process, timeout=1)
+    assert process.poll() is not None  # Process is dead.
+
+
+def test_popen():
+    with Popen(["echo"]) as process:
+        communicate(process, timeout=60)
+    assert process.poll() is not None  # Process is dead.
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This adds new parsing logic for benchmark URIs that is more robust than the previous regex-based custom parsing, and enables much expressive URIs such as benchmark URIs that contain query parameters or fragment identifiers.

* Adds a new `BenchmarkUri` class. Fixes #524.
* Changes the type of `Benchmark.uri` from string to `BenchmarkUri`.
* Adds a `dataset=num` parameter to the cBench URIs which can be used to specify which of the 20 datasets to run, e.g. `cbench-v1/qsort?dataset=10` or `cbench-v1/gsm?dataset=0`. Fixes #370.
* Audits all uses of `subprocess.Popen()` and `subprocess.communicate()` in the codebase to minimize the risk of resource leakage. Issue #459.