### PR TITLE
[cbench] Fix return type of Benchmark.validate().

### DIFF
--- a/compiler_gym/bin/validate.py
+++ b/compiler_gym/bin/validate.py
@@ -207,7 +207,7 @@ def main(argv):
     progress_message(len(states))
     result_dicts = []
 
-    def dump_result_dicst_to_json():
+    def dump_result_dicts_to_json():
         with open(FLAGS.validation_logfile, "w") as f:
             json.dump(result_dicts, f)
 
@@ -223,9 +223,9 @@ def main(argv):
             walltimes.append(result.state.walltime)
 
         if not i % 10:
-            dump_result_dicst_to_json()
+            dump_result_dicts_to_json()
 
-    dump_result_dicst_to_json()
+    dump_result_dicts_to_json()
 
     # Print a summary footer.
     intermediate_print("\r\033[K----", "-" * name_col_width, "-----------", sep="")

--- a/tests/llvm/datasets/cbench_validate_test.py
+++ b/tests/llvm/datasets/cbench_validate_test.py
@@ -3,6 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 """Test for cBench semantics validation."""
+import pytest
+
 from compiler_gym import ValidationResult
 from compiler_gym.envs.llvm import LlvmEnv
 from tests.test_main import main
@@ -10,6 +12,7 @@ from tests.test_main import main
 pytest_plugins = ["tests.pytest_plugins.llvm"]
 
 
+@pytest.mark.timeout(600)
 def test_validate_benchmark_semantics(env: LlvmEnv, validatable_cbench_uri: str):
     """Run the validation routine on all benchmarks."""
     env.reward_space = "IrInstructionCount"
@@ -29,6 +32,7 @@ def test_validate_benchmark_semantics(env: LlvmEnv, validatable_cbench_uri: str)
     assert result.okay()
 
 
+@pytest.mark.timeout(600)
 def test_non_validatable_benchmark_validate(
     env: LlvmEnv, non_validatable_cbench_uri: str
 ):


### PR DESCRIPTION
Fixes a regression in cBench validators. The validator should return an iterable of `ValidationError`, not an `Optional[ValidationError]`. Since I don't have a testcase to cover that, I only discovered the problem by breaking a program.

I should follow up with a new testcase.