### PR TITLE
Split CompilerEnv.step() into two methods for singular or lists of actions

### DIFF
--- a/compiler_gym/bin/service.py
+++ b/compiler_gym/bin/service.py
@@ -105,7 +105,7 @@ from absl import app, flags
 from compiler_gym.datasets import Dataset
 from compiler_gym.envs import CompilerEnv
 from compiler_gym.service.connection import ConnectionOpts
-from compiler_gym.spaces import Commandline
+from compiler_gym.spaces import Commandline, NamedDiscrete
 from compiler_gym.util.flags.env_from_flags import env_from_flags
 from compiler_gym.util.tabulate import tabulate
 from compiler_gym.util.truncate import truncate
@@ -249,12 +249,13 @@ def print_service_capabilities(env: CompilerEnv):
                 ],
                 headers=("Action", "Description"),
             )
-        else:
+            print(table)
+        elif isinstance(action_space, NamedDiscrete):
             table = tabulate(
                 [(a,) for a in sorted(action_space.names)],
                 headers=("Action",),
             )
-        print(table)
+            print(table)
 
 
 def main(argv):

--- a/compiler_gym/envs/compiler_env.py
+++ b/compiler_gym/envs/compiler_env.py
@@ -1022,7 +1022,7 @@ class CompilerEnv(gym.Env):
 
         return observations, rewards, reply.end_of_session, info
 
