### PR TITLE
Rename id attribute for rewards to "name"

### DIFF
--- a/compiler_gym/bin/manual_env.py
+++ b/compiler_gym/bin/manual_env.py
@@ -684,7 +684,7 @@ The 'tutorial' command will give a step by step guide."""
         Tab completion will be used if available.
         """
         if arg == "" and self.env.reward_space:
-            arg = self.env.reward_space.id
+            arg = self.env.reward_space.name
 
         if self.rewards.count(arg):
             with Timer(f"Reward {arg}"):

--- a/compiler_gym/bin/validate.py
+++ b/compiler_gym/bin/validate.py
@@ -169,7 +169,7 @@ def main(argv):
             )
 
         if env.reward_space:
-            reward_name = f"{reward_aggregation_name} {env.reward_space.id}"
+            reward_name = f"{reward_aggregation_name} {env.reward_space.name}"
         else:
             reward_name = ""
 

--- a/compiler_gym/envs/compiler_env.py
+++ b/compiler_gym/envs/compiler_env.py
@@ -485,7 +485,7 @@ class CompilerEnv(gym.Env):
     def reward_space(self, reward_space: Optional[Union[str, Reward]]) -> None:
         # Coerce the observation space into a string.
         reward_space: Optional[str] = (
-            reward_space.id if isinstance(reward_space, Reward) else reward_space
+            reward_space.name if isinstance(reward_space, Reward) else reward_space
         )
 
         if reward_space:
@@ -633,7 +633,7 @@ class CompilerEnv(gym.Env):
         if self.observation_space:
             new_env.observation_space = self.observation_space_spec.id
         if self.reward_space:
-            new_env.reward_space = self.reward_space.id
+            new_env.reward_space = self.reward_space.name
 
         # Copy over the mutable episode state.
         new_env.episode_reward = self.episode_reward

