### PR TITLE
Build system tweaks patchset

### DIFF
--- a/.github/actions/install-cmake-build-dependencies/action.yaml
+++ b/.github/actions/install-cmake-build-dependencies/action.yaml
@@ -9,8 +9,7 @@ runs:
         - name: Install CMake dependencies
           run: |
               if [ "$(uname)" = "Darwin" ]; then
-                  echo "CMake build for Darwin is unimplemented."
-                  exit 1
+                  brew install bazelisk ccache cmake zlib
               else
                   # Compiler
                   sudo apt-get install clang++-9 lld-9 tar bzip2 ninja-build

--- a/.github/actions/install-cmake-build-dependencies/action.yaml
+++ b/.github/actions/install-cmake-build-dependencies/action.yaml
@@ -12,8 +12,10 @@ runs:
                   brew install bazelisk ccache cmake zlib
               else
                   # Compiler
-                  sudo apt-get install clang++-9 lld-9 tar bzip2 ninja-build
-                  sudo apt-get install tar bzip2 ninja-build
+                  sudo apt-get install -y bzip2 clang-9 clang++-9 lld-9 tar bzip2 ninja-build tar ninja-build
+                  sudo ln -s $(which clang++-9) /usr/bin/clang++
+                  sudo ln -s $(which clang-9) /usr/bin/clang
+                  sudo ln -s $(which lld-9) /usr/bin/lld
                   # CMake
                   wget https://github.com/Kitware/CMake/releases/download/v3.20.5/cmake-3.20.5-linux-x86_64.sh -O /tmp/cmake.sh
                   sudo bash /tmp/cmake.sh --prefix=/usr/local --exclude-subdir --skip-license

--- a/.github/actions/install-cmake-build-dependencies/action.yaml
+++ b/.github/actions/install-cmake-build-dependencies/action.yaml
@@ -13,9 +13,6 @@ runs:
               else
                   # Compiler
                   sudo apt-get install -y bzip2 clang-9 clang++-9 lld-9 tar bzip2 ninja-build tar ninja-build
-                  sudo ln -s $(which clang++-9) /usr/bin/clang++
-                  sudo ln -s $(which clang-9) /usr/bin/clang
-                  sudo ln -s $(which lld-9) /usr/bin/lld
                   # CMake
                   wget https://github.com/Kitware/CMake/releases/download/v3.20.5/cmake-3.20.5-linux-x86_64.sh -O /tmp/cmake.sh
                   sudo bash /tmp/cmake.sh --prefix=/usr/local --exclude-subdir --skip-license

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -363,42 +363,6 @@ jobs:
         needs: build-macos
         runs-on: macos-latest
         steps:
-            - uses: docker-practice/actions-setup-docker@master
-
-            - name: Confirm docker install
-              run: docker version
-
-            - uses: actions/checkout@v2
-
-            - name: Set up Python
-              uses: actions/setup-python@v2
-              with:
-                  python-version: 3.9
-
-            - name: Download Python wheel
-              uses: actions/download-artifact@v2
-              with:
-                  name: macos-wheel
-
-            - name: Install wheel
-              run: python -m pip install *.whl
-
-            - name: Install runtime dependencies
-              uses: ./.github/actions/install-runtime-dependencies
-
-            - name: Install test dependencies
-              run: python -m pip install -r tests/requirements.txt
-
-            - name: Run the test suite
-              run: make install-test-cov TEST_TARGET="tests/gcc"
-
-            - name: Upload coverage report to Codecov
-              uses: codecov/codecov-action@v2
-
-    test-gcc-env-macos-no-docker:
-        needs: build-macos
-        runs-on: macos-latest
-        steps:
             - uses: actions/checkout@v2
 
             - name: Set up Python
@@ -461,11 +425,6 @@ jobs:
         needs: build-macos
         runs-on: macos-latest
         steps:
-            - uses: docker-practice/actions-setup-docker@master
-
-            - name: Confirm docker install
-              run: docker version
-
             - uses: actions/checkout@v2
 
             - name: Set up Python

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,8 +56,8 @@ jobs:
               run: |
                   cmake \
                       -GNinja \
-                      -DCMAKE_C_COMPILER=clang-9 \
-                      -DCMAKE_CXX_COMPILER=clang++-9 \
+                      -DCMAKE_C_COMPILER=clang \
+                      -DCMAKE_CXX_COMPILER=clang++ \
                       -DCMAKE_EXE_LINKER_FLAGS_INIT="-fuse-ld=lld" \
                       -DCMAKE_MODULE_LINKER_FLAGS_INIT="-fuse-ld=lld" \
                       -DCMAKE_SHARED_LINKER_FLAGS_INIT="-fuse-ld=lld" \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,6 +52,19 @@ jobs:
             - name: Install build dependencies
               uses: ./.github/actions/install-cmake-build-dependencies
 
+            - name: Download LLVM 10.0.0 release
+              run: |
+                  if [ "$(uname)" = "Darwin" ]; then
+                    wget https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/clang+llvm-10.0.0-x86_64-apple-darwin.tar.xz -O ~/llvm.tar.xz
+                  else
+                    wget https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/clang+llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz -O ~/llvm.tar.xz
+                  fi
+                  # TODO(cummins): Remove 'v' debugging flag:
+                  mkdir ~/llvm && tar xvf ~/llvm.tar.xz --strip-components 1 -C ~/llvm
+                  rm ~/llvm.tar.xz
+                  echo "Unpacked, testing for expected file:"
+                  test -d ~/llvm/lib/cmake/llvm
+
             - name: CMake Build
               run: |
                   cmake \