-    def step(
+    def step(  # pylint: disable=arguments-differ
         self,
         action: Union[ActionType, Iterable[ActionType]],
         observations: Optional[Iterable[Union[str, ObservationSpaceSpec]]] = None,

--- a/compiler_gym/envs/compiler_env.py
+++ b/compiler_gym/envs/compiler_env.py
@@ -11,7 +11,7 @@ from copy import deepcopy
 from math import isclose
 from pathlib import Path
 from time import time
-from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
 
 import gym
 import numpy as np
@@ -128,7 +128,7 @@ class CompilerEnv(gym.Env):
     :ivar actions: The list of actions that have been performed since the
         previous call to :func:`reset`.
 
-    :vartype actions: List[int]
+    :vartype actions: List[ActionType]
 
     :ivar reward_range: A tuple indicating the range of reward values. Default
         range is (-inf, +inf).
@@ -321,7 +321,7 @@ class CompilerEnv(gym.Env):
         self.reward_range: Tuple[float, float] = (-np.inf, np.inf)
         self.episode_reward: Optional[float] = None
         self.episode_start_time: float = time()
-        self.actions: List[int] = []
+        self.actions: List[ActionType] = []
 
         # Initialize the default observation/reward spaces.
         self.observation_space_spec: Optional[ObservationSpaceSpec] = None
@@ -375,7 +375,7 @@ class CompilerEnv(gym.Env):
         """
         raise NotImplementedError("abstract method")
 
-    def commandline_to_actions(self, commandline: str) -> List[int]:
+    def commandline_to_actions(self, commandline: str) -> List[ActionType]:
         """Interface for :class:`CompilerEnv <compiler_gym.envs.CompilerEnv>`
         subclasses to convert from a commandline invocation to a sequence of
         actions.
@@ -409,7 +409,7 @@ class CompilerEnv(gym.Env):
         )
 
     @property
-    def action_space(self) -> NamedDiscrete:
+    def action_space(self) -> Space:
         """The current action space.
 
         :getter: Get the current action space.
@@ -587,7 +587,7 @@ class CompilerEnv(gym.Env):
             self.reset()
             if actions:
                 logger.warning("Parent service of fork() has died, replaying state")
-                _, _, done, _ = self.step(actions)
+                _, _, done, _ = self.multistep(actions)
                 assert not done, "Failed to replay action sequence"
 
         request = ForkSessionRequest(session_id=self._session_id)
@@ -620,7 +620,7 @@ class CompilerEnv(gym.Env):
             # replay the state.
             new_env = type(self)(**self._init_kwargs())
             new_env.reset()
-            _, _, done, _ = new_env.step(self.actions)
+            _, _, done, _ = new_env.multistep(self.actions)
             assert not done, "Failed to replay action sequence in forked environment"
 
         # Create copies of the mutable reward and observation spaces. This
@@ -878,9 +878,9 @@ class CompilerEnv(gym.Env):
 
     def raw_step(
         self,
-        actions: Iterable[int],
-        observations: Iterable[ObservationSpaceSpec],
-        rewards: Iterable[Reward],
+        actions: Iterable[ActionType],
+        observation_spaces: List[ObservationSpaceSpec],
+        reward_spaces: List[Reward],
     ) -> StepType:
         """Take a step.
 
@@ -901,17 +901,14 @@ class CompilerEnv(gym.Env):
 
         .. warning::
 
-            Prefer :meth:`step() <compiler_gym.envs.CompilerEnv.step>` to
-            :meth:`raw_step() <compiler_gym.envs.CompilerEnv.step>`.
-            :meth:`step() <compiler_gym.envs.CompilerEnv.step>` has equivalent
-            functionality, and is less likely to change in the future.
+            Don't call this method directly, use :meth:`step()
+            <compiler_gym.envs.CompilerEnv.step>` or :meth:`multistep()
+            <compiler_gym.envs.CompilerEnv.multistep>` instead. The
+            :meth:`raw_step() <compiler_gym.envs.CompilerEnv.step>` method is an
+            implementation detail.
         """
         if not self.in_episode:
             raise SessionNotFound("Must call reset() before step()")
-
-        # Build the list of observations that must be computed by the backend
-        user_observation_spaces: List[ObservationSpaceSpec] = list(observations)
-        reward_spaces: List[Reward] = list(rewards)
 
         reward_observation_spaces: List[ObservationSpaceSpec] = []
         for reward_space in reward_spaces:
@@ -920,7 +917,7 @@ class CompilerEnv(gym.Env):
             ]
 
         observations_to_compute: List[ObservationSpaceSpec] = list(
-            set(user_observation_spaces).union(set(reward_observation_spaces))
+            set(observation_spaces).union(set(reward_observation_spaces))
         )
         observation_space_index_map: Dict[ObservationSpaceSpec, int] = {
             observation_space: i
@@ -967,7 +964,7 @@ class CompilerEnv(gym.Env):
 
             default_observations = [
                 observation_space.default_value
-                for observation_space in user_observation_spaces
+                for observation_space in observation_spaces
             ]
             default_rewards = [
                 float(reward_space.reward_on_error(self.episode_reward))
@@ -995,7 +992,7 @@ class CompilerEnv(gym.Env):
         # Get the user-requested observation.
         observations: List[ObservationType] = [
             computed_observations[observation_space_index_map[observation_space]]
-            for observation_space in user_observation_spaces
+            for observation_space in observation_spaces
         ]
 
         # Update and compute the rewards.
@@ -1025,22 +1022,22 @@ class CompilerEnv(gym.Env):
     def step(  # pylint: disable=arguments-differ
         self,
         action: ActionType,
+        observation_spaces: Optional[Iterable[Union[str, ObservationSpaceSpec]]] = None,
+        reward_spaces: Optional[Iterable[Union[str, Reward]]] = None,
         observations: Optional[Iterable[Union[str, ObservationSpaceSpec]]] = None,
         rewards: Optional[Iterable[Union[str, Reward]]] = None,
     ) -> StepType:
         """Take a step.
 
-        :param action: An action, or a sequence of actions. When multiple
-            actions are provided the observation and reward are returned after
-            running all of the actions.
+        :param action: An action.
 
-        :param observations: A list of observation spaces to compute
+        :param observation_spaces: A list of observation spaces to compute
             observations from. If provided, this changes the :code:`observation`
             element of the return tuple to be a list of observations from the
             requested spaces. The default :code:`env.observation_space` is not
             returned.
 
-        :param rewards: A list of reward spaces to compute rewards from. If
+        :param reward_spaces: A list of reward spaces to compute rewards from. If
             provided, this changes the :code:`reward` element of the return
             tuple to be a list of rewards from the requested spaces. The default
             :code:`env.reward_space` is not returned.
@@ -1051,22 +1048,42 @@ class CompilerEnv(gym.Env):
         :raises SessionNotFound: If :meth:`reset()
             <compiler_gym.envs.CompilerEnv.reset>` has not been called.
         """
-        # NOTE(github.com/facebookresearch/CompilerGym/issues/610): This
-        # workaround for accepting a list of actions will be removed in v0.2.4.
         if isinstance(action, IterableType):
             warnings.warn(
-                "env.step() only takes a single action. Use env.multistep() "
-                "for an iterable of actions",
+                "Argument `action` of CompilerEnv.step no longer accepts a list "
+                " of actions. Please use CompilerEnv.multistep instead",
                 category=DeprecationWarning,
             )
-        else:
-            action = [action]
-
-        return self.multistep(action, observations, rewards)
+            return self.multistep(
+                action,
+                observation_spaces=observation_spaces,
+                reward_spaces=reward_spaces,
+                observations=observations,
+                rewards=rewards,
+            )
+        if observations is not None:
+            warnings.warn(
+                "Argument `observations` of CompilerEnv.step has been "
+                "renamed `observation_spaces`. Please update your code",
+                category=DeprecationWarning,
+            )
+            observation_spaces = observations
+        if rewards is not None:
+            warnings.warn(
+                "Argument `rewards` of CompilerEnv.step has been renamed "
+                "`reward_spaces`. Please update your code",
+                category=DeprecationWarning,
+            )
+            reward_spaces = rewards
+        return self._multistep(
+            self.raw_step, [action], observation_spaces, reward_spaces
+        )
 
     def multistep(
         self,
         actions: Iterable[ActionType],
+        observation_spaces: Optional[Iterable[Union[str, ObservationSpaceSpec]]] = None,
+        reward_spaces: Optional[Iterable[Union[str, Reward]]] = None,
         observations: Optional[Iterable[Union[str, ObservationSpaceSpec]]] = None,
         rewards: Optional[Iterable[Union[str, Reward]]] = None,
     ):
@@ -1074,13 +1091,13 @@ class CompilerEnv(gym.Env):
 
         :param action: A sequence of actions to apply in order.
 
-        :param observations: A list of observation spaces to compute
+        :param observation_spaces: A list of observation spaces to compute
             observations from. If provided, this changes the :code:`observation`
             element of the return tuple to be a list of observations from the
             requested spaces. The default :code:`env.observation_space` is not
             returned.
 
-        :param rewards: A list of reward spaces to compute rewards from. If
+        :param reward_spaces: A list of reward spaces to compute rewards from. If
             provided, this changes the :code:`reward` element of the return
             tuple to be a list of rewards from the requested spaces. The default
             :code:`env.reward_space` is not returned.
@@ -1091,49 +1108,77 @@ class CompilerEnv(gym.Env):
         :raises SessionNotFound: If :meth:`reset()
             <compiler_gym.envs.CompilerEnv.reset>` has not been called.
         """
+        if observations is not None:
+            warnings.warn(
+                "Argument `observations` of CompilerEnv.multistep has been "
+                "renamed `observation_spaces`. Please update your code",
+                category=DeprecationWarning,
+            )
+            observation_spaces = observations
+        if rewards is not None:
+            warnings.warn(
+                "Argument `rewards` of CompilerEnv.multistep has been renamed "
+                "`reward_spaces`. Please update your code",
+                category=DeprecationWarning,
+            )
+            reward_spaces = rewards
+        return self._multistep(
+            self.raw_step, list(actions), observation_spaces, reward_spaces
+        )
+
+    def _multistep(
+        self,
+        raw_step: Callable[
+            [Iterable[ActionType], Iterable[ObservationSpaceSpec], Iterable[Reward]],
+            StepType,
+        ],
+        actions: Iterable[ActionType],
+        observation_spaces: Optional[Iterable[Union[str, ObservationSpaceSpec]]],
+        reward_spaces: Optional[Iterable[Union[str, Reward]]],
+    ) -> StepType:
         # Coerce observation spaces into a list of ObservationSpaceSpec instances.
-        if observations:
-            observation_spaces: List[ObservationSpaceSpec] = [
+        if observation_spaces:
+            observation_spaces_to_compute: List[ObservationSpaceSpec] = [
                 obs
                 if isinstance(obs, ObservationSpaceSpec)
                 else self.observation.spaces[obs]
-                for obs in observations
+                for obs in observation_spaces
             ]
         elif self.observation_space_spec:
-            observation_spaces: List[ObservationSpaceSpec] = [
+            observation_spaces_to_compute: List[ObservationSpaceSpec] = [
                 self.observation_space_spec
             ]
         else:
-            observation_spaces: List[ObservationSpaceSpec] = []
+            observation_spaces_to_compute: List[ObservationSpaceSpec] = []
 
         # Coerce reward spaces into a list of Reward instances.
-        if rewards:
-            reward_spaces: List[Reward] = [
+        if reward_spaces:
+            reward_spaces_to_compute: List[Reward] = [
                 rew if isinstance(rew, Reward) else self.reward.spaces[rew]
-                for rew in rewards
+                for rew in reward_spaces
             ]
         elif self.reward_space:
-            reward_spaces: List[Reward] = [self.reward_space]
+            reward_spaces_to_compute: List[Reward] = [self.reward_space]
         else:
-            reward_spaces: List[Reward] = []
+            reward_spaces_to_compute: List[Reward] = []
 
         # Perform the underlying environment step.
-        observation_values, reward_values, done, info = self.raw_step(
-            actions, observation_spaces, reward_spaces
+        observation_values, reward_values, done, info = raw_step(
+            actions, observation_spaces_to_compute, reward_spaces_to_compute
         )
 
         # Translate observations lists back to the appropriate types.
-        if observations is None and self.observation_space_spec:
+        if observation_spaces is None and self.observation_space_spec:
             observation_values = observation_values[0]
-        elif not observation_spaces:
+        elif not observation_spaces_to_compute:
             observation_values = None
 
         # Translate reward lists back to the appropriate types.
-        if rewards is None and self.reward_space:
+        if reward_spaces is None and self.reward_space:
             reward_values = reward_values[0]
             # Update the cumulative episode reward
             self.episode_reward += reward_values
-        elif not reward_spaces:
+        elif not reward_spaces_to_compute:
             reward_values = None
 
         return observation_values, reward_values, done, info
@@ -1206,7 +1251,9 @@ class CompilerEnv(gym.Env):
             )
 
         actions = self.commandline_to_actions(state.commandline)
-        _, _, done, info = self.step(actions)
+        done = False
+        for action in actions:
+            _, _, done, info = self.step(action)
         if done:
             raise ValueError(
                 f"Environment terminated with error: `{info.get('error_details')}`"

--- a/compiler_gym/envs/llvm/llvm_rewards.py
+++ b/compiler_gym/envs/llvm/llvm_rewards.py
@@ -7,7 +7,7 @@ from typing import List, Optional
 
 from compiler_gym.datasets import Benchmark
 from compiler_gym.spaces.reward import Reward
-from compiler_gym.util.gym_type_hints import ObservationType, RewardType
+from compiler_gym.util.gym_type_hints import ActionType, ObservationType, RewardType
 from compiler_gym.views.observation import ObservationView
 
 
@@ -44,7 +44,7 @@ class CostFunctionReward(Reward):
 
     def update(
         self,
-        actions: List[int],
+        actions: List[ActionType],
         observations: List[ObservationType],
         observation_view: ObservationView,
     ) -> RewardType:
@@ -81,7 +81,7 @@ class NormalizedReward(CostFunctionReward):
 
     def update(
         self,
-        actions: List[int],
+        actions: List[ActionType],
         observations: List[ObservationType],
         observation_view: ObservationView,
     ) -> RewardType:

--- a/compiler_gym/random_replay.py
+++ b/compiler_gym/random_replay.py
@@ -15,7 +15,7 @@ from compiler_gym.random_search import (
 )
 
 
-@deprecated(version="0.2.1", reason="Use env.step(actions) instead")
+@deprecated(version="0.2.1", reason="Use env.step(action) instead")
 def replay_actions(env: CompilerEnv, action_names: List[str], outdir: Path):
     return replay_actions_(env, action_names, outdir)
 

--- a/compiler_gym/random_search.py
+++ b/compiler_gym/random_search.py
@@ -17,6 +17,7 @@ from compiler_gym.envs import CompilerEnv
 from compiler_gym.envs.llvm import LlvmEnv
 from compiler_gym.service.connection import ServiceError
 from compiler_gym.util import logs
+from compiler_gym.util.gym_type_hints import ActionType
 from compiler_gym.util.logs import create_logging_dir
 from compiler_gym.util.tabulate import tabulate
 
@@ -79,8 +80,8 @@ class RandomAgentWorker(Thread):
         self.total_episode_count = 0
         self.total_step_count = 0
         self.best_returns = -float("inf")
-        self.best_actions: List[int] = []
-        self.best_commandline: List[int] = []
+        self.best_actions: List[ActionType] = []
+        self.best_commandline: str = []
         self.best_found_at_time = time()
 
         self.alive = True  # Set this to False to signal the thread to stop.
@@ -112,17 +113,17 @@ class RandomAgentWorker(Thread):
         :return: True if the episode ended gracefully, else False.
         """
         observation = env.reset()
-        actions: List[int] = []
+        actions: List[ActionType] = []
         patience = self._patience
         total_returns = 0
         while patience >= 0:
             patience -= 1
             self.total_step_count += 1
             # === Your agent here! ===
-            action_index = env.action_space.sample()
+            action = env.action_space.sample()
             # === End of agent. ===
-            actions.append(action_index)
-            observation, reward, done, _ = env.step(action_index)
+            actions.append(action)
+            observation, reward, done, _ = env.step(action)
             if done:
                 return False
             total_returns += reward

--- a/compiler_gym/spaces/named_discrete.py
+++ b/compiler_gym/spaces/named_discrete.py
@@ -2,9 +2,11 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
+from collections.abc import Iterable as IterableType
 from typing import Iterable, List, Union
 
 from compiler_gym.spaces.discrete import Discrete
+from compiler_gym.util.gym_type_hints import ActionType
 
 
 class NamedDiscrete(Discrete):
@@ -51,18 +53,20 @@ class NamedDiscrete(Discrete):
     def __repr__(self) -> str:
         return f"NamedDiscrete([{', '.join(self.names)}])"
 
-    def to_string(self, values: Union[int, Iterable[int]]) -> str:
+    def to_string(self, values: Union[int, Iterable[ActionType]]) -> str:
         """Convert an action, or sequence of actions, to string.
 
         :param values: A numeric value, or list of numeric values.
         :return: A string representing the values.
         """
-        if isinstance(values, int):
-            return self.names[values]
-        else:
+        if isinstance(values, IterableType):
             return " ".join([self.names[v] for v in values])
+        else:
+            return self.names[values]
 
-    def from_string(self, values: Union[str, Iterable[str]]) -> Union[int, List[int]]:
+    def from_string(
+        self, values: Union[str, Iterable[str]]
+    ) -> Union[ActionType, List[ActionType]]:
         """Convert a name, or list of names, to numeric values.
 
         :param values: A name, or list of names.

--- a/compiler_gym/spaces/reward.py
+++ b/compiler_gym/spaces/reward.py
@@ -8,7 +8,7 @@ import numpy as np
 
 import compiler_gym
 from compiler_gym.spaces.scalar import Scalar
-from compiler_gym.util.gym_type_hints import ObservationType, RewardType
+from compiler_gym.util.gym_type_hints import ActionType, ObservationType, RewardType
 
 
 class Reward(Scalar):
@@ -104,7 +104,7 @@ class Reward(Scalar):
 
     def update(
         self,
-        actions: List[int],
+        actions: List[ActionType],
         observations: List[ObservationType],
         observation_view: "compiler_gym.views.ObservationView",  # noqa: F821
     ) -> RewardType:

--- a/compiler_gym/util/gym_type_hints.py
+++ b/compiler_gym/util/gym_type_hints.py
@@ -9,7 +9,7 @@ JsonDictType = Dict[str, Any]
 
 # Type hints for the values returned by gym.Env.step().
 ObservationType = TypeVar("ObservationType")
-ActionType = int
+ActionType = TypeVar("ActionType")
 RewardType = float
 DoneType = bool
 InfoType = JsonDictType

--- a/compiler_gym/util/minimize_trajectory.py
+++ b/compiler_gym/util/minimize_trajectory.py
@@ -41,7 +41,7 @@ def _apply_and_test(env, actions, hypothesis, flakiness) -> bool:
     env.reset(benchmark=env.benchmark)
     for _ in range(flakiness):
         logger.debug("Applying %d actions ...", len(actions))
-        _, _, done, info = env.step(actions)
+        _, _, done, info = env.multistep(actions)
         if done:
             raise MinimizationError(
                 f"Failed to replay actions: {info.get('error_details', '')}"

--- a/compiler_gym/views/observation.py
+++ b/compiler_gym/views/observation.py
@@ -67,7 +67,7 @@ class ObservationView:
         """
         observation_space: ObservationSpaceSpec = self.spaces[observation_space]
         observations, _, done, info = self._raw_step(
-            actions=[], observations=[observation_space], rewards=[]
+            actions=[], observation_spaces=[observation_space], reward_spaces=[]
         )
 
         if done:

--- a/compiler_gym/wrappers/llvm.py
+++ b/compiler_gym/wrappers/llvm.py
@@ -11,7 +11,7 @@ from compiler_gym.datasets.benchmark import BenchmarkInitError
 from compiler_gym.envs.llvm import LlvmEnv
 from compiler_gym.service.connection import ServiceError
 from compiler_gym.spaces import Reward
-from compiler_gym.util.gym_type_hints import ObservationType
+from compiler_gym.util.gym_type_hints import ActionType, ObservationType
 from compiler_gym.wrappers import CompilerEnvWrapper
 
 
@@ -65,7 +65,7 @@ class RuntimePointEstimateReward(CompilerEnvWrapper):
 
         def update(
             self,
-            actions: List[int],
+            actions: List[ActionType],
             observations: List[ObservationType],
             observation_view,
         ) -> float:

--- a/compiler_gym/wrappers/time_limit.py
+++ b/compiler_gym/wrappers/time_limit.py
@@ -2,9 +2,10 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-from typing import Iterable, Optional, Union
+from typing import Optional
 
 from compiler_gym.envs import CompilerEnv
+from compiler_gym.util.gym_type_hints import ActionType
 from compiler_gym.wrappers.core import CompilerEnvWrapper
 
 
@@ -31,7 +32,7 @@ class TimeLimit(CompilerEnvWrapper):
         self._max_episode_steps = max_episode_steps
         self._elapsed_steps = None
 
-    def step(self, action: Union[int, Iterable[int]], **kwargs):
+    def step(self, action: ActionType, **kwargs):
         assert (
             self._elapsed_steps is not None
         ), "Cannot call env.step() before calling reset()"

--- a/compiler_gym/wrappers/validation.py
+++ b/compiler_gym/wrappers/validation.py
@@ -2,7 +2,10 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
+from typing import List
+
 from compiler_gym.envs import CompilerEnv
+from compiler_gym.util.gym_type_hints import ActionType
 from compiler_gym.wrappers.core import CompilerEnvWrapper
 
 
@@ -26,9 +29,16 @@ class ValidateBenchmarkAfterEveryStep(CompilerEnvWrapper):
         super().__init__(env)
         self.reward_penalty = reward_penalty
 
-    def step(self, action, observations=None, rewards=None):
-        observation, reward, done, info = self.env.step(
-            action, observations=observations, rewards=rewards
+    def raw_step(
+        self,
+        actions: List[ActionType],
+        observation_spaces=None,
+        reward_spaces=None,
+    ):
+        observation, reward, done, info = self.env.raw_step(
+            actions,
+            observation_spaces=observation_spaces,
+            reward_spaces=reward_spaces,
         )
 
         # Early exit if environment reaches terminal state.

--- a/examples/brute_force.py
+++ b/examples/brute_force.py
@@ -42,6 +42,7 @@ import compiler_gym.util.flags.output_dir  # noqa Flag definition.
 from compiler_gym.envs import CompilerEnv
 from compiler_gym.util.flags.benchmark_from_flags import benchmark_from_flags
 from compiler_gym.util.flags.env_from_flags import env_from_flags
+from compiler_gym.util.gym_type_hints import ActionType
 from compiler_gym.util.logs import create_logging_dir
 
 flags.DEFINE_list(
@@ -68,7 +69,7 @@ class BruteForceProducer(Thread):
     def __init__(
         self,
         in_q: Queue,
-        actions: List[int],
+        actions: List[ActionType],
         episode_length: int,
         nproc: int,
         chunksize: int = 128,

--- a/examples/llvm_autotuning/autotuners/nevergrad_.py
+++ b/examples/llvm_autotuning/autotuners/nevergrad_.py
@@ -10,6 +10,7 @@ import nevergrad as ng
 from llvm_autotuning.optimization_target import OptimizationTarget
 
 from compiler_gym.envs import CompilerEnv
+from compiler_gym.util.gym_type_hints import ActionType
 
 
 def nevergrad(
@@ -30,17 +31,17 @@ def nevergrad(
     """
     if optimization_target == OptimizationTarget.RUNTIME:
 
-        def calculate_negative_reward(actions: Tuple[int]) -> float:
+        def calculate_negative_reward(actions: Tuple[ActionType]) -> float:
             env.reset()
-            env.step(actions)
+            env.multistep(actions)
             return -env.episode_reward
 
     else:
         # Only cache the deterministic non-runtime rewards.
         @lru_cache(maxsize=int(1e4))
-        def calculate_negative_reward(actions: Tuple[int]) -> float:
+        def calculate_negative_reward(actions: Tuple[ActionType]) -> float:
             env.reset()
-            env.step(actions)
+            env.multistep(actions)
             return -env.episode_reward
 
     params = ng.p.Choice(
@@ -61,4 +62,4 @@ def nevergrad(
     # Get best solution and replay it.
     recommendation = optimizer.provide_recommendation()
     env.reset()
-    env.step(recommendation.value)
+    env.multistep(recommendation.value)

--- a/examples/llvm_autotuning/optimization_target.py
+++ b/examples/llvm_autotuning/optimization_target.py
@@ -68,7 +68,7 @@ class OptimizationTarget(str, Enum):
         actions = list(env.actions)
         env.reset()
         for i in range(1, 5 + 1):
-            _, _, done, info = env.step(actions)
+            _, _, done, info = env.multistep(actions)
             if not done:
                 break
             logger.warning(

--- a/examples/llvm_rl/wrappers.py
+++ b/examples/llvm_rl/wrappers.py
@@ -3,13 +3,13 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 """Environment wrappers to closer replicate the MLSys'20 Autophase paper."""
-from collections.abc import Iterable as IterableType
-from typing import List, Union
+from typing import List
 
 import gym
 import numpy as np
 
 from compiler_gym.envs import CompilerEnv, LlvmEnv
+from compiler_gym.util.gym_type_hints import ActionType
 from compiler_gym.wrappers import (
     ConstrainedCommandline,
     ObservationWrapper,
@@ -126,12 +126,16 @@ class ConcatActionsHistogram(ObservationWrapper):
         )
         return super().reset(*args, **kwargs)
 
-    def step(self, action: Union[int, List[int]], observations=None, **kwargs):
-        if not isinstance(action, IterableType):
-            action = [action]
-        for a in action:
+    def raw_step(
+        self,
+        actions: List[ActionType],
+        observation_spaces=None,
+        observations=None,
+        **kwargs,
+    ):
+        for a in actions:
             self.histogram[a] += self.increment
-        return super().step(action, **kwargs)
+        return self.env.raw_step(actions, **kwargs)
 
     def observation(self, observation):
         return np.concatenate((observation, self.histogram)).astype(

--- a/examples/sensitivity_analysis/action_sensitivity_analysis.py
+++ b/examples/sensitivity_analysis/action_sensitivity_analysis.py
@@ -40,6 +40,7 @@ from sensitivity_analysis.sensitivity_analysis_eval import (
 from compiler_gym.envs import CompilerEnv
 from compiler_gym.util.flags.benchmark_from_flags import benchmark_from_flags
 from compiler_gym.util.flags.env_from_flags import env_from_flags
+from compiler_gym.util.gym_type_hints import ActionType
 from compiler_gym.util.logs import create_logging_dir
 from compiler_gym.util.timer import Timer
 
@@ -118,12 +119,12 @@ def run_one_trial(
     _, _, done, _ = env.step(warmup_actions)
     if done:
         return None
-    _, (reward,), done, _ = env.step(action, rewards=[reward_space])
+    _, (reward,), done, _ = env.step(action, reward_spaces=[reward_space])
     return None if done else reward
 
 
 def run_action_sensitivity_analysis(
-    actions: List[int],
+    actions: List[ActionType],
     rewards_path: Path,
     runtimes_path: Path,
     reward_space: str,

--- a/tests/llvm/episode_reward_test.py
+++ b/tests/llvm/episode_reward_test.py
@@ -28,7 +28,7 @@ def test_episode_reward_with_non_default_reward_space(env: LlvmEnv):
     assert env.episode_reward == 0
     _, rewards, _, _ = env.step(
         env.action_space["-mem2reg"],
-        rewards=["IrInstructionCount"],
+        reward_spaces=["IrInstructionCount"],
     )
     assert rewards[0] > 0
     assert env.episode_reward == 0

--- a/tests/llvm/fork_regression_test.py
+++ b/tests/llvm/fork_regression_test.py
@@ -57,14 +57,14 @@ def test_fork_regression_test(env: LlvmEnv, test: ForkRegressionTest):
     pre_fork = [env.action_space[f] for f in test.pre_fork.split()]
     post_fork = [env.action_space[f] for f in test.post_fork.split()]
 
-    _, _, done, info = env.step(pre_fork)
+    _, _, done, info = env.multistep(pre_fork)
     assert not done, info
 
     with env.fork() as fkd:
         assert env.state == fkd.state  # Sanity check
 
-        env.step(post_fork)
-        fkd.step(post_fork)
+        env.multistep(post_fork)
+        fkd.multistep(post_fork)
         # Verify that the environment states no longer line up.
         assert env.state != fkd.state
 

--- a/tests/llvm/llvm_env_test.py
+++ b/tests/llvm/llvm_env_test.py
@@ -221,7 +221,7 @@ def test_step_multiple_actions_list(env: LlvmEnv):
         env.action_space.flags.index("-mem2reg"),
         env.action_space.flags.index("-reg2mem"),
     ]
-    _, _, done, _ = env.step(actions)
+    _, _, done, _ = env.multistep(actions)
     assert not done
     assert env.actions == actions
 
@@ -233,7 +233,7 @@ def test_step_multiple_actions_generator(env: LlvmEnv):
         env.action_space.flags.index("-mem2reg"),
         env.action_space.flags.index("-reg2mem"),
     )
-    _, _, done, _ = env.step(actions)
+    _, _, done, _ = env.multistep(actions)
     assert not done
     assert env.actions == [
         env.action_space.flags.index("-mem2reg"),

--- a/tests/llvm/multiprocessing_test.py
+++ b/tests/llvm/multiprocessing_test.py
@@ -12,11 +12,14 @@ import pytest
 from flaky import flaky
 
 from compiler_gym.envs import LlvmEnv
+from compiler_gym.util.gym_type_hints import ActionType
 from tests.pytest_plugins.common import macos_only
 from tests.test_main import main
 
 
-def process_worker(env_name: str, benchmark: str, actions: List[int], queue: mp.Queue):
+def process_worker(
+    env_name: str, benchmark: str, actions: List[ActionType], queue: mp.Queue
+):
     assert actions
     with gym.make(env_name) as env:
         env.reset(benchmark=benchmark)
@@ -28,7 +31,7 @@ def process_worker(env_name: str, benchmark: str, actions: List[int], queue: mp.
         queue.put((observation, reward, done, info))
 
 
-def process_worker_with_env(env: LlvmEnv, actions: List[int], queue: mp.Queue):
+def process_worker_with_env(env: LlvmEnv, actions: List[ActionType], queue: mp.Queue):
     assert actions
 
     for action in actions:

--- a/tests/llvm/threading_test.py
+++ b/tests/llvm/threading_test.py
@@ -10,13 +10,14 @@ import gym
 from flaky import flaky
 
 from compiler_gym import CompilerEnv
+from compiler_gym.util.gym_type_hints import ActionType
 from tests.test_main import main
 
 
 class ThreadedWorker(Thread):
     """Create an environment and run through a set of actions in a background thread."""
 
-    def __init__(self, env_name: str, benchmark: str, actions: List[int]):
+    def __init__(self, env_name: str, benchmark: str, actions: List[ActionType]):
         super().__init__()
         self.done = False
         self.env_name = env_name
@@ -38,7 +39,7 @@ class ThreadedWorker(Thread):
 class ThreadedWorkerWithEnv(Thread):
     """Create an environment and run through a set of actions in a background thread."""
 
-    def __init__(self, env: CompilerEnv, actions: List[int]):
+    def __init__(self, env: CompilerEnv, actions: List[ActionType]):
         super().__init__()
         self.done = False
         self.env = env

--- a/tests/util/minimize_trajectory_test.py
+++ b/tests/util/minimize_trajectory_test.py
@@ -10,6 +10,7 @@ from typing import List
 import pytest
 
 from compiler_gym.util import minimize_trajectory as mt
+from compiler_gym.util.gym_type_hints import ActionType
 from tests.test_main import main
 
 pytest_plugins = ["tests.pytest_plugins.llvm"]
@@ -38,7 +39,7 @@ class MockValidationResult:
 class MockEnv:
     """A mock environment for testing trajectory minimization."""
 
-    def __init__(self, actions: List[int], validate=lambda env: True):
+    def __init__(self, actions: List[ActionType], validate=lambda env: True):
         self.original_trajectory = actions
         self.actions = actions.copy()
         self.validate = lambda: MockValidationResult(validate(self))
@@ -49,7 +50,7 @@ class MockEnv:
         self.actions = []
         assert benchmark == self.benchmark
 
-    def step(self, actions):
+    def multistep(self, actions):
         for action in actions:
             assert action in self.original_trajectory
         self.actions += actions

--- a/tests/views/observation_test.py
+++ b/tests/views/observation_test.py
@@ -28,11 +28,11 @@ class MockRawStep:
         self.called_observation_spaces = []
         self.ret = list(reversed(ret or [None]))
 
-    def __call__(self, actions, observations, rewards):
+    def __call__(self, actions, observation_spaces, reward_spaces):
         assert not actions
-        assert len(observations) == 1
-        assert not rewards
-        self.called_observation_spaces.append(observations[0].id)
+        assert len(observation_spaces) == 1
+        assert not reward_spaces
+        self.called_observation_spaces.append(observation_spaces[0].id)
         ret = self.ret[-1]
         del self.ret[-1]
         return [ret], [], False, {}

--- a/tests/wrappers/time_limit_wrappers_test.py
+++ b/tests/wrappers/time_limit_wrappers_test.py
@@ -28,7 +28,7 @@ def test_wrapped_fork_type(env: LlvmEnv):
 def test_wrapped_step_multi_step(env: LlvmEnv):
     env = TimeLimit(env, max_episode_steps=5)
     env.reset(benchmark="benchmark://cbench-v1/dijkstra")
-    env.step([0, 0, 0])
+    env.multistep([0, 0, 0])
 
     assert env.benchmark == "benchmark://cbench-v1/dijkstra"
     assert env.actions == [0, 0, 0]
@@ -37,7 +37,7 @@ def test_wrapped_step_multi_step(env: LlvmEnv):
 def test_wrapped_custom_step_args(env: LlvmEnv):
     env = TimeLimit(env, max_episode_steps=5)
     env.reset(benchmark="benchmark://cbench-v1/dijkstra")
-    (ic,), _, _, _ = env.step(0, observations=["IrInstructionCount"])
+    (ic,), _, _, _ = env.step(0, observation_spaces=["IrInstructionCount"])
     assert isinstance(ic, int)
 
 

--- a/www/www.py
+++ b/www/www.py
@@ -217,9 +217,9 @@ def _step(request: StepRequest) -> StepReply:
         if request.all_states:
             # Replay actions one at a time to receive incremental rewards. The
             # first item represents the state prior to any actions.
-            (instcount, autophase), _, done, info = env.step(
-                action=[],
-                observations=[
+            (instcount, autophase), _, done, info = env.raw_step(
+                actions=[],
+                observation_spaces=[
                     env.observation.spaces["InstCountDict"],
                     env.observation.spaces["AutophaseDict"],
                 ],
@@ -238,7 +238,7 @@ def _step(request: StepRequest) -> StepReply:
             for action in request.actions[:-1]:
                 (instcount, autophase), reward, done, info = env.step(
                     action,
-                    observations=[
+                    observation_spaces=[
                         env.observation.spaces["InstCountDict"],
                         env.observation.spaces["AutophaseDict"],
                     ],
@@ -265,12 +265,12 @@ def _step(request: StepRequest) -> StepReply:
         # Perform the final action.
         (ir, instcount, autophase), (reward,), done, _ = env.raw_step(
             actions=request.actions[-1:],
-            observations=[
+            observation_spaces=[
                 env.observation.spaces["Ir"],
                 env.observation.spaces["InstCountDict"],
                 env.observation.spaces["AutophaseDict"],
             ],
-            rewards=[env.reward_space],
+            reward_spaces=[env.reward_space],
         )
 
     states.append(


### PR DESCRIPTION
`CompilerEnv.step()` currently accepts two types for the "action" argument:

(1) a scalar action:

```py
>>> env.step(action)
```

(2) an iterable of actions:

```py
>>> env.step([action1, action2])
```

This PR splits this overloaded behavior into two methods: `CompilerEnv.step()` only takes a single action, and `CompilerEnv.multistep()` only takes an iterable sequence of actions:

```py
>>> env.step(action)
>>> env.multistep([action1, action2])
```

For now, calling `CompilerEnv.step()` with a list of actions still works, though with a deprecation warning. In the v0.2.4 release support for lists of actions in `CompilerEnv.step()` will be removed.

## Benefits

Passing a list of actions to execute in a single step enables them to be executed in a single RPC invocation, significantly reducing the overhead of round trips to the backend, and removing the need to calculate observation/rewards for each individual step. We measured speedups of ~3x on typical LLVM workloads using this (more details [here](https://arxiv.org/pdf/2109.08267.pdf)).

## Drawbacks

Adding a new method means we probably need to refactor all step wrappers to overload the `multistep()` wrappers, as otherwise this could be missed:

```py
class MyStepWrapper(Wrapper):
  def step(action):
    # .. my overload

env = MyStepWrapper(env)
env.multistep(actions)   # oh no! Not using the overload
```

Instead, we can require that wrappers that wish to change the behavior of an environments step function override the `raw_step()` method, as that method is the common denominator between `step()` and `multistep()`, and also has a tighter function signature with less room for mixing and matching different arg types.

Fixes #610.