### PR TITLE
🔥🚒🧯 Put out the fire

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -277,7 +277,7 @@ http_archive(
 http_archive(
     name = "csmith",
     build_file_content = all_content,
-    sha256 = "ba871c1e5a05a71ecd1af514fedba30561b16ee80b8dd5ba8f884eaded47009f",
+    sha256 = "86d08c19a1f123054ed9350b7962edaad7d46612de0e07c10b73e578911156fd",
     strip_prefix = "csmith-csmith-2.3.0",
     urls = ["https://github.com/csmith-project/csmith/archive/refs/tags/csmith-2.3.0.tar.gz"],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -279,7 +279,10 @@ http_archive(
     build_file_content = all_content,
     sha256 = "86d08c19a1f123054ed9350b7962edaad7d46612de0e07c10b73e578911156fd",
     strip_prefix = "csmith-csmith-2.3.0",
-    urls = ["https://github.com/csmith-project/csmith/archive/refs/tags/csmith-2.3.0.tar.gz"],
+    urls = [
+        "https://github.com/ChrisCummins/csmith/archive/refs/tags/csmith-2.3.0.tar.gz",
+        "https://github.com/csmith-project/csmith/archive/refs/tags/csmith-2.3.0.tar.gz",
+    ],
 )
 
 # === DeepDataFlow ===

--- a/examples/example_compiler_gym_service/__init__.py
+++ b/examples/example_compiler_gym_service/__init__.py
@@ -74,7 +74,7 @@ class ExampleDataset(Dataset):
 
     def benchmark_from_parsed_uri(self, uri: BenchmarkUri) -> Benchmark:
         if uri.path in self._benchmarks:
-            return self._benchmarks[uri]
+            return self._benchmarks[uri.path]
         else:
             raise LookupError("Unknown program name")
 

--- a/examples/loop_optimizations_service/__init__.py
+++ b/examples/loop_optimizations_service/__init__.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Iterable
 
 from compiler_gym.datasets import Benchmark, Dataset
+from compiler_gym.datasets.uri import BenchmarkUri
 from compiler_gym.envs.llvm.llvm_benchmark import get_system_library_flags
 from compiler_gym.spaces import Reward
 from compiler_gym.third_party import llvm
@@ -86,15 +87,15 @@ class LoopsDataset(Dataset):
         )
 
         self._benchmarks = {
-            "benchmark://loops-opt-v0/add": Benchmark.from_file_contents(
+            "/add": Benchmark.from_file_contents(
                 "benchmark://loops-opt-v0/add",
                 self.preprocess(BENCHMARKS_PATH / "add.c"),
             ),
-            "benchmark://loops-opt-v0/offsets1": Benchmark.from_file_contents(
+            "/offsets1": Benchmark.from_file_contents(
                 "benchmark://loops-opt-v0/offsets1",
                 self.preprocess(BENCHMARKS_PATH / "offsets1.c"),
             ),
-            "benchmark://loops-opt-v0/conv2d": Benchmark.from_file_contents(
+            "/conv2d": Benchmark.from_file_contents(
                 "benchmark://loops-opt-v0/conv2d",
                 self.preprocess(BENCHMARKS_PATH / "conv2d.c"),
             ),
@@ -122,11 +123,11 @@ class LoopsDataset(Dataset):
         )
 
     def benchmark_uris(self) -> Iterable[str]:
-        yield from self._benchmarks.keys()
+        yield from (f"benchmark://loops-opt-v0{k}" for k in self._benchmarks.keys())
 
-    def benchmark(self, uri: str) -> Benchmark:
-        if uri in self._benchmarks:
-            return self._benchmarks[uri]
+    def benchmark_from_parsed_uri(self, uri: BenchmarkUri) -> Benchmark:
+        if uri.path in self._benchmarks:
+            return self._benchmarks[uri.path]
         else:
             raise LookupError("Unknown program name")
 

--- a/tests/llvm/BUILD
+++ b/tests/llvm/BUILD
@@ -233,6 +233,7 @@ py_test(
     deps = [
         "//compiler_gym/envs",
         "//tests:test_main",
+        "//tests/pytest_plugins:common",
         "//tests/pytest_plugins:llvm",
     ],
 )

--- a/tests/llvm/BUILD
+++ b/tests/llvm/BUILD
@@ -177,6 +177,7 @@ py_test(
         "//compiler_gym/envs",
         "//compiler_gym/service/proto",
         "//tests:test_main",
+        "//tests/pytest_plugins:common",
         "//tests/pytest_plugins:llvm",
     ],
 )

--- a/tests/llvm/CMakeLists.txt
+++ b/tests/llvm/CMakeLists.txt
@@ -173,6 +173,7 @@ cg_py_test(
   DEPS
     compiler_gym::envs::envs
     compiler_gym::service::proto::proto
+    tests::pytest_plugins::common
     tests::pytest_plugins::llvm
     tests::test_main
 )

--- a/tests/llvm/CMakeLists.txt
+++ b/tests/llvm/CMakeLists.txt
@@ -231,6 +231,7 @@ cg_py_test(
     "observation_spaces_test.py"
   DEPS
     compiler_gym::envs::envs
+    tests::pytest_plugins::common
     tests::pytest_plugins::llvm
     tests::test_main
 )

--- a/tests/llvm/gym_interface_compatability.py
+++ b/tests/llvm/gym_interface_compatability.py
@@ -12,6 +12,10 @@ pytest_plugins = ["tests.pytest_plugins.llvm"]
 
 
 def test_type_classes(env: LlvmEnv):
+    env.observation_space = "Autophase"
+    env.reward_space = "IrInstructionCount"
+    env.reset()
+
     assert isinstance(env, gym.Env)
     assert isinstance(env, LlvmEnv)
     assert isinstance(env.unwrapped, LlvmEnv)


### PR DESCRIPTION
All CI jobs are failing and building from source, caused by a change in the checksum of the csmith dependency.

As best as I can tell, this checksum change is innocuous. By simply updating the checksum all tests continue to pass. As a precaution I've added a secondary URL for csmith tarballs.

This PR also includes a handful of tiny fixes I found while testing the #590 mitigation using `make test`.

Fixes #590.