@@ -61,6 +74,8 @@ jobs:
                       -DCMAKE_EXE_LINKER_FLAGS_INIT="-fuse-ld=lld" \
                       -DCMAKE_MODULE_LINKER_FLAGS_INIT="-fuse-ld=lld" \
                       -DCMAKE_SHARED_LINKER_FLAGS_INIT="-fuse-ld=lld" \
+                      -DCOMPILER_GYM_LLVM_PROVIDER=external \
+                      -DLLVM_DIR=$HOME/llvm/lib/cmake/llvm \
                       -DPython3_FIND_VIRTUALENV=FIRST \
                       -DCOMPILER_GYM_BUILD_TESTS=ON \
                       -DCOMPILER_GYM_BUILD_EXAMPLES=ON \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,8 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_CURRENT_BINARY_DIR)
     )
 endif()
 
+include(build_tools/cmake/FindAndEnableCcache.cmake)
+
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     set(DARWIN TRUE)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,8 +12,6 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_CURRENT_BINARY_DIR)
     )
 endif()
 
-include(build_tools/cmake/FindAndEnableCcache.cmake)
-
 project(compiler_gym ASM C CXX)
 
 set(CMAKE_C_STANDARD 11 CACHE STRING "C standard to be used.")
@@ -21,25 +19,27 @@ set(CMAKE_CXX_STANDARD 17 CACHE STRING "C++ standard to be used.")
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
-list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/build_tools/cmake/)
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/build_tools/cmake)
 
+# Project features.
 set(COMPILER_GYM_BUILD_TESTS OFF CACHE BOOL "Enable Compiler Gym tests.")
 set(COMPILER_GYM_BUILD_EXAMPLES OFF CACHE BOOL "Enable Comiler Gym examples.")
 
-include(cg_macros)
-include(cg_copts)
-include(cg_genrule)
-include(cg_cc_binary)
-include(cg_cc_library)
-include(cg_cc_test)
-include(cg_py_binary)
-include(cg_py_library)
-include(cg_py_test)
-include(cg_python)
-include(cg_add_all_subdirs)
-include(cg_filegroup)
-include(grpc)
-include(protobuf)
+include(build_tools/cmake/FindAndEnableCcache.cmake)
+include(build_tools/cmake/cg_macros.cmake)
+include(build_tools/cmake/cg_copts.cmake)
+include(build_tools/cmake/cg_genrule.cmake)
+include(build_tools/cmake/cg_cc_binary.cmake)
+include(build_tools/cmake/cg_cc_library.cmake)
+include(build_tools/cmake/cg_cc_test.cmake)
+include(build_tools/cmake/cg_py_binary.cmake)
+include(build_tools/cmake/cg_py_library.cmake)
+include(build_tools/cmake/cg_py_test.cmake)
+include(build_tools/cmake/cg_python.cmake)
+include(build_tools/cmake/cg_add_all_subdirs.cmake)
+include(build_tools/cmake/cg_filegroup.cmake)
+include(build_tools/cmake/grpc.cmake)
+include(build_tools/cmake/protobuf.cmake)
 
 set(COMPILER_GYM_PYTHONPATH "$ENV{PYTHONPATH}"
     CACHE STRING "PYTHONPATH environment variable during build step."
@@ -48,7 +48,7 @@ if(COMPILER_GYM_PYTHONPATH)
     string(PREPEND COMPILER_GYM_PYTHONPATH ":")
 endif()
 string(PREPEND COMPILER_GYM_PYTHONPATH "${CMAKE_BINARY_DIR}")
-include(set_command_pythonpath)
+include(build_tools/cmake/set_command_pythonpath.cmake)
 
 set(DEFAULT_CMAKE_BUILD_TYPE "Release")
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
@@ -67,11 +67,14 @@ set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
 find_package(Python3 REQUIRED COMPONENTS Interpreter)
 
 include(external/external.cmake)
+
 add_subdirectory(compiler_gym)
+
 if(COMPILER_GYM_BUILD_TESTS)
     enable_testing()
     add_subdirectory(tests)
 endif()
+
 if(COMPILER_GYM_BUILD_EXAMPLES)
     add_subdirectory(examples)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,10 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/build_tools/cmake)
 set(COMPILER_GYM_BUILD_TESTS OFF CACHE BOOL "Enable Compiler Gym tests.")
 set(COMPILER_GYM_BUILD_EXAMPLES OFF CACHE BOOL "Enable Comiler Gym examples.")
 
+# Toolchain configuration.
 include(build_tools/cmake/FindAndEnableCcache.cmake)
