### PR TITLE
Example unrolling service without bazel

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,6 +75,7 @@ jobs:
                       -DCMAKE_SHARED_LINKER_FLAGS_INIT="-fuse-ld=lld" \
                       -DPython3_FIND_VIRTUALENV=FIRST \
                       -DCOMPILER_GYM_BUILD_TESTS=ON \
+                      -DCOMPILER_GYM_BUILD_EXAMPLES=ON \
                       -S . \
                       -B ~/cmake_build
                   cmake --build ~/cmake_build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ list(APPEND CMAKE_MODULE_PATH
 )
 
 set(COMPILER_GYM_BUILD_TESTS OFF CACHE BOOL "Enable Compiler Gym tests.")
+set(COMPILER_GYM_BUILD_EXAMPLES OFF CACHE BOOL "Enable Comiler Gym examples.")
 
 include(cg_macros)
 include(cg_copts)
@@ -65,4 +66,7 @@ add_subdirectory(compiler_gym)
 if(COMPILER_GYM_BUILD_TESTS)
   enable_testing()
   add_subdirectory(tests)
+endif()
+if(COMPILER_GYM_BUILD_EXAMPLES)
+  add_subdirectory(examples)
 endif()

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -145,6 +145,12 @@ Additional optional configuration arguments:
     -DCOMPILER_GYM_BUILD_TESTS=ON
     ```
 
+* Builds additional tools required by some examples.
+
+    ```bash
+    -DCOMPILER_GYM_BUILD_EXAMPLES=ON
+    ```
+
 * For faster linking.
 
     ```bash

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(example_unrolling_service)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,1 +1,6 @@
-add_subdirectory(example_unrolling_service)
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+cg_add_all_subdirs()

--- a/examples/example_unrolling_service/CMakeLists.txt
+++ b/examples/example_unrolling_service/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(loop_unroller)

--- a/examples/example_unrolling_service/CMakeLists.txt
+++ b/examples/example_unrolling_service/CMakeLists.txt
@@ -1,1 +1,6 @@
-add_subdirectory(loop_unroller)
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+cg_add_all_subdirs()

--- a/examples/example_unrolling_service/README.md
+++ b/examples/example_unrolling_service/README.md
@@ -28,3 +28,23 @@ Run `env_tests.py` unit tests:
 ```sh
 $ bazel test //examples/example_unrolling_service:env_tests
 ```
