### PR TITLE
[env] Forbid shallow copy, support deep copy.

### DIFF
--- a/compiler_gym/envs/compiler_env.py
+++ b/compiler_gym/envs/compiler_env.py
@@ -1322,3 +1322,12 @@ class CompilerEnv(gym.Env):
             )
 
         return list(reply.reply)
+
+    def __copy__(self) -> "CompilerEnv":
+        raise TypeError(
+            "CompilerEnv instances do not support shallow copies. Use deepcopy()"
+        )
+
+    def __deepcopy__(self, memo) -> "CompilerEnv":
+        del memo  # unused
+        return self.fork()

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -27,6 +27,16 @@ py_test(
 )
 
 py_test(
+    name = "env_copy_test",
+    srcs = ["env_copy_test.py"],
+    deps = [
+        "//compiler_gym/envs",
+        "//tests:test_main",
+        "//tests/pytest_plugins:llvm",
+    ],
+)
+
+py_test(
     name = "make_test",
     timeout = "short",
     srcs = ["make_test.py"],

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,6 +30,17 @@ cg_py_test(
 
 cg_py_test(
   NAME
+    env_copy_test
+  SRCS
+    "env_copy_test.py"
+  DEPS
+    compiler_gym::envs::envs
+    tests::pytest_plugins::llvm
+    tests::test_main
+)
+
+cg_py_test(
+  NAME
     make_test
   SRCS
     "make_test.py"

--- a/tests/env_copy_test.py
+++ b/tests/env_copy_test.py
@@ -1,0 +1,35 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Tests for the copy() and deepcopy() operators on CompilerEnv."""
+from copy import copy, deepcopy
+
+import pytest
+
+from compiler_gym.envs.llvm import LlvmEnv
+from tests.test_main import main
+
+pytest_plugins = ["tests.pytest_plugins.llvm"]
+
+
+def test_forbidden_shallow_copy(env: LlvmEnv):
+    """Test that shallow copy operator is explicitly forbidden."""
+    with pytest.raises(
+        TypeError,
+        match=r"^CompilerEnv instances do not support shallow copies. Use deepcopy\(\)",
+    ):
+        copy(env)
+
+
+def test_deep_copy(env: LlvmEnv):
+    """Test that deep copy creates an independent copy."""
+    env.reset()
+    with deepcopy(env) as cpy:
+        assert cpy.state == env.state
+        env.step(env.action_space.sample())
+        assert cpy.state != env.state
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This adds support for `deepcopy(env)`, which has identical semantics
to `env.fork()`.

Shallow copies are explicitly disallowed as environments cannot share
state.

Fixes #351.