+include(build_tools/cmake/FindAndEnableLld.cmake)
+
 include(build_tools/cmake/cg_macros.cmake)
 include(build_tools/cmake/cg_copts.cmake)
 include(build_tools/cmake/cg_genrule.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,13 +44,14 @@ include(build_tools/cmake/cg_filegroup.cmake)
 include(build_tools/cmake/grpc.cmake)
 include(build_tools/cmake/protobuf.cmake)
 
-set(COMPILER_GYM_PYTHONPATH "$ENV{PYTHONPATH}"
+# Set up the build Python path.
+set(COMPILER_GYM_BUILD_PYTHONPATH "$ENV{PYTHONPATH}"
     CACHE STRING "PYTHONPATH environment variable during build step."
 )
-if(COMPILER_GYM_PYTHONPATH)
-    string(PREPEND COMPILER_GYM_PYTHONPATH ":")
+if(COMPILER_GYM_BUILD_PYTHONPATH)
+    string(PREPEND COMPILER_GYM_BUILD_PYTHONPATH ":")
 endif()
-string(PREPEND COMPILER_GYM_PYTHONPATH "${CMAKE_BINARY_DIR}")
+string(PREPEND COMPILER_GYM_BUILD_PYTHONPATH "${CMAKE_BINARY_DIR}")
 include(build_tools/cmake/set_command_pythonpath.cmake)
 
 set(DEFAULT_CMAKE_BUILD_TYPE "Release")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,6 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     set(DARWIN TRUE)
 endif()
 
-set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-
 project(compiler_gym ASM C CXX)
 
 set(CMAKE_C_STANDARD 11 CACHE STRING "C standard to be used.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,10 +14,6 @@ endif()
 
 include(build_tools/cmake/FindAndEnableCcache.cmake)
 
-if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-    set(DARWIN TRUE)
-endif()
-
 project(compiler_gym ASM C CXX)
 
 set(CMAKE_C_STANDARD 11 CACHE STRING "C standard to be used.")

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -122,6 +122,7 @@ By default most dependencies are built together with Compiler Gym. To search for
 * `COMPILER_GYM_GLOG_PROVIDER`
 * `COMPILER_GYM_GRPC_PROVIDER`
 * `COMPILER_GYM_GTEST_PROVIDER`
+* `COMPILER_GYM_LLVM_PROVIDER`
 * `COMPILER_GYM_NLOHMANN_JSON_PROVIDER`
 * `COMPILER_GYM_PROTOBUF_PROVIDER`
 
@@ -134,10 +135,11 @@ cmake \
   -S "<path to source directory>" \
   -B "<path to build directory>"
 
-cmake  --build "<path to build directory>"
+cmake --build "<path to build directory>"
 
 pip install <path to build directory>/py_pkg/dist/compiler_gym*.whl --force-reinstall
 ```
+
 Additional optional configuration arguments:
 
 * Enables testing.
@@ -166,3 +168,18 @@ Additional optional configuration arguments:
     -DCMAKE_C_COMPILER_LAUNCHER=ccache
     -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
     ```
+
+By default, CompilerGym builds LLVM from source. This takes a long time and a
+lot of compute resources. To prevent this, download a pre-compiled clang+llvm
+release of LLVM 10.0.0 from the [llvm-project releases
+page](https://github.com/llvm/llvm-project/releases/tag/llvmorg-10.0.0), unpack
+it, and pass path of the `lib/cmake/llvm` subdirectory in the archive you just
+extracted to `LLVM_DIR`:
+
+```
+$ cmake ... \
+    -DCOMPILER_GYM_LLVM_PROVIDER=external \
+    -DLLVM_DIR=/path/to/llvm/lib/cmake/llvm
+```
+
+⚠️ CompilerGym requires exactly LLVM 10.0.0.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -129,7 +129,6 @@ By default most dependencies are built together with Compiler Gym. To search for
 cmake -GNinja \
   -DCMAKE_C_COMPILER=clang-9 \
   -DCMAKE_CXX_COMPILER=clang++-9 \
-  -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \ # For faster rebuilds, can be removed
   -DCMAKE_EXE_LINKER_FLAGS_INIT="-fuse-ld=lld" -DCMAKE_MODULE_LINKER_FLAGS_INIT="-fuse-ld=lld" -DCMAKE_SHARED_LINKER_FLAGS_INIT="-fuse-ld=lld" \ # For faster builds, can be removed
   -DPython3_FIND_VIRTUALENV=FIRST \
   -DCMAKE_BUILD_WITH_INSTALL_RPATH=true \

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -126,7 +126,7 @@ By default most dependencies are built together with Compiler Gym. To search for
 * `COMPILER_GYM_PROTOBUF_PROVIDER`
 
 ```bash
-cmake -GNinja \
+cmake \
   -DCMAKE_C_COMPILER=clang-9 \
   -DCMAKE_CXX_COMPILER=clang++-9 \
   -DCMAKE_EXE_LINKER_FLAGS_INIT="-fuse-ld=lld" -DCMAKE_MODULE_LINKER_FLAGS_INIT="-fuse-ld=lld" -DCMAKE_SHARED_LINKER_FLAGS_INIT="-fuse-ld=lld" \ # For faster builds, can be removed

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -129,7 +129,6 @@ By default most dependencies are built together with Compiler Gym. To search for
 cmake \
   -DCMAKE_C_COMPILER=clang-9 \
   -DCMAKE_CXX_COMPILER=clang++-9 \
-  -DCMAKE_EXE_LINKER_FLAGS_INIT="-fuse-ld=lld" -DCMAKE_MODULE_LINKER_FLAGS_INIT="-fuse-ld=lld" -DCMAKE_SHARED_LINKER_FLAGS_INIT="-fuse-ld=lld" \ # For faster builds, can be removed
   -DPython3_FIND_VIRTUALENV=FIRST \
   -DCMAKE_BUILD_WITH_INSTALL_RPATH=true \
   -S "<path to source directory>" \

--- a/PreLoad.cmake
+++ b/PreLoad.cmake
@@ -1,0 +1,6 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+set(CMAKE_GENERATOR "Ninja" CACHE INTERNAL "Generator to use" FORCE)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -334,9 +334,9 @@ boost_deps()
 
 http_archive(
     name = "programl",
-    sha256 = "c56360aade351eda1c138a594177fcb7cd2cda2a0a6c5c0d9aa62c7f856194bd",
-    strip_prefix = "ProGraML-4f0981d7a0d27aecef3d6e918c886642b231562d",
-    urls = ["https://github.com/ChrisCummins/ProGraML/archive/4f0981d7a0d27aecef3d6e918c886642b231562d.tar.gz"],
+    sha256 = "c4a20b4a2deade7157dcbc56e78a729ad10e40120e4ad4482e2a0b97738dfe84",
+    strip_prefix = "ProGraML-0.3.2",
+    urls = ["https://github.com/ChrisCummins/ProGraML/archive/refs/tags/v0.3.2.tar.gz"],
 )
 
 load("@programl//tools:bzl/deps.bzl", "programl_deps")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -334,9 +334,9 @@ boost_deps()
 
 http_archive(
     name = "programl",
-    sha256 = "c4a20b4a2deade7157dcbc56e78a729ad10e40120e4ad4482e2a0b97738dfe84",
-    strip_prefix = "ProGraML-0.3.2",
-    urls = ["https://github.com/ChrisCummins/ProGraML/archive/refs/tags/v0.3.2.tar.gz"],
+    sha256 = "704826311b842b3ffc2dedcce593fdd319d76e95bdf5386985768007ebb22316",
+    strip_prefix = "ProGraML-83f00233b04f4ecf7f12a79c80ffe23c2953913f",
+    urls = ["https://github.com/ChrisCummins/ProGraML/archive/83f00233b04f4ecf7f12a79c80ffe23c2953913f.tar.gz"],
 )
 
 load("@programl//tools:bzl/deps.bzl", "programl_deps")

--- a/build_tools/cmake/FindAndEnableCcache.cmake
+++ b/build_tools/cmake/FindAndEnableCcache.cmake
@@ -1,0 +1,13 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+find_program(CCACHE ccache)
+if(CCACHE)
+    message("Found ccache: ${CCACHE}")
+    set(CMAKE_C_COMPILER_LAUNCHER ${CCACHE})
+    set(CMAKE_CXX_COMPILER_LAUNCHER ${CCACHE})
+else()
+    message("ccache not found")
+endif()

--- a/build_tools/cmake/FindAndEnableLld.cmake
+++ b/build_tools/cmake/FindAndEnableLld.cmake
@@ -1,0 +1,14 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+find_program(LLD lld)
+if(LLD)
+    message("Found lld: ${LLD}")
+    set(CMAKE_EXE_LINKER_FLAGS_INIT "-fuse-ld=${LLD}")
+    set(CMAKE_MODULE_LINKER_FLAGS_INIT "-fuse-ld=${LLD}")
+    set(CMAKE_SHARED_LINKER_FLAGS_INIT "-fuse-ld=${LLD}")
+else()
+    message("lld not found")
+endif()

--- a/build_tools/cmake/FindProGraML.cmake
+++ b/build_tools/cmake/FindProGraML.cmake
@@ -69,28 +69,16 @@ endif()
 # For some reason the linker takes the path to the library
 # instead of just the name for the dynamic section when linking to these libs.
 # See https://stackoverflow.com/questions/70088552/linker-adds-the-path-to-library-in-the-dynamic-section-instead-of-its-name
-find_library(
-    ProGraML_proto_programl_cc_LIBRARIES
-    ${CMAKE_STATIC_LIBRARY_PREFIX}programl${CMAKE_STATIC_LIBRARY_SUFFIX}
-    PATH_SUFFIXES programl/proto
-)
-find_path(
-    ProGraML_proto_programl_cc_INCLUDE_DIRS
-    programl/proto/program_graph_options.pb.h
-)
-if(
-    ProGraML_proto_programl_cc_LIBRARIES
-    AND ProGraML_proto_programl_cc_INCLUDE_DIRS
-)
-    add_library(ProGraML::proto::programl_cc UNKNOWN IMPORTED)
-    set_target_properties(
-        ProGraML::proto::programl_cc
-        PROPERTIES
-            INTERFACE_INCLUDE_DIRECTORIES
-                "${ProGraML_proto_programl_cc_INCLUDE_DIRS}"
-            IMPORTED_LINK_INTERFACE_LANGUAGES "CXX"
-            IMPORTED_LOCATION "${ProGraML_proto_programl_cc_LIBRARIES}"
-    )
+find_library(ProGraML_proto_programl_cc_LIBRARIES
+  ${CMAKE_STATIC_LIBRARY_PREFIX}programl${CMAKE_STATIC_LIBRARY_SUFFIX}
+  PATH_SUFFIXES programl/proto)
+find_path(ProGraML_proto_programl_cc_INCLUDE_DIRS programl/proto/program_graph.pb.h)
+if (ProGraML_proto_programl_cc_LIBRARIES AND ProGraML_proto_programl_cc_INCLUDE_DIRS)
+  add_library(ProGraML::proto::programl_cc UNKNOWN IMPORTED)
+  set_target_properties(ProGraML::proto::programl_cc PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${ProGraML_proto_programl_cc_INCLUDE_DIRS}"
+    IMPORTED_LINK_INTERFACE_LANGUAGES "CXX"
+    IMPORTED_LOCATION "${ProGraML_proto_programl_cc_LIBRARIES}")
 endif()
 
 find_library(

--- a/build_tools/cmake/FindProGraML.cmake
+++ b/build_tools/cmake/FindProGraML.cmake
@@ -69,16 +69,28 @@ endif()
 # For some reason the linker takes the path to the library
 # instead of just the name for the dynamic section when linking to these libs.
 # See https://stackoverflow.com/questions/70088552/linker-adds-the-path-to-library-in-the-dynamic-section-instead-of-its-name
-find_library(ProGraML_proto_programl_cc_LIBRARIES
-  ${CMAKE_STATIC_LIBRARY_PREFIX}programl${CMAKE_STATIC_LIBRARY_SUFFIX}
-  PATH_SUFFIXES programl/proto)
-find_path(ProGraML_proto_programl_cc_INCLUDE_DIRS programl/proto/program_graph.pb.h)
-if (ProGraML_proto_programl_cc_LIBRARIES AND ProGraML_proto_programl_cc_INCLUDE_DIRS)
-  add_library(ProGraML::proto::programl_cc UNKNOWN IMPORTED)
-  set_target_properties(ProGraML::proto::programl_cc PROPERTIES
-    INTERFACE_INCLUDE_DIRECTORIES "${ProGraML_proto_programl_cc_INCLUDE_DIRS}"
-    IMPORTED_LINK_INTERFACE_LANGUAGES "CXX"
-    IMPORTED_LOCATION "${ProGraML_proto_programl_cc_LIBRARIES}")
+find_library(
+    ProGraML_proto_programl_cc_LIBRARIES
+    ${CMAKE_STATIC_LIBRARY_PREFIX}programl${CMAKE_STATIC_LIBRARY_SUFFIX}
+    PATH_SUFFIXES programl/proto
+)
+find_path(
+    ProGraML_proto_programl_cc_INCLUDE_DIRS
+    programl/proto/program_graph.pb.h
+)
+if(
+    ProGraML_proto_programl_cc_LIBRARIES
+    AND ProGraML_proto_programl_cc_INCLUDE_DIRS
+)
+    add_library(ProGraML::proto::programl_cc UNKNOWN IMPORTED)
+    set_target_properties(
+        ProGraML::proto::programl_cc
+        PROPERTIES
+            INTERFACE_INCLUDE_DIRECTORIES
+                "${ProGraML_proto_programl_cc_INCLUDE_DIRS}"
+            IMPORTED_LINK_INTERFACE_LANGUAGES "CXX"
+            IMPORTED_LOCATION "${ProGraML_proto_programl_cc_LIBRARIES}"
+    )
 endif()
 
 find_library(

--- a/build_tools/cmake/cg_py_test.cmake
+++ b/build_tools/cmake/cg_py_test.cmake
@@ -9,6 +9,8 @@
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# TODO(github.com/facebookresearch/CompilerGym/issues/621): Gersemi fails.
+# gersemi: off
 
 include(CMakeParseArguments)
 include(cg_installed_test)
@@ -85,3 +87,5 @@ function(cg_py_test)
   # CMake seems to not allow build targets to be dependencies for tests.
   # One way to achieve this is to make the test execution a target.
 endfunction()
+
+# gersemi: on

--- a/build_tools/cmake/cg_python.cmake
+++ b/build_tools/cmake/cg_python.cmake
@@ -9,6 +9,9 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+# TODO(github.com/facebookresearch/CompilerGym/issues/621): Gersemi fails.
+# gersemi: off
+
 include(CMakeParseArguments)
 include(cg_installed_test)
 
@@ -205,3 +208,5 @@ function(cg_pyext_module)
     endif()
   endif()
 endfunction()
+
+# gersemi: on

--- a/build_tools/cmake/set_command_pythonpath.cmake
+++ b/build_tools/cmake/set_command_pythonpath.cmake
@@ -2,15 +2,14 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-
 include(CMakeParseArguments)
 
 function(set_command_pythonpath)
     cmake_parse_arguments(_ARG "" "COMMAND;RESULT" "" ${ARGN})
 
-    if(COMPILER_GYM_PYTHONPATH)
+    if(COMPILER_GYM_BUILD_PYTHONPATH)
         set(${_ARG_RESULT}
-            "\"${CMAKE_COMMAND}\" -E env \"PYTHONPATH=${COMPILER_GYM_PYTHONPATH}\" ${_ARG_COMMAND}"
+            "\"${CMAKE_COMMAND}\" -E env \"PYTHONPATH=${COMPILER_GYM_BUILD_PYTHONPATH}\" ${_ARG_COMMAND}"
             PARENT_SCOPE
         )
     else()

--- a/compiler_gym/CMakeLists.txt
+++ b/compiler_gym/CMakeLists.txt
@@ -23,7 +23,6 @@ cg_py_library(
     compiler_gym::util::util
     compiler_gym::util::flags::flags
     compiler_gym::wrappers::wrappers
-    compiler_gym::envs::llvm::specs
   PUBLIC
 )
 

--- a/compiler_gym/CMakeLists.txt
+++ b/compiler_gym/CMakeLists.txt
@@ -5,25 +5,9 @@
 
 cg_add_all_subdirs()
 
-# This target trickery with compiler_gym and compiler_gym_partial
-# is needed because specs.py imports the compiler_gym module,
-# therefore creating a circular dependency.
-# compiler_gym_partial is all the other bits of the proto package so that
-# specs.py can import it.
 cg_py_library(
   NAME
     compiler_gym
-  GENERATED_SRCS
-    "$<TARGET_PROPERTY:compiler_gym__envs__llvm__specs,LOCATION>"
-  DEPS
-    ::compiler_gym_partial
-    compiler_gym::envs::llvm::specs
-  PUBLIC
-)
-
-cg_py_library(
-  NAME
-    compiler_gym_partial
   SRCS
     "__init__.py"
   DEPS
@@ -39,6 +23,7 @@ cg_py_library(
     compiler_gym::util::util
     compiler_gym::util::flags::flags
     compiler_gym::wrappers::wrappers
+    compiler_gym::envs::llvm::specs
   PUBLIC
 )
 

--- a/compiler_gym/envs/llvm/CMakeLists.txt
+++ b/compiler_gym/envs/llvm/CMakeLists.txt
@@ -10,6 +10,7 @@ cg_py_library(
     llvm
   SRCS
     "__init__.py"
+    "specs.py"
   DATA
     compiler_gym::envs::llvm::service::service
   DEPS
@@ -70,24 +71,4 @@ cg_py_library(
     compiler_gym::util::util
     compiler_gym::views::views
   PUBLIC
-)
-
-string(
-    CONCAT
-    _CMD
-    "\"${Python3_EXECUTABLE}\" "
-    "\"$<TARGET_PROPERTY:compiler_gym__envs__llvm__make_specs,LOCATION>\" "
-    "\"$<TARGET_FILE:compiler_gym__envs__llvm__service__compiler_gym-llvm-service>\" "
-    "\"$@\""
-)
-set_command_pythonpath(COMMAND "${_CMD}" RESULT _CMD)
-cg_genrule(
-  NAME specs
-  OUTS "specs.py"
-  COMMAND "${_CMD}"
-  DEPENDS
-    ::make_specs
-    compiler_gym::compiler_gym_partial
-    compiler_gym::envs::llvm::service::service
-    compiler_gym::envs::llvm::service::compiler_gym-llvm-service
 )

--- a/compiler_gym/envs/llvm/service/CMakeLists.txt
+++ b/compiler_gym/envs/llvm/service/CMakeLists.txt
@@ -37,8 +37,6 @@ cg_cc_library(
   ABS_DEPS
     fmt
     magic_enum
-  NON_LIB_DEPS
-    compiler_gym::envs::llvm::service::passes::actions_genfiles
   PUBLIC
 )
 
@@ -183,7 +181,6 @@ cg_cc_library(
     "-DGOOGLE_PROTOBUF_NO_RTTI"
     "-fno-rtti"
   HDRS
-    compiler_gym::envs::llvm::service::passes::10.0.0::headers
     "LlvmSession.h"
   SRCS
     "LlvmSession.cc"
@@ -194,6 +191,7 @@ cg_cc_library(
     ::Cost
     ::Observation
     ::ObservationSpaces
+    compiler_gym::envs::llvm::service::passes::10.0.0::headers
     compiler_gym::service::CompilationSession
     compiler_gym::service::proto::compiler_gym_service_cc_grpc
     compiler_gym::third_party::autophase::InstCount
@@ -215,7 +213,6 @@ cg_cc_library(
     Clog::libclog
   INCLUDES
     ${LLVM_INCLUDE_DIRS}
-    "$<TARGET_PROPERTY:compiler_gym__envs__llvm__service__passes__actions_genfiles,BINARY_DIR>"
   DEFINES
     ${LLVM_DEFINITIONS}
   PUBLIC

--- a/compiler_gym/envs/llvm/service/CMakeLists.txt
+++ b/compiler_gym/envs/llvm/service/CMakeLists.txt
@@ -183,8 +183,7 @@ cg_cc_library(
     "-DGOOGLE_PROTOBUF_NO_RTTI"
     "-fno-rtti"
   HDRS
-    "$<TARGET_PROPERTY:compiler_gym__envs__llvm__service__passes__actions_genfiles,BINARY_DIR>/ActionHeaders.h"
-    "$<TARGET_PROPERTY:compiler_gym__envs__llvm__service__passes__actions_genfiles,BINARY_DIR>/ActionSwitch.h"
+    compiler_gym::envs::llvm::service::passes::10.0.0::headers
     "LlvmSession.h"
   SRCS
     "LlvmSession.cc"

--- a/compiler_gym/envs/llvm/service/CMakeLists.txt
+++ b/compiler_gym/envs/llvm/service/CMakeLists.txt
@@ -6,9 +6,6 @@
 cg_add_all_subdirs()
 
 set(_DEPS "compiler_gym-llvm-service")
-if(DARWIN)
-    #list(APPEND _DEPS "@llvm//:darwin")
-endif()
 cg_filegroup(
   NAME "service"
   DEPENDS ${_DEPS}
@@ -141,9 +138,6 @@ cg_cc_binary(
 )
 
 set(_FILES "${CMAKE_CURRENT_BINARY_DIR}/compute_observation")
-if(DARWIN)
-    message(FATAL_ERROR "TODO(boian): implement")
-endif()
 cg_filegroup(
   NAME compute_observation-files
   FILES ${_FILES}

--- a/compiler_gym/envs/llvm/service/LlvmSession.h
+++ b/compiler_gym/envs/llvm/service/LlvmSession.h
@@ -25,7 +25,7 @@
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"
 #include "llvm/Pass.h"
-#include "programl/proto/program_graph_options.pb.h"
+#include "programl/proto/util.pb.h"
 
 namespace compiler_gym::llvm_service {
 

--- a/compiler_gym/envs/llvm/service/LlvmSession.h
+++ b/compiler_gym/envs/llvm/service/LlvmSession.h
@@ -25,7 +25,6 @@
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"
 #include "llvm/Pass.h"
-#include "programl/proto/util.pb.h"
 
 namespace compiler_gym::llvm_service {
 

--- a/compiler_gym/envs/llvm/service/RunService.cc
+++ b/compiler_gym/envs/llvm/service/RunService.cc
@@ -16,10 +16,7 @@ using namespace compiler_gym::llvm_service;
 namespace {
 
 void initLlvm() {
-  llvm::InitializeAllTargets();
-  llvm::InitializeAllTargetMCs();
-  llvm::InitializeAllAsmPrinters();
-  llvm::InitializeAllAsmParsers();
+  llvm::InitializeNativeTarget();
 
   // Initialize passes.
   llvm::PassRegistry& Registry = *llvm::PassRegistry::getPassRegistry();

--- a/external/absl/CMakeLists.txt
+++ b/external/absl/CMakeLists.txt
@@ -12,9 +12,9 @@ externalproject_add(
     absl
     PREFIX "${CMAKE_CURRENT_BINARY_DIR}/absl"
     URL
-        "https://github.com/abseil/abseil-cpp/archive/997aaf3a28308eba1b9156aa35ab7bca9688e9f6.tar.gz"
+        "https://github.com/abseil/abseil-cpp/archive/ec33f404bb16564a9aea3044cd8504d6885165b0.tar.gz"
     URL_HASH
-        "SHA256=35f22ef5cb286f09954b7cc4c85b5a3f6221c9d4df6b8c4a1e9d399555b366ee"
+        "SHA256=20a968fab8432661b5c6f3f951cd299fe6d7677541c7dfd62407475a046c91aa"
     CMAKE_ARGS
         -C "${CMAKE_CURRENT_BINARY_DIR}/absl_initial_cache.cmake"
         "-DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}"

--- a/external/external.cmake
+++ b/external/external.cmake
@@ -144,13 +144,16 @@ set_property(
     CACHE COMPILER_GYM_LLVM_PROVIDER
     PROPERTY STRINGS "internal" "external"
 )
-build_external_cmake_project(
-  NAME llvm
-  SRC_DIR "${CMAKE_CURRENT_LIST_DIR}/llvm"
-  CONFIG_ARGS "-DCOMPILER_GYM_LLVM_PROVIDER=${COMPILER_GYM_LLVM_PROVIDER}"
-)
+if(COMPILER_GYM_LLVM_PROVIDER STREQUAL "internal")
+    build_external_cmake_project(
+        NAME llvm
+        SRC_DIR "${CMAKE_CURRENT_LIST_DIR}/llvm"
+        CONFIG_ARGS "-DCOMPILER_GYM_LLVM_PROVIDER=${COMPILER_GYM_LLVM_PROVIDER}"
+    )
+endif()
 set(LLVM_SRC_DIR "${CMAKE_CURRENT_BINARY_DIR}/external/llvm/llvm/src/llvm")
 find_package(LLVM 10.0.0 EXACT REQUIRED)
+message("Using LLVM version ${LLVM_VERSION} from ${LLVM_DIR}")
 
 # === Protocol buffers ===
 

--- a/external/external.cmake
+++ b/external/external.cmake
@@ -51,7 +51,7 @@ if(COMPILER_GYM_BENCHMARK_PROVIDER STREQUAL "internal")
         "${CMAKE_CURRENT_BINARY_DIR}/external/benchmark"
         GIT_REPOSITORY "https://github.com/google/benchmark.git"
         GIT_TAG
-            9913418d323e64a0111ca0da81388260c2bbe1e9 #tag v1.4.0
+            0d98dba29d66e93259db7daa53a9327df767a415 #tag v1.6.1
     )
 
     if(NOT benchmark_POPULATED)

--- a/external/programl/CMakeLists.txt
+++ b/external/programl/CMakeLists.txt
@@ -19,9 +19,9 @@ externalproject_add(
     programl
     PREFIX "${CMAKE_CURRENT_BINARY_DIR}/programl"
     URL
-        "https://github.com/ChrisCummins/ProGraML/archive/e1e8c982d47d022e7a10764bbc41601d4a19d392.tar.gz"
+        "https://github.com/ChrisCummins/ProGraML/archive/83f00233b04f4ecf7f12a79c80ffe23c2953913f.tar.gz"
     URL_HASH
-        "SHA256=9cb77c4dd4940f62655a8bb7fa6cf61dcec9303537e5bbaa88cb5ca3b91e5693"
+        "SHA256=704826311b842b3ffc2dedcce593fdd319d76e95bdf5386985768007ebb22316"
     DOWNLOAD_NO_EXTRACT FALSE
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""

--- a/external/programl/CMakeLists.txt
+++ b/external/programl/CMakeLists.txt
@@ -19,9 +19,9 @@ externalproject_add(
     programl
     PREFIX "${CMAKE_CURRENT_BINARY_DIR}/programl"
     URL
-        "https://github.com/ChrisCummins/ProGraML/archive/refs/tags/v0.3.2.tar.gz"
+        "https://github.com/ChrisCummins/ProGraML/archive/e1e8c982d47d022e7a10764bbc41601d4a19d392.tar.gz"
     URL_HASH
-        "SHA256=c4a20b4a2deade7157dcbc56e78a729ad10e40120e4ad4482e2a0b97738dfe84"
+        "SHA256=9cb77c4dd4940f62655a8bb7fa6cf61dcec9303537e5bbaa88cb5ca3b91e5693"
     DOWNLOAD_NO_EXTRACT FALSE
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""

--- a/external/programl/CMakeLists.txt
+++ b/external/programl/CMakeLists.txt
@@ -19,9 +19,9 @@ externalproject_add(
     programl
     PREFIX "${CMAKE_CURRENT_BINARY_DIR}/programl"
     URL
-        "https://github.com/ChrisCummins/ProGraML/archive/4f0981d7a0d27aecef3d6e918c886642b231562d.tar.gz"
+        "https://github.com/ChrisCummins/ProGraML/archive/refs/tags/v0.3.2.tar.gz"
     URL_HASH
-        "SHA256=c56360aade351eda1c138a594177fcb7cd2cda2a0a6c5c0d9aa62c7f856194bd"
+        "SHA256=c4a20b4a2deade7157dcbc56e78a729ad10e40120e4ad4482e2a0b97738dfe84"
     DOWNLOAD_NO_EXTRACT FALSE
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""

--- a/tests/pytest_plugins/BUILD
+++ b/tests/pytest_plugins/BUILD
@@ -23,7 +23,6 @@ py_library(
     testonly = 1,
     srcs = ["llvm.py"],
     data = [
-        "//compiler_gym/envs/llvm/service/passes:actions_genfiles",
         "//compiler_gym/third_party/cbench:benchmarks_list",
     ],
     deps = [

--- a/tests/pytest_plugins/CMakeLists.txt
+++ b/tests/pytest_plugins/CMakeLists.txt
@@ -23,7 +23,6 @@ cg_py_library(
   SRCS
     "llvm.py"
   DATA
-    compiler_gym::envs::llvm::service::passes::actions_genfiles
     compiler_gym::third_party::cbench::benchmarks_list
   DEPS
     compiler_gym::envs::llvm::llvm


### PR DESCRIPTION
This pull request makes two important changes to the build:

- Fixes a bunch of errors that were introduced in #620 (not sure what happened there), un-breaking the build.
- Adds support for building CompilerGym against a pre-compiled LLVM. This reduces CI build time by **35 minutes**, and reduces the size of the build directory by **55%** (11 GB to 4.9 GB) (#595).

And a bunch of smaller tweaks to the CMake build:
- Switches the CI cmake job to use a pre-compiled LLVM.
- Updates the version of absl and benchmark to work around some build errors on newer linux releases.
- Updates ProGraML so that it uses the same version of absl.
- Turns off the redundant conditional logic for building on Darwin. There is no Linux/macOS-dependent logic in the build system (except for janky linker workarounds needed by bazel).
- Automatically enables ccache in the CMake config when it is available.
- Automatically uses the lld linker when it is available.
- Forces the Ninja generator.
- Makes a number of small formatting tweaks for readability.

---

My eventual goal is to add support for CMake on macOS (#618), but I am hitting a problem with the protobuf configuration step (`autoreconf`) in `external/protobuf/build_protobuf.cmake`:

```
checking for g++ options needed to detect all undeclared functions... cannot detect
configure: error: in `/Users/cummins/src/CompilerGym/build/external/protobuf/protobuf/src/protobuf':
configure: error: cannot make g++ report undeclared builtins
See `config.log' for more details
CMake Error at /Users/cummins/src/CompilerGym/external/protobuf/build_protobuf.cmake:50 (execute_process):
  execute_process failed command indexes:

    1: "Child return code: 1"
```

For some reason, the configure script doesn't like the detected C/C++ compiler. I'll pick this up at a later date.