### PR TITLE
[llvm] Bump ProGraML version to v0.3.2.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -334,9 +334,9 @@ boost_deps()
 
 http_archive(
     name = "programl",
-    sha256 = "c56360aade351eda1c138a594177fcb7cd2cda2a0a6c5c0d9aa62c7f856194bd",
-    strip_prefix = "ProGraML-4f0981d7a0d27aecef3d6e918c886642b231562d",
-    urls = ["https://github.com/ChrisCummins/ProGraML/archive/4f0981d7a0d27aecef3d6e918c886642b231562d.tar.gz"],
+    sha256 = "c4a20b4a2deade7157dcbc56e78a729ad10e40120e4ad4482e2a0b97738dfe84",
+    strip_prefix = "ProGraML-0.3.2",
+    urls = ["https://github.com/ChrisCummins/ProGraML/archive/refs/tags/v0.3.2.tar.gz"],
 )
 
 load("@programl//tools:bzl/deps.bzl", "programl_deps")

--- a/build_tools/cmake/FindProGraML.cmake
+++ b/build_tools/cmake/FindProGraML.cmake
@@ -76,7 +76,7 @@ find_library(
 )
 find_path(
     ProGraML_proto_programl_cc_INCLUDE_DIRS
-    programl/proto/program_graph_options.pb.h
+    programl/proto/program_graph.pb.h
 )
 if(
     ProGraML_proto_programl_cc_LIBRARIES

--- a/compiler_gym/envs/llvm/service/LlvmSession.h
+++ b/compiler_gym/envs/llvm/service/LlvmSession.h
@@ -25,7 +25,7 @@
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"
 #include "llvm/Pass.h"
-#include "programl/proto/program_graph_options.pb.h"
+#include "programl/proto/util.pb.h"
 
 namespace compiler_gym::llvm_service {
 

--- a/external/programl/CMakeLists.txt
+++ b/external/programl/CMakeLists.txt
@@ -19,9 +19,9 @@ externalproject_add(
     programl
     PREFIX "${CMAKE_CURRENT_BINARY_DIR}/programl"
     URL
-        "https://github.com/ChrisCummins/ProGraML/archive/4f0981d7a0d27aecef3d6e918c886642b231562d.tar.gz"
+        "https://github.com/ChrisCummins/ProGraML/archive/refs/tags/v0.3.2.tar.gz"
     URL_HASH
-        "SHA256=c56360aade351eda1c138a594177fcb7cd2cda2a0a6c5c0d9aa62c7f856194bd"
+        "SHA256=c4a20b4a2deade7157dcbc56e78a729ad10e40120e4ad4482e2a0b97738dfe84"
     DOWNLOAD_NO_EXTRACT FALSE
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""


### PR DESCRIPTION
ProGraML v0.3.2 fixes a bug in which the outgoing edge position was 0
for all outgoing edges of a block, regardless of how many unique edges
there are.