### PR TITLE
[service] Loosen gRPC constraints on message sizes.

### DIFF
--- a/compiler_gym/service/connection.py
+++ b/compiler_gym/service/connection.py
@@ -35,8 +35,11 @@ from compiler_gym.util.shell_format import plural
 from compiler_gym.util.truncate import truncate_lines
 
 GRPC_CHANNEL_OPTIONS = [
-    # Raise the default inbound message filter from 4MB.
-    ("grpc.max_receive_message_length", 512 * 1024 * 1024),
+    # Disable the inbound message length filter to allow for large messages such
+    # as observations.
+    ("grpc.max_receive_message_length", -1),
+    # Fix for "received initial metadata size exceeds limit"
+    ("grpc.max_metadata_size", 512 * 1024),
     # Spurious error UNAVAILABLE "Trying to connect an http1.x server".
     # https://putridparrot.com/blog/the-unavailable-trying-to-connect-an-http1-x-server-grpc-error/
     ("grpc.enable_http_proxy", 0),


### PR DESCRIPTION
Remove the size limit on incoming and outgoing messages, and
increase the mazimum allowed metadata message size.

This is all to improve the reliability of the service when working
with particuluarly large programs / observations, that can exceed
the quite tight default resource constraints in gRPC.
