### PR TITLE
Add backwards compatibility for Reward.id.

### DIFF
--- a/tests/spaces/BUILD
+++ b/tests/spaces/BUILD
@@ -25,6 +25,16 @@ py_test(
 )
 
 py_test(
+    name = "reward_test",
+    timeout = "short",
+    srcs = ["reward_test.py"],
+    deps = [
+        "//compiler_gym/spaces",
+        "//tests:test_main",
+    ],
+)
+
+py_test(
     name = "scalar_test",
     timeout = "short",
     srcs = ["scalar_test.py"],

--- a/tests/spaces/CMakeLists.txt
+++ b/tests/spaces/CMakeLists.txt
@@ -27,6 +27,16 @@ cg_py_test(
 
 cg_py_test(
   NAME
+    reward_test
+  SRCS
+    "reward_test.py"
+  DEPS
+    compiler_gym::spaces::spaces
+    tests::test_main
+)
+
+cg_py_test(
+  NAME
     scalar_test
   SRCS
     "scalar_test.py"

--- a/tests/spaces/reward_test.py
+++ b/tests/spaces/reward_test.py
@@ -1,0 +1,25 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Unit tests for compiler_gym.spaces.Reward."""
+import pytest
+
+from compiler_gym.spaces import Reward
+from tests.test_main import main
+
+
+def test_reward_id_backwards_compatibility():
+    """Test that Reward.id is backwards compatible with Reward.name.
+
+    See: github.com/facebookresearch/CompilerGym/issues/381
+    """
+    with pytest.warns(DeprecationWarning, match="renamed `name`"):
+        reward = Reward(id="foo")
+
+    assert reward.id == "foo"
+    assert reward.name == "foo"
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
We don't want the change introduced in #565 to immediately break
existing user code. Instead, add a workaround that emits a deprecation
warning so that users can update their code upon the next release.

Issue #381.