### PR TITLE
Fix gRPC header include path.

### DIFF
--- a/compiler_gym/util/GrpcStatusMacros.h
+++ b/compiler_gym/util/GrpcStatusMacros.h
@@ -9,7 +9,7 @@
 #include <boost/current_function.hpp>
 
 #include "glog/logging.h"
-#include "include/grpcpp/grpcpp.h"
+#include "grpcpp/grpcpp.h"
 
 using grpc::Status;
 

--- a/external/external.cmake
+++ b/external/external.cmake
@@ -174,8 +174,6 @@ if(COMPILER_GYM_GRPC_PROVIDER STREQUAL "internal")
   )
   FetchContent_MakeAvailable(grpc)
   set(_GRPC_CPP_PLUGIN_EXECUTABLE $<TARGET_FILE:grpc_cpp_plugin>)
-  #TODO(boian): remove this when GrpcStatusMacros.h uses the correct include path.
-  target_include_directories(grpc++ INTERFACE "${grpc_SOURCE_DIR}")
 else()
   find_package(gRPC REQUIRED)
   set(_GRPC_CPP_PLUGIN_EXECUTABLE $<TARGET_FILE:grpc::grpc_cpp_plugin>)


### PR DESCRIPTION
Strip the `include/` directory prefix.