--- a/compiler_gym/envs/gcc/gcc_rewards.py
+++ b/compiler_gym/envs/gcc/gcc_rewards.py
@@ -12,7 +12,7 @@ class AsmSizeReward(Reward):
 
     def __init__(self):
         super().__init__(
-            id="asm_size",
+            name="asm_size",
             observation_spaces=["asm_size"],
             default_value=0,
             default_negates_returns=True,
@@ -43,7 +43,7 @@ class ObjSizeReward(Reward):
 
     def __init__(self):
         super().__init__(
-            id="obj_size",
+            name="obj_size",
             observation_spaces=["obj_size"],
             default_value=0,
             default_negates_returns=True,

--- a/compiler_gym/envs/llvm/llvm_env.py
+++ b/compiler_gym/envs/llvm/llvm_env.py
@@ -77,7 +77,7 @@ class LlvmEnv(CompilerEnv):
             datasets=_get_llvm_datasets(site_data_base=datasets_site_path),
             rewards=[
                 CostFunctionReward(
-                    id="IrInstructionCount",
+                    name="IrInstructionCount",
                     cost_function="IrInstructionCount",
                     init_cost_function="IrInstructionCountO0",
                     default_negates_returns=True,
@@ -85,7 +85,7 @@ class LlvmEnv(CompilerEnv):
                     platform_dependent=False,
                 ),
                 NormalizedReward(
-                    id="IrInstructionCountNorm",
+                    name="IrInstructionCountNorm",
                     cost_function="IrInstructionCount",
                     init_cost_function="IrInstructionCountO0",
                     max=1,
@@ -94,7 +94,7 @@ class LlvmEnv(CompilerEnv):
                     platform_dependent=False,
                 ),
                 BaselineImprovementNormalizedReward(
-                    id="IrInstructionCountO3",
+                    name="IrInstructionCountO3",
                     cost_function="IrInstructionCount",
                     baseline_cost_function="IrInstructionCountO3",
                     init_cost_function="IrInstructionCountO0",
@@ -104,7 +104,7 @@ class LlvmEnv(CompilerEnv):
                     platform_dependent=False,
                 ),
                 BaselineImprovementNormalizedReward(
-                    id="IrInstructionCountOz",
+                    name="IrInstructionCountOz",
                     cost_function="IrInstructionCount",
                     baseline_cost_function="IrInstructionCountOz",
                     init_cost_function="IrInstructionCountO0",
@@ -114,7 +114,7 @@ class LlvmEnv(CompilerEnv):
                     platform_dependent=False,
                 ),
                 CostFunctionReward(
-                    id="ObjectTextSizeBytes",
+                    name="ObjectTextSizeBytes",
                     cost_function="ObjectTextSizeBytes",
                     init_cost_function="ObjectTextSizeO0",
                     default_negates_returns=True,
@@ -122,7 +122,7 @@ class LlvmEnv(CompilerEnv):
                     platform_dependent=True,
                 ),
                 NormalizedReward(
-                    id="ObjectTextSizeNorm",
+                    name="ObjectTextSizeNorm",
                     cost_function="ObjectTextSizeBytes",
                     init_cost_function="ObjectTextSizeO0",
                     max=1,
@@ -131,7 +131,7 @@ class LlvmEnv(CompilerEnv):
                     platform_dependent=True,
                 ),
                 BaselineImprovementNormalizedReward(
-                    id="ObjectTextSizeO3",
+                    name="ObjectTextSizeO3",
                     cost_function="ObjectTextSizeBytes",
                     init_cost_function="ObjectTextSizeO0",
                     baseline_cost_function="ObjectTextSizeO3",
@@ -141,7 +141,7 @@ class LlvmEnv(CompilerEnv):
                     platform_dependent=True,
                 ),
                 BaselineImprovementNormalizedReward(
-                    id="ObjectTextSizeOz",
+                    name="ObjectTextSizeOz",
                     cost_function="ObjectTextSizeBytes",
                     init_cost_function="ObjectTextSizeO0",
                     baseline_cost_function="ObjectTextSizeOz",

--- a/compiler_gym/envs/loop_tool/__init__.py
+++ b/compiler_gym/envs/loop_tool/__init__.py
@@ -25,7 +25,7 @@ class FLOPSReward(Reward):
 
     def __init__(self):
         super().__init__(
-            id="flops",
+            name="flops",
             observation_spaces=["flops"],
             default_value=0,
             default_negates_returns=True,

--- a/compiler_gym/leaderboard/llvm_instcount.py
+++ b/compiler_gym/leaderboard/llvm_instcount.py
@@ -124,7 +124,7 @@ class _EvalPolicyWorker(Thread):
                 ), "Policy changed environment benchmark"
                 assert self.env.reward_space, "Policy unset environment reward space"
                 assert (
-                    self.env.reward_space.id == "IrInstructionCountOz"
+                    self.env.reward_space.name == "IrInstructionCountOz"
                 ), "Policy changed environment reward space"
 
                 # Override walltime in the generated state.

--- a/compiler_gym/random_search.py
+++ b/compiler_gym/random_search.py
@@ -163,7 +163,7 @@ def random_search(
 
         if not env.reward_space:
             raise ValueError("A reward space must be specified for random search")
-        reward_space_name = env.reward_space.id
+        reward_space_name = env.reward_space.name
 
         action_space_names = list(env.action_space.names)
 

--- a/compiler_gym/spaces/reward.py
+++ b/compiler_gym/spaces/reward.py
@@ -27,7 +27,7 @@ class Reward(Scalar):
     """
 
     __slots__ = [
-        "id",
+        "name",
         "observation_spaces",
         "default_value",
         "default_negates_returns",
@@ -38,9 +38,7 @@ class Reward(Scalar):
 
     def __init__(
         self,
-        # TODO(github.com/facebookresearch/CompilerGym/issues/381): Rename `id`
-        # to `name` for consistency with the other space classes.
-        id: str,
+        name: str,
         observation_spaces: Optional[List[str]] = None,
         default_value: RewardType = 0,
         min: Optional[RewardType] = None,
@@ -52,7 +50,7 @@ class Reward(Scalar):
     ):
         """Constructor.
 
-        :param id: The ID of the reward space. This is a unique name used to
+        :param name: The name of the reward space. This is a unique name used to
             represent the reward.
         :param observation_spaces: A list of observation space IDs
             (:class:`space.id <compiler_gym.views.ObservationSpaceSpec>` values)
@@ -79,12 +77,12 @@ class Reward(Scalar):
             execution environment of the service.
         """
         super().__init__(
-            name=id,
+            name=name,
             min=-np.inf if min is None else min,
             max=np.inf if max is None else max,
             dtype=np.float64,
         )
-        self.id = id
+        self.name = name
         self.observation_spaces = observation_spaces or []
         self.default_value: RewardType = default_value
         self.default_negates_returns: bool = default_negates_returns
@@ -142,13 +140,13 @@ class Reward(Scalar):
         return (self.min, self.max)
 
     def __repr__(self):
-        return self.id
+        return self.name
 
     def __eq__(self, other: Union["Reward", str]) -> bool:
         if isinstance(other, str):
-            return self.id == other
+            return self.name == other
         elif isinstance(other, Reward):
-            return self.id == other.id
+            return self.name == other.name
         else:
             return False
 
@@ -156,7 +154,7 @@ class Reward(Scalar):
 class DefaultRewardFromObservation(Reward):
     def __init__(self, observation_name: str, **kwargs):
         super().__init__(
-            observation_spaces=[observation_name], id=observation_name, **kwargs
+            observation_spaces=[observation_name], name=observation_name, **kwargs
         )
         self.previous_value: Optional[ObservationType] = None
 

--- a/compiler_gym/views/reward.py
+++ b/compiler_gym/views/reward.py
@@ -75,14 +75,14 @@ class RewardView:
 
         :param space: The reward space to be added.
         """
-        if space.id in self.spaces:
-            warnings.warn(f"Replacing existing reward space '{space.id}'")
+        if space.name in self.spaces:
+            warnings.warn(f"Replacing existing reward space '{space.name}'")
         self._add_space(space)
 
     def _add_space(self, space: Reward):
         """Register a new space."""
-        self.spaces[space.id] = space
+        self.spaces[space.name] = space
         # Bind a new method to this class that is a callback to compute the
-        # given reward space. E.g. if a new space is added with ID `FooBar`,
+        # given reward space. E.g. if a new space is added with name `FooBar`,
         # this reward can be computed using env.reward.FooBar().
-        setattr(self, space.id, lambda: self[space.id])
+        setattr(self, space.name, lambda: self[space.name])

--- a/compiler_gym/wrappers/llvm.py
+++ b/compiler_gym/wrappers/llvm.py
@@ -32,7 +32,7 @@ class RuntimePointEstimateReward(CompilerEnvWrapper):
             estimator: Callable[[Iterable[float]], float],
         ):
             super().__init__(
-                id="runtime",
+                name="runtime",
                 observation_spaces=["Runtime"],
                 default_value=0,
                 min=None,

--- a/examples/brute_force.py
+++ b/examples/brute_force.py
@@ -178,7 +178,7 @@ def run_brute_force(
 
         if not env.reward_space:
             raise ValueError("A reward space must be specified for random search")
-        reward_space_name = env.reward_space.id
+        reward_space_name = env.reward_space.name
 
         actions = [env.action_space.names.index(a) for a in action_names]
         benchmark_uri = str(env.benchmark)

--- a/examples/example_compiler_gym_service/__init__.py
+++ b/examples/example_compiler_gym_service/__init__.py
@@ -28,7 +28,7 @@ class RuntimeReward(Reward):
 
     def __init__(self):
         super().__init__(
-            id="runtime",
+            name="runtime",
             observation_spaces=["runtime"],
             default_value=0,
             default_negates_returns=True,

--- a/examples/example_compiler_gym_service/demo_without_bazel.py
+++ b/examples/example_compiler_gym_service/demo_without_bazel.py
@@ -34,7 +34,7 @@ class RuntimeReward(Reward):
 
     def __init__(self):
         super().__init__(
-            id="runtime",
+            name="runtime",
             observation_spaces=["runtime"],
             default_value=0,
             default_negates_returns=True,

--- a/examples/example_unrolling_service/__init__.py
+++ b/examples/example_unrolling_service/__init__.py
@@ -33,7 +33,7 @@ class RuntimeReward(Reward):
 
     def __init__(self):
         super().__init__(
-            id="runtime",
+            name="runtime",
             observation_spaces=["runtime"],
             default_value=0,
             default_negates_returns=True,
@@ -59,7 +59,7 @@ class SizeReward(Reward):
 
     def __init__(self):
         super().__init__(
-            id="size",
+            name="size",
             observation_spaces=["size"],
             default_value=0,
             default_negates_returns=True,

--- a/examples/example_unrolling_service/example_without_bazel.py
+++ b/examples/example_unrolling_service/example_without_bazel.py
@@ -45,7 +45,7 @@ class RuntimeReward(Reward):
 
     def __init__(self):
         super().__init__(
-            id="runtime",
+            name="runtime",
             observation_spaces=["runtime"],
             default_value=0,
             default_negates_returns=True,
@@ -71,7 +71,7 @@ class SizeReward(Reward):
 
     def __init__(self):
         super().__init__(
-            id="size",
+            name="size",
             observation_spaces=["size"],
             default_value=0,
             default_negates_returns=True,

--- a/examples/loop_optimizations_service/__init__.py
+++ b/examples/loop_optimizations_service/__init__.py
@@ -32,7 +32,7 @@ class RuntimeReward(Reward):
 
     def __init__(self):
         super().__init__(
-            id="runtime",
+            name="runtime",
             observation_spaces=["runtime"],
             default_value=0,
             default_negates_returns=True,
@@ -58,7 +58,7 @@ class SizeReward(Reward):
 
     def __init__(self):
         super().__init__(
-            id="size",
+            name="size",
             observation_spaces=["size"],
             default_value=0,
             default_negates_returns=True,

--- a/examples/loop_optimizations_service/example_without_bazel.py
+++ b/examples/loop_optimizations_service/example_without_bazel.py
@@ -43,7 +43,7 @@ class RuntimeReward(Reward):
 
     def __init__(self):
         super().__init__(
-            id="runtime",
+            name="runtime",
             observation_spaces=["runtime"],
             default_value=0,
             default_negates_returns=True,
@@ -69,7 +69,7 @@ class SizeReward(Reward):
 
     def __init__(self):
         super().__init__(
-            id="size",
+            name="size",
             observation_spaces=["size"],
             default_value=0,
             default_negates_returns=True,

--- a/tests/compiler_env_test.py
+++ b/tests/compiler_env_test.py
@@ -116,7 +116,7 @@ def test_gym_make_kwargs():
         "llvm-v0", observation_space="Autophase", reward_space="IrInstructionCount"
     ) as env:
         assert env.observation_space_spec.id == "Autophase"
-        assert env.reward_space.id == "IrInstructionCount"
+        assert env.reward_space.name == "IrInstructionCount"
 
 
 def test_step_session_id_not_found(env: LlvmEnv):

--- a/tests/llvm/reward_spaces_test.py
+++ b/tests/llvm/reward_spaces_test.py
@@ -40,7 +40,7 @@ def test_instruction_count_reward(env: LlvmEnv):
 
 def test_reward_space(env: LlvmEnv):
     env.reward_space = "IrInstructionCount"
-    assert env.reward_space.id == "IrInstructionCount"
+    assert env.reward_space.name == "IrInstructionCount"
 
     env.reward_space = None
     assert env.reward_space is None

--- a/tests/views/reward_test.py
+++ b/tests/views/reward_test.py
@@ -10,8 +10,8 @@ from tests.test_main import main
 
 
 class MockReward:
-    def __init__(self, id, ret=None):
-        self.id = id
+    def __init__(self, name, ret=None):
+        self.name = name
         self.ret = list(reversed(ret or []))
         self.observation_spaces = []
 
@@ -33,15 +33,15 @@ def test_empty_space():
 
 
 def test_invalid_reward_name():
-    reward = RewardView([MockReward(id="foo")], MockObservationView())
+    reward = RewardView([MockReward(name="foo")], MockObservationView())
     with pytest.raises(KeyError):
         _ = reward["invalid"]
 
 
 def test_reward_values():
     spaces = [
-        MockReward(id="codesize", ret=[-5]),
-        MockReward(id="runtime", ret=[10]),
+        MockReward(name="codesize", ret=[-5]),
+        MockReward(name="runtime", ret=[10]),
     ]
     reward = RewardView(spaces, MockObservationView())
 
@@ -54,8 +54,8 @@ def test_reward_values():
 
 def test_reward_values_bound_methods():
     spaces = [
-        MockReward(id="codesize", ret=[-5]),
-        MockReward(id="runtime", ret=[10]),
+        MockReward(name="codesize", ret=[-5]),
+        MockReward(name="runtime", ret=[10]),
     ]
     reward = RewardView(spaces, MockObservationView())
 

--- a/tests/wrappers/core_wrappers_test.py
+++ b/tests/wrappers/core_wrappers_test.py
@@ -190,7 +190,7 @@ def test_wrapped_env_changes_default_spaces(env: LlvmEnv, wrapper_type):
     env = MyWrapper(env)
     assert env.observation_space.shape == (56,)
     assert env.observation_space_spec.id == "Autophase"
-    assert env.reward_space.id == "IrInstructionCount"
+    assert env.reward_space.name == "IrInstructionCount"
 
     observation = env.reset()
     assert env.observation_space.contains(observation)
@@ -210,7 +210,7 @@ def test_wrapped_env_change_spaces(env: LlvmEnv, wrapper_type):
 
     assert env.observation_space.shape == (56,)
     assert env.observation_space_spec.id == "Autophase"
-    assert env.reward_space.id == "IrInstructionCount"
+    assert env.reward_space.name == "IrInstructionCount"
 
 
 def test_wrapped_action(env: LlvmEnv):

--- a/tests/wrappers/llvm_test.py
+++ b/tests/wrappers/llvm_test.py
@@ -66,7 +66,7 @@ def test_reward_range_not_runnable_benchmark(env: LlvmEnv):
 def test_fork(env: LlvmEnv):
     env = RuntimePointEstimateReward(env)
     with env.fork() as fkd:
-        assert fkd.reward_space_spec.id == "runtime"
+        assert fkd.reward_space_spec.name == "runtime"
 
 
 @pytest.mark.xfail(


### PR DESCRIPTION
This PR renames the `id` attribute in `Reward` class to `name` to be consistent with other space classes. 

Fixes #381
