### PR TITLE
Update CMake Instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -98,7 +98,7 @@ Darwin is not supported with CMake.
 ### Dependency instructions for Ubuntu
 
 ```bash
-sudo apt-get install lld-9 \
+sudo apt-get install g++ lld-9 \
   autoconf libtool ninja-build ccache git \
 ```
 
@@ -132,10 +132,13 @@ cmake -GNinja \
   -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \ # For faster rebuilds, can be removed
   -DCMAKE_EXE_LINKER_FLAGS_INIT="-fuse-ld=lld" -DCMAKE_MODULE_LINKER_FLAGS_INIT="-fuse-ld=lld" -DCMAKE_SHARED_LINKER_FLAGS_INIT="-fuse-ld=lld" \ # For faster builds, can be removed
   -DPython3_FIND_VIRTUALENV=FIRST \
+  -DCMAKE_BUILD_WITH_INSTALL_RPATH=true \
   -S "<path to source directory>" \
   -B "<path to build directory>"
 
 cmake  --build "<path to build directory>"
+
+pip install <path to build directory>/py_pkg/dist/compiler_gym*.whl --force-reinstall
 ```
 Additional optional configuration arguments:
 


### PR DESCRIPTION
I followed the CMake instructions on a newly installed Ubuntu virtual machine (using the latest Ubuntu version out there).
This PR has minor changes required for me to get it to work

The main addition I made is the command to install .whl file.
There are also some minor changes that you may feel are not necessary or may break things on other versions of Linux, so I can remove them if you want.

On another note, I feel that the conda environment we create is necessary and shouldn't be removed. At least that what I noticed for both bazel and CMake builds, because we need the libraries installed by the `make init` command to stay in the environment.
(You may have noticed I have added a `--force-reinstall` when installing the .whl file in order to overwrite the public `compiler_gym` library installed by `make init`)