+
+### Using the python service without bazel
+
+Because the python service contains no compiled code, it can be run directly as
+a standalone script without using the bazel build system. From the root of the
+CompilerGym repository,
+
+1. Build the `loop_unroller` custom tool that modifies the unrolling factor of each loop in a LLVM IR file:
+Follow the [Building from source using CMake](../../INSTALL.md#building-from-source-with-cmake) instructions with `-DCOMPILER_GYM_BUILD_EXAMPLES=ON` added to the `cmake` command.
+
+2. Copy the `loop_unroller` binary:
+```sh
+cp <path to build directory>/examples/example_unrolling_service/loop_unroller/loop_unroller ./examples/example_unrolling_service/loop_unroller/
+```
+
+3. Run the example
+```sh
+$ cd examples
+$ python3 example_compiler_gym_service/demo_without_bazel.py
+```

--- a/examples/example_unrolling_service/README.md
+++ b/examples/example_unrolling_service/README.md
@@ -32,18 +32,12 @@ $ bazel test //examples/example_unrolling_service:env_tests
 ### Using the python service without bazel
 
 Because the python service contains no compiled code, it can be run directly as
-a standalone script without using the bazel build system. From the root of the
-CompilerGym repository,
+a standalone script without using the bazel build system.
 
 1. Build the `loop_unroller` custom tool that modifies the unrolling factor of each loop in a LLVM IR file:
 Follow the [Building from source using CMake](../../INSTALL.md#building-from-source-with-cmake) instructions with `-DCOMPILER_GYM_BUILD_EXAMPLES=ON` added to the `cmake` command.
 
-2. Copy the `loop_unroller` binary:
-```sh
-cp <path to build directory>/examples/example_unrolling_service/loop_unroller/loop_unroller ./examples/example_unrolling_service/loop_unroller/
-```
-
-3. Run the example
+2. Run the example
 ```sh
 $ cd examples
 $ python3 example_compiler_gym_service/demo_without_bazel.py

--- a/examples/example_unrolling_service/example.py
+++ b/examples/example_unrolling_service/example.py
@@ -2,7 +2,11 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
+"""This script demonstrates how the example services defined in this directory
+can be used as gym environments. Usage:
 
+    $ bazel run -c opt //examples/example_unrolling_service:example
+"""
 import compiler_gym
 import examples.example_unrolling_service as unrolling_service  # noqa Register environments.
 

--- a/examples/example_unrolling_service/example_without_bazel.py
+++ b/examples/example_unrolling_service/example_without_bazel.py
@@ -1,0 +1,174 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""This module demonstrates how to """
+import os
+import subprocess
+from pathlib import Path
+from typing import Iterable
+
+import compiler_gym
+from compiler_gym.datasets import Benchmark, Dataset
+from compiler_gym.envs.llvm.llvm_benchmark import get_system_includes
+from compiler_gym.spaces import Reward
+from compiler_gym.third_party import llvm
+from compiler_gym.util.registration import register
+
+UNROLLING_PY_SERVICE_BINARY: Path = Path(
+    "example_unrolling_service/service_py/example_service.py"
+)
+assert UNROLLING_PY_SERVICE_BINARY.is_file(), "Service script not found"
+
+BENCHMARKS_PATH: Path = Path("example_unrolling_service/benchmarks")
+
+NEURO_VECTORIZER_HEADER: Path = Path(
+    "../compiler_gym/third_party/neuro-vectorizer/header.h"
+)
+
+
+class RuntimeReward(Reward):
+    """An example reward that uses changes in the "runtime" observation value
+    to compute incremental reward.
+    """
+
+    def __init__(self):
+        super().__init__(
+            id="runtime",
+            observation_spaces=["runtime"],
+            default_value=0,
+            default_negates_returns=True,
+            deterministic=False,
+            platform_dependent=True,
+        )
+        self.baseline_runtime = 0
+
+    def reset(self, benchmark: str, observation_view):
+        del benchmark  # unused
+        self.baseline_runtime = observation_view["runtime"]
+
+    def update(self, action, observations, observation_view):
+        del action  # unused
+        del observation_view  # unused
+        return float(self.baseline_runtime - observations[0]) / self.baseline_runtime
+
+
+class SizeReward(Reward):
+    """An example reward that uses changes in the "size" observation value
+    to compute incremental reward.
+    """
+
+    def __init__(self):
+        super().__init__(
+            id="size",
+            observation_spaces=["size"],
+            default_value=0,
+            default_negates_returns=True,
+            deterministic=False,
+            platform_dependent=True,
+        )
+        self.baseline_size = 0
+
+    def reset(self, benchmark: str, observation_view):
+        del benchmark  # unused
+        self.baseline_runtime = observation_view["size"]
+
+    def update(self, action, observations, observation_view):
+        del action  # unused
+        del observation_view  # unused
+        return float(self.baseline_size - observations[0]) / self.baseline_size
+
+
+class UnrollingDataset(Dataset):
+    def __init__(self, *args, **kwargs):
+        super().__init__(
+            name="benchmark://unrolling-v0",
+            license="MIT",
+            description="Unrolling example dataset",
+        )
+
+        self._benchmarks = {
+            "benchmark://unrolling-v0/offsets1": Benchmark.from_file_contents(
+                "benchmark://unrolling-v0/offsets1",
+                self.preprocess(os.path.join(BENCHMARKS_PATH, "offsets1.c")),
+            ),
+            "benchmark://unrolling-v0/conv2d": Benchmark.from_file_contents(
+                "benchmark://unrolling-v0/conv2d",
+                self.preprocess(os.path.join(BENCHMARKS_PATH, "conv2d.c")),
+            ),
+        }
+
+    @staticmethod
+    def preprocess(src: Path) -> bytes:
+        """Front a C source through the compiler frontend."""
+        # TODO(github.com/facebookresearch/CompilerGym/issues/325): We can skip
+        # this pre-processing, or do it on the service side, once support for
+        # multi-file benchmarks lands.
+        cmd = [
+            str(llvm.clang_path()),
+            "-E",
+            "-o",
+            "-",
+            "-I",
+            str(NEURO_VECTORIZER_HEADER.parent),
+            src,
+        ]
+        for directory in get_system_includes():
+            cmd += ["-isystem", str(directory)]
+        return subprocess.check_output(
+            cmd,
+            timeout=300,
+        )
+
+    def benchmark_uris(self) -> Iterable[str]:
+        yield from self._benchmarks.keys()
+
+    def benchmark(self, uri: str) -> Benchmark:
+        if uri in self._benchmarks:
+            return self._benchmarks[uri]
+        else:
+            raise LookupError("Unknown program name")
+
+
+# Register the unrolling example service on module import. After importing this module,
+# the unrolling-py-v0 environment will be available to gym.make(...).
+
+register(
+    id="unrolling-py-v0",
+    entry_point="compiler_gym.envs:CompilerEnv",
+    kwargs={
+        "service": UNROLLING_PY_SERVICE_BINARY,
+        "rewards": [RuntimeReward(), SizeReward()],
+        "datasets": [UnrollingDataset()],
+    },
+)
+
+env = compiler_gym.make(
+    "unrolling-py-v0",
+    benchmark="unrolling-v0/offsets1",
+    observation_space="features",
+    reward_space="runtime",
+)
+compiler_gym.set_debug_level(4)  # TODO: check why this has no effect
+
+observation = env.reset()
+print("observation: ", observation)
+
+print()
+
+observation, reward, done, info = env.step(env.action_space.sample())
+print("observation: ", observation)
+print("reward: ", reward)
+print("done: ", done)
+print("info: ", info)
+
+print()
+
+observation, reward, done, info = env.step(env.action_space.sample())
+print("observation: ", observation)
+print("reward: ", reward)
+print("done: ", done)
+print("info: ", info)
+
+# TODO: implement write_bitcode(..) or write_ir(..)
+# env.write_bitcode("/tmp/output.bc")

--- a/examples/example_unrolling_service/example_without_bazel.py
+++ b/examples/example_unrolling_service/example_without_bazel.py
@@ -7,10 +7,7 @@ to use the bazel build system.
 
 Prerequisite:
     # In the repo's INSTALL.md, follow the 'Building from source using CMake' instructions with `-DCOMPILER_GYM_BUILD_EXAMPLES=ON` added to the `cmake` command
-    # Then copy the `loop_unroller` binary
     $ cd <path to source directory>/examples
-    $ cp <path to build directory>/examples/example_unrolling_service/loop_unroller/loop_unroller ./example_unrolling_service/loop_unroller/
-
 Usage:
 
     $ python example_unrolling_service/examples_without_bazel.py

--- a/examples/example_unrolling_service/example_without_bazel.py
+++ b/examples/example_unrolling_service/example_without_bazel.py
@@ -2,7 +2,21 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-"""This module demonstrates how to """
+"""This script demonstrates how the Python example service without needing
+to use the bazel build system.
+
+Prerequisite:
+    # In the repo's INSTALL.md, follow the 'Building from source using CMake' instructions with `-DCOMPILER_GYM_BUILD_EXAMPLES=ON` added to the `cmake` command
+    # Then copy the `loop_unroller` binary
+    $ cd <path to source directory>/examples
+    $ cp <path to build directory>/examples/example_unrolling_service/loop_unroller/loop_unroller ./example_unrolling_service/loop_unroller/
+
+Usage:
+
+    $ python example_unrolling_service/examples_without_bazel.py
+
+It is equivalent in behavior to the example.py script in this directory.
+"""
 import os
 import subprocess
 from pathlib import Path

--- a/examples/example_unrolling_service/loop_unroller/CMakeLists.txt
+++ b/examples/example_unrolling_service/loop_unroller/CMakeLists.txt
@@ -1,0 +1,25 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+cg_add_all_subdirs()
+
+
+llvm_map_components_to_libnames(_LLVM_LIBS analysis core irreader support passes)
+cg_cc_binary(
+  NAME
+    loop_unroller
+  SRCS
+    "loop_unroller.cc"
+  COPTS
+    "-Wall"
+    "-fdiagnostics-color=always"
+    "-fno-rtti"
+  ABS_DEPS
+    ${_LLVM_LIBS}
+  INCLUDES
+    ${LLVM_INCLUDE_DIRS}
+  DEFINES
+    ${LLVM_DEFINITIONS}
+)

--- a/examples/example_unrolling_service/loop_unroller/CMakeLists.txt
+++ b/examples/example_unrolling_service/loop_unroller/CMakeLists.txt
@@ -13,8 +13,6 @@ cg_cc_binary(
   SRCS
     "loop_unroller.cc"
   COPTS
-    "-Wall"
-    "-fdiagnostics-color=always"
     "-fno-rtti"
   ABS_DEPS
     ${_LLVM_LIBS}

--- a/examples/example_unrolling_service/loop_unroller/CMakeLists.txt
+++ b/examples/example_unrolling_service/loop_unroller/CMakeLists.txt
@@ -21,3 +21,6 @@ cg_cc_binary(
   DEFINES
     ${LLVM_DEFINITIONS}
 )
+
+ADD_CUSTOM_TARGET(link_target ALL
+                  COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_BINARY_DIR}/examples/example_unrolling_service/loop_unroller/loop_unroller ${CMAKE_SOURCE_DIR}/examples/example_unrolling_service/loop_unroller/loop_unroller)


### PR DESCRIPTION
Here I build the `loop_unroller` tool within the repo's CMake. Do you think it is better to have a separate/isolated build script for it?