### PR TITLE
[examples] Don't pin typing-extensions version.

### DIFF
--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -13,4 +13,3 @@ submitit>=1.2.0
 tensorflow==2.6.1
 torch>=1.6.0
 typer[all]>=0.3.2
-typing-extensions~=3.7.4  # Pin version for tensorflow.


### PR DESCRIPTION
This causes an incompatibility with linters.

Fixes #537.