### PR TITLE
Split CompilerEnv.step() into two methods for singular or lists of actions (take 2)

### DIFF
--- a/compiler_gym/bin/service.py
+++ b/compiler_gym/bin/service.py
@@ -105,7 +105,7 @@ from absl import app, flags
 from compiler_gym.datasets import Dataset
 from compiler_gym.envs import CompilerEnv
 from compiler_gym.service.connection import ConnectionOpts
-from compiler_gym.spaces import Commandline
+from compiler_gym.spaces import Commandline, NamedDiscrete
 from compiler_gym.util.flags.env_from_flags import env_from_flags
 from compiler_gym.util.tabulate import tabulate
 from compiler_gym.util.truncate import truncate
@@ -249,12 +249,13 @@ def print_service_capabilities(env: CompilerEnv):
                 ],
                 headers=("Action", "Description"),
             )
-        else:
+            print(table)
+        elif isinstance(action_space, NamedDiscrete):
             table = tabulate(
                 [(a,) for a in sorted(action_space.names)],
                 headers=("Action",),
             )
-        print(table)
+            print(table)
 
 
 def main(argv):

--- a/compiler_gym/bin/service.py
+++ b/compiler_gym/bin/service.py
@@ -256,6 +256,10 @@ def print_service_capabilities(env: CompilerEnv):
                 headers=("Action",),
             )
             print(table)
+        else:
+            raise NotImplementedError(
+                "Only Commandline and NamedDiscrete are supported."
+            )
 
 
 def main(argv):

--- a/compiler_gym/envs/compiler_env.py
+++ b/compiler_gym/envs/compiler_env.py
@@ -1031,7 +1031,7 @@ class CompilerEnv(gym.Env):
 
     def step(  # pylint: disable=arguments-differ
         self,
-        action: Union[ActionType, Iterable[ActionType]],
+        action: ActionType,
         observations: Optional[Iterable[Union[str, ObservationSpaceSpec]]] = None,
         rewards: Optional[Iterable[Union[str, Reward]]] = None,
     ) -> StepType:
@@ -1058,9 +1058,46 @@ class CompilerEnv(gym.Env):
         :raises SessionNotFound: If :meth:`reset()
             <compiler_gym.envs.CompilerEnv.reset>` has not been called.
         """
-        # Coerce actions into a list.
-        actions = action if isinstance(action, IterableType) else [action]
+        # NOTE(github.com/facebookresearch/CompilerGym/issues/610): This
+        # workaround for accepting a list of actions will be removed in v0.2.4.
+        if isinstance(action, IterableType):
+            warnings.warn(
+                "env.step() only takes a single action. Use env.multistep() "
+                "for an iterable of actions",
+                category=DeprecationWarning,
+            )
+        else:
+            action = [action]
 
+        return self.multistep(action, observations, rewards)
+
+    def multistep(
+        self,
+        actions: Iterable[ActionType],
+        observations: Optional[Iterable[Union[str, ObservationSpaceSpec]]] = None,
+        rewards: Optional[Iterable[Union[str, Reward]]] = None,
+    ):
+        """Take a sequence of steps and return the final observation and reward.
+
+        :param action: A sequence of actions to apply in order.
+
+        :param observations: A list of observation spaces to compute
+            observations from. If provided, this changes the :code:`observation`
+            element of the return tuple to be a list of observations from the
+            requested spaces. The default :code:`env.observation_space` is not
+            returned.
+
+        :param rewards: A list of reward spaces to compute rewards from. If
+            provided, this changes the :code:`reward` element of the return
+            tuple to be a list of rewards from the requested spaces. The default
+            :code:`env.reward_space` is not returned.
+
+        :return: A tuple of observation, reward, done, and info. Observation and
+            reward are None if default observation/reward is not set.
+
+        :raises SessionNotFound: If :meth:`reset()
+            <compiler_gym.envs.CompilerEnv.reset>` has not been called.
+        """
         # Coerce observation spaces into a list of ObservationSpaceSpec instances.
         if observations:
             observation_spaces: List[ObservationSpaceSpec] = [

--- a/compiler_gym/envs/compiler_env.py
+++ b/compiler_gym/envs/compiler_env.py
@@ -1029,7 +1029,7 @@ class CompilerEnv(gym.Env):
 
         return observations, rewards, reply.end_of_session, info
 
-    def step(
+    def step(  # pylint: disable=arguments-differ
         self,
         action: Union[ActionType, Iterable[ActionType]],
         observations: Optional[Iterable[Union[str, ObservationSpaceSpec]]] = None,

--- a/compiler_gym/envs/compiler_env.py
+++ b/compiler_gym/envs/compiler_env.py
@@ -11,7 +11,7 @@ from copy import deepcopy
 from math import isclose
 from pathlib import Path
 from time import time
-from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 
 import gym
 import numpy as np
@@ -1082,9 +1082,7 @@ class CompilerEnv(gym.Env):
                 category=DeprecationWarning,
             )
             reward_spaces = rewards
-        return self._multistep(
-            self.raw_step, [action], observation_spaces, reward_spaces
-        )
+        return self.multistep([action], observation_spaces, reward_spaces)
 
     def multistep(
         self,
@@ -1129,20 +1127,7 @@ class CompilerEnv(gym.Env):
                 category=DeprecationWarning,
             )
             reward_spaces = rewards
-        return self._multistep(
-            self.raw_step, list(actions), observation_spaces, reward_spaces
-        )
 
-    def _multistep(
-        self,
-        raw_step: Callable[
-            [Iterable[ActionType], Iterable[ObservationSpaceSpec], Iterable[Reward]],
-            StepType,
-        ],
-        actions: Iterable[ActionType],
-        observation_spaces: Optional[Iterable[Union[str, ObservationSpaceSpec]]],
-        reward_spaces: Optional[Iterable[Union[str, Reward]]],
-    ) -> StepType:
         # Coerce observation spaces into a list of ObservationSpaceSpec instances.
         if observation_spaces:
             observation_spaces_to_compute: List[ObservationSpaceSpec] = [
@@ -1170,7 +1155,7 @@ class CompilerEnv(gym.Env):
             reward_spaces_to_compute: List[Reward] = []
 
         # Perform the underlying environment step.
-        observation_values, reward_values, done, info = raw_step(
+        observation_values, reward_values, done, info = self.raw_step(
             actions, observation_spaces_to_compute, reward_spaces_to_compute
         )
 

--- a/compiler_gym/envs/llvm/llvm_rewards.py
+++ b/compiler_gym/envs/llvm/llvm_rewards.py
@@ -7,7 +7,7 @@ from typing import List, Optional
 
 from compiler_gym.datasets import Benchmark
 from compiler_gym.spaces.reward import Reward
-from compiler_gym.util.gym_type_hints import ObservationType, RewardType
+from compiler_gym.util.gym_type_hints import ActionType, ObservationType, RewardType
 from compiler_gym.views.observation import ObservationView
 
 
@@ -44,7 +44,7 @@ class CostFunctionReward(Reward):
 
     def update(
         self,
-        actions: List[int],
+        actions: List[ActionType],
         observations: List[ObservationType],
         observation_view: ObservationView,
     ) -> RewardType:
@@ -81,7 +81,7 @@ class NormalizedReward(CostFunctionReward):
 
     def update(
         self,
-        actions: List[int],
+        actions: List[ActionType],
         observations: List[ObservationType],
         observation_view: ObservationView,
     ) -> RewardType:

--- a/compiler_gym/random_replay.py
+++ b/compiler_gym/random_replay.py
@@ -15,7 +15,7 @@ from compiler_gym.random_search import (
 )
 
 
-@deprecated(version="0.2.1", reason="Use env.step(actions) instead")
+@deprecated(version="0.2.1", reason="Use env.step(action) instead")
 def replay_actions(env: CompilerEnv, action_names: List[str], outdir: Path):
     return replay_actions_(env, action_names, outdir)
 

--- a/compiler_gym/random_search.py
+++ b/compiler_gym/random_search.py
@@ -17,6 +17,7 @@ from compiler_gym.envs import CompilerEnv
 from compiler_gym.envs.llvm import LlvmEnv
 from compiler_gym.service.connection import ServiceError
 from compiler_gym.util import logs
+from compiler_gym.util.gym_type_hints import ActionType
 from compiler_gym.util.logs import create_logging_dir
 from compiler_gym.util.tabulate import tabulate
 
@@ -79,8 +80,8 @@ class RandomAgentWorker(Thread):
         self.total_episode_count = 0
         self.total_step_count = 0
         self.best_returns = -float("inf")
-        self.best_actions: List[int] = []
-        self.best_commandline: List[int] = []
+        self.best_actions: List[ActionType] = []
+        self.best_commandline: str = []
         self.best_found_at_time = time()
 
         self.alive = True  # Set this to False to signal the thread to stop.
@@ -112,17 +113,17 @@ class RandomAgentWorker(Thread):
         :return: True if the episode ended gracefully, else False.
         """
         observation = env.reset()
-        actions: List[int] = []
+        actions: List[ActionType] = []
         patience = self._patience
         total_returns = 0
         while patience >= 0:
             patience -= 1
             self.total_step_count += 1
             # === Your agent here! ===
-            action_index = env.action_space.sample()
+            action = env.action_space.sample()
             # === End of agent. ===
-            actions.append(action_index)
-            observation, reward, done, _ = env.step(action_index)
+            actions.append(action)
+            observation, reward, done, _ = env.step(action)
             if done:
                 return False
             total_returns += reward

--- a/compiler_gym/spaces/named_discrete.py
+++ b/compiler_gym/spaces/named_discrete.py
@@ -2,9 +2,11 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
+from collections.abc import Iterable as IterableType
 from typing import Iterable, List, Union
 
 from compiler_gym.spaces.discrete import Discrete
+from compiler_gym.util.gym_type_hints import ActionType
 
 
 class NamedDiscrete(Discrete):
@@ -51,18 +53,20 @@ class NamedDiscrete(Discrete):
     def __repr__(self) -> str:
         return f"NamedDiscrete([{', '.join(self.names)}])"
 
-    def to_string(self, values: Union[int, Iterable[int]]) -> str:
+    def to_string(self, values: Union[int, Iterable[ActionType]]) -> str:
         """Convert an action, or sequence of actions, to string.
 
         :param values: A numeric value, or list of numeric values.
         :return: A string representing the values.
         """
-        if isinstance(values, int):
-            return self.names[values]
-        else:
+        if isinstance(values, IterableType):
             return " ".join([self.names[v] for v in values])
+        else:
+            return self.names[values]
 
-    def from_string(self, values: Union[str, Iterable[str]]) -> Union[int, List[int]]:
+    def from_string(
+        self, values: Union[str, Iterable[str]]
+    ) -> Union[ActionType, List[ActionType]]:
         """Convert a name, or list of names, to numeric values.
 
         :param values: A name, or list of names.

--- a/compiler_gym/spaces/reward.py
+++ b/compiler_gym/spaces/reward.py
@@ -9,7 +9,7 @@ import numpy as np
 
 import compiler_gym
 from compiler_gym.spaces.scalar import Scalar
-from compiler_gym.util.gym_type_hints import ObservationType, RewardType
+from compiler_gym.util.gym_type_hints import ActionType, ObservationType, RewardType
 
 
 class Reward(Scalar):
@@ -132,7 +132,7 @@ class Reward(Scalar):
 
     def update(
         self,
-        actions: List[int],
+        actions: List[ActionType],
         observations: List[ObservationType],
         observation_view: "compiler_gym.views.ObservationView",  # noqa: F821
     ) -> RewardType:

--- a/compiler_gym/util/gym_type_hints.py
+++ b/compiler_gym/util/gym_type_hints.py
@@ -9,7 +9,7 @@ JsonDictType = Dict[str, Any]
 
 # Type hints for the values returned by gym.Env.step().
 ObservationType = TypeVar("ObservationType")
-ActionType = int
+ActionType = TypeVar("ActionType")
 RewardType = float
 DoneType = bool
 InfoType = JsonDictType

--- a/compiler_gym/util/minimize_trajectory.py
+++ b/compiler_gym/util/minimize_trajectory.py
@@ -41,7 +41,7 @@ def _apply_and_test(env, actions, hypothesis, flakiness) -> bool:
     env.reset(benchmark=env.benchmark)
     for _ in range(flakiness):
         logger.debug("Applying %d actions ...", len(actions))
-        _, _, done, info = env.step(actions)
+        _, _, done, info = env.multistep(actions)
         if done:
             raise MinimizationError(
                 f"Failed to replay actions: {info.get('error_details', '')}"

--- a/compiler_gym/views/observation.py
+++ b/compiler_gym/views/observation.py
@@ -67,7 +67,7 @@ class ObservationView:
         """
         observation_space: ObservationSpaceSpec = self.spaces[observation_space]
         observations, _, done, info = self._raw_step(
-            actions=[], observations=[observation_space], rewards=[]
+            actions=[], observation_spaces=[observation_space], reward_spaces=[]
         )
 
         if done:

--- a/compiler_gym/wrappers/commandline.py
+++ b/compiler_gym/wrappers/commandline.py
@@ -57,11 +57,13 @@ class CommandlineWithTerminalAction(CompilerEnvWrapper):
             name=f"{type(self).__name__}<{env.action_space.name}>",
         )
 
-    def raw_step(
+    def multistep(
         self,
         actions: List[ActionType],
         observation_spaces: Optional[Iterable[Union[str, ObservationSpaceSpec]]] = None,
         reward_spaces: Optional[Iterable[Union[str, Reward]]] = None,
+        observations: Optional[Iterable[Union[str, ObservationSpaceSpec]]] = None,
+        rewards: Optional[Iterable[Union[str, Reward]]] = None,
     ) -> StepType:
         terminal_action: int = len(self.action_space.flags) - 1
 
@@ -74,10 +76,12 @@ class CommandlineWithTerminalAction(CompilerEnvWrapper):
         if index_of_terminal >= 0:
             actions = actions[:index_of_terminal]
 
-        observation, reward, done, info = self.env.raw_step(
+        observation, reward, done, info = self.env.multistep(
             actions,
             observation_spaces=observation_spaces,
             reward_spaces=reward_spaces,
+            observations=observations,
+            rewards=rewards,
         )
 
         # Communicate back to the frontend.

--- a/compiler_gym/wrappers/llvm.py
+++ b/compiler_gym/wrappers/llvm.py
@@ -11,7 +11,7 @@ from compiler_gym.datasets.benchmark import BenchmarkInitError
 from compiler_gym.envs.llvm import LlvmEnv
 from compiler_gym.service.connection import ServiceError
 from compiler_gym.spaces import Reward
-from compiler_gym.util.gym_type_hints import ObservationType
+from compiler_gym.util.gym_type_hints import ActionType, ObservationType
 from compiler_gym.wrappers import CompilerEnvWrapper
 
 
@@ -65,7 +65,7 @@ class RuntimePointEstimateReward(CompilerEnvWrapper):
 
         def update(
             self,
-            actions: List[int],
+            actions: List[ActionType],
             observations: List[ObservationType],
             observation_view,
         ) -> float:

--- a/compiler_gym/wrappers/time_limit.py
+++ b/compiler_gym/wrappers/time_limit.py
@@ -2,9 +2,10 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-from typing import Iterable, Optional, Union
+from typing import Optional
 
 from compiler_gym.envs import CompilerEnv
+from compiler_gym.util.gym_type_hints import ActionType
 from compiler_gym.wrappers.core import CompilerEnvWrapper
 
 
@@ -31,7 +32,7 @@ class TimeLimit(CompilerEnvWrapper):
         self._max_episode_steps = max_episode_steps
         self._elapsed_steps = None
 
-    def step(self, action: Union[int, Iterable[int]], **kwargs):
+    def step(self, action: ActionType, **kwargs):
         assert (
             self._elapsed_steps is not None
         ), "Cannot call env.step() before calling reset()"

--- a/compiler_gym/wrappers/validation.py
+++ b/compiler_gym/wrappers/validation.py
@@ -34,11 +34,15 @@ class ValidateBenchmarkAfterEveryStep(CompilerEnvWrapper):
         actions: List[ActionType],
         observation_spaces=None,
         reward_spaces=None,
+        observations=None,
+        rewards=None,
     ):
         observation, reward, done, info = self.env.multistep(
             actions,
             observation_spaces=observation_spaces,
             reward_spaces=reward_spaces,
+            observations=observations,
+            rewards=rewards,
         )
 
         # Early exit if environment reaches terminal state.

--- a/compiler_gym/wrappers/validation.py
+++ b/compiler_gym/wrappers/validation.py
@@ -2,7 +2,10 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
+from typing import List
+
 from compiler_gym.envs import CompilerEnv
+from compiler_gym.util.gym_type_hints import ActionType
 from compiler_gym.wrappers.core import CompilerEnvWrapper
 
 
@@ -26,9 +29,16 @@ class ValidateBenchmarkAfterEveryStep(CompilerEnvWrapper):
         super().__init__(env)
         self.reward_penalty = reward_penalty
 
-    def step(self, action, observations=None, rewards=None):
-        observation, reward, done, info = self.env.step(
-            action, observations=observations, rewards=rewards
+    def raw_step(
+        self,
+        actions: List[ActionType],
+        observation_spaces=None,
+        reward_spaces=None,
+    ):
+        observation, reward, done, info = self.env.raw_step(
+            actions,
+            observation_spaces=observation_spaces,
+            reward_spaces=reward_spaces,
         )
 
         # Early exit if environment reaches terminal state.

--- a/compiler_gym/wrappers/validation.py
+++ b/compiler_gym/wrappers/validation.py
@@ -29,13 +29,13 @@ class ValidateBenchmarkAfterEveryStep(CompilerEnvWrapper):
         super().__init__(env)
         self.reward_penalty = reward_penalty
 
-    def raw_step(
+    def multistep(
         self,
         actions: List[ActionType],
         observation_spaces=None,
         reward_spaces=None,
     ):
-        observation, reward, done, info = self.env.raw_step(
+        observation, reward, done, info = self.env.multistep(
             actions,
             observation_spaces=observation_spaces,
             reward_spaces=reward_spaces,

--- a/examples/brute_force.py
+++ b/examples/brute_force.py
@@ -42,6 +42,7 @@ import compiler_gym.util.flags.output_dir  # noqa Flag definition.
 from compiler_gym.envs import CompilerEnv
 from compiler_gym.util.flags.benchmark_from_flags import benchmark_from_flags
 from compiler_gym.util.flags.env_from_flags import env_from_flags
+from compiler_gym.util.gym_type_hints import ActionType
 from compiler_gym.util.logs import create_logging_dir
 
 flags.DEFINE_list(
@@ -68,7 +69,7 @@ class BruteForceProducer(Thread):
     def __init__(
         self,
         in_q: Queue,
-        actions: List[int],
+        actions: List[ActionType],
         episode_length: int,
         nproc: int,
         chunksize: int = 128,

--- a/examples/llvm_autotuning/autotuners/nevergrad_.py
+++ b/examples/llvm_autotuning/autotuners/nevergrad_.py
@@ -10,6 +10,7 @@ import nevergrad as ng
 from llvm_autotuning.optimization_target import OptimizationTarget
 
 from compiler_gym.envs import CompilerEnv
+from compiler_gym.util.gym_type_hints import ActionType
 
 
 def nevergrad(
@@ -30,17 +31,17 @@ def nevergrad(
     """
     if optimization_target == OptimizationTarget.RUNTIME:
 
-        def calculate_negative_reward(actions: Tuple[int]) -> float:
+        def calculate_negative_reward(actions: Tuple[ActionType]) -> float:
             env.reset()
-            env.step(actions)
+            env.multistep(actions)
             return -env.episode_reward
 
     else:
         # Only cache the deterministic non-runtime rewards.
         @lru_cache(maxsize=int(1e4))
-        def calculate_negative_reward(actions: Tuple[int]) -> float:
+        def calculate_negative_reward(actions: Tuple[ActionType]) -> float:
             env.reset()
-            env.step(actions)
+            env.multistep(actions)
             return -env.episode_reward
 
     params = ng.p.Choice(
@@ -61,4 +62,4 @@ def nevergrad(
     # Get best solution and replay it.
     recommendation = optimizer.provide_recommendation()
     env.reset()
-    env.step(recommendation.value)
+    env.multistep(recommendation.value)

--- a/examples/llvm_autotuning/autotuners/opentuner_.py
+++ b/examples/llvm_autotuning/autotuners/opentuner_.py
@@ -93,7 +93,7 @@ def opentuner_ga(
         wrapped = DesiredResult(Configuration(manipulator.best_config))
         manipulator.run(wrapped, None, None)
         env.reset()
-        env.step(manipulator.serialize_actions(manipulator.best_config))
+        env.multistep(manipulator.serialize_actions(manipulator.best_config))
 
 
 class LlvmOptFlagsTuner(MeasurementInterface):

--- a/examples/llvm_autotuning/optimization_target.py
+++ b/examples/llvm_autotuning/optimization_target.py
@@ -68,7 +68,7 @@ class OptimizationTarget(str, Enum):
         actions = list(env.actions)
         env.reset()
         for i in range(1, 5 + 1):
-            _, _, done, info = env.step(actions)
+            _, _, done, info = env.multistep(actions)
             if not done:
                 break
             logger.warning(

--- a/examples/llvm_rl/wrappers.py
+++ b/examples/llvm_rl/wrappers.py
@@ -3,13 +3,13 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 """Environment wrappers to closer replicate the MLSys'20 Autophase paper."""
-from collections.abc import Iterable as IterableType
-from typing import List, Union
+from typing import List
 
 import gym
 import numpy as np
 
 from compiler_gym.envs import CompilerEnv, LlvmEnv
+from compiler_gym.util.gym_type_hints import ActionType
 from compiler_gym.wrappers import (
     ConstrainedCommandline,
     ObservationWrapper,
@@ -126,12 +126,16 @@ class ConcatActionsHistogram(ObservationWrapper):
         )
         return super().reset(*args, **kwargs)
 
-    def step(self, action: Union[int, List[int]], observations=None, **kwargs):
-        if not isinstance(action, IterableType):
-            action = [action]
-        for a in action:
+    def raw_step(
+        self,
+        actions: List[ActionType],
+        observation_spaces=None,
+        observations=None,
+        **kwargs,
+    ):
+        for a in actions:
             self.histogram[a] += self.increment
-        return super().step(action, **kwargs)
+        return self.env.raw_step(actions, **kwargs)
 
     def observation(self, observation):
         return np.concatenate((observation, self.histogram)).astype(

--- a/examples/llvm_rl/wrappers.py
+++ b/examples/llvm_rl/wrappers.py
@@ -135,7 +135,7 @@ class ConcatActionsHistogram(ObservationWrapper):
     ):
         for a in actions:
             self.histogram[a] += self.increment
-        return self.env.multistep(actions, **kwargs)
+        return super().multistep(actions, **kwargs)
 
     def observation(self, observation):
         return np.concatenate((observation, self.histogram)).astype(

--- a/examples/llvm_rl/wrappers.py
+++ b/examples/llvm_rl/wrappers.py
@@ -126,7 +126,7 @@ class ConcatActionsHistogram(ObservationWrapper):
         )
         return super().reset(*args, **kwargs)
 
-    def raw_step(
+    def multistep(
         self,
         actions: List[ActionType],
         observation_spaces=None,
@@ -135,7 +135,7 @@ class ConcatActionsHistogram(ObservationWrapper):
     ):
         for a in actions:
             self.histogram[a] += self.increment
-        return self.env.raw_step(actions, **kwargs)
+        return self.env.multistep(actions, **kwargs)
 
     def observation(self, observation):
         return np.concatenate((observation, self.histogram)).astype(

--- a/examples/loop_optimizations_service/service_py/CMakeLists.txt
+++ b/examples/loop_optimizations_service/service_py/CMakeLists.txt
@@ -5,6 +5,8 @@
 
 cg_add_all_subdirs()
 
+return()
+
 cg_py_library(
   NAME
     loops_opt_service

--- a/examples/loop_optimizations_service/service_py/CMakeLists.txt
+++ b/examples/loop_optimizations_service/service_py/CMakeLists.txt
@@ -5,8 +5,6 @@
 
 cg_add_all_subdirs()
 
-return()
-
 cg_py_library(
   NAME
     loops_opt_service

--- a/examples/op_benchmarks.py
+++ b/examples/op_benchmarks.py
@@ -267,7 +267,7 @@ def _step_worker(
             # Run all actions in a single step().
             steps = [env.action_space.sample() for _ in range(num_steps)]
             with Timer() as timer:
-                _, _, done, _ = env.step(steps)
+                _, _, done, _ = env.multistep(steps)
             if not done:
                 return [timer.time / num_steps] * num_steps
             env.reset()

--- a/examples/sensitivity_analysis/action_sensitivity_analysis.py
+++ b/examples/sensitivity_analysis/action_sensitivity_analysis.py
@@ -116,7 +116,7 @@ def run_one_trial(
     num_warmup_steps = random.randint(0, max_warmup_steps)
     warmup_actions = [env.action_space.sample() for _ in range(num_warmup_steps)]
     env.reward_space = reward_space
-    _, _, done, _ = env.step(warmup_actions)
+    _, _, done, _ = env.multistep(warmup_actions)
     if done:
         return None
     _, (reward,), done, _ = env.step(action, reward_spaces=[reward_space])

--- a/examples/sensitivity_analysis/action_sensitivity_analysis.py
+++ b/examples/sensitivity_analysis/action_sensitivity_analysis.py
@@ -40,6 +40,7 @@ from sensitivity_analysis.sensitivity_analysis_eval import (
 from compiler_gym.envs import CompilerEnv
 from compiler_gym.util.flags.benchmark_from_flags import benchmark_from_flags
 from compiler_gym.util.flags.env_from_flags import env_from_flags
+from compiler_gym.util.gym_type_hints import ActionType
 from compiler_gym.util.logs import create_logging_dir
 from compiler_gym.util.timer import Timer
 
@@ -118,12 +119,12 @@ def run_one_trial(
     _, _, done, _ = env.step(warmup_actions)
     if done:
         return None
-    _, (reward,), done, _ = env.step(action, rewards=[reward_space])
+    _, (reward,), done, _ = env.step(action, reward_spaces=[reward_space])
     return None if done else reward
 
 
 def run_action_sensitivity_analysis(
-    actions: List[int],
+    actions: List[ActionType],
     rewards_path: Path,
     runtimes_path: Path,
     reward_space: str,

--- a/examples/sensitivity_analysis/benchmark_sensitivity_analysis.py
+++ b/examples/sensitivity_analysis/benchmark_sensitivity_analysis.py
@@ -116,7 +116,7 @@ def run_one_trial(
     num_steps = random.randint(min_steps, max_steps)
     warmup_actions = [env.action_space.sample() for _ in range(num_steps)]
     env.reward_space = reward_space
-    _, _, done, _ = env.step(warmup_actions)
+    _, _, done, _ = env.multistep(warmup_actions)
     if done:
         return None
     return env.episode_reward

--- a/tests/llvm/episode_reward_test.py
+++ b/tests/llvm/episode_reward_test.py
@@ -28,7 +28,7 @@ def test_episode_reward_with_non_default_reward_space(env: LlvmEnv):
     assert env.episode_reward == 0
     _, rewards, _, _ = env.step(
         env.action_space["-mem2reg"],
-        rewards=["IrInstructionCount"],
+        reward_spaces=["IrInstructionCount"],
     )
     assert rewards[0] > 0
     assert env.episode_reward == 0

--- a/tests/llvm/fork_regression_test.py
+++ b/tests/llvm/fork_regression_test.py
@@ -57,14 +57,14 @@ def test_fork_regression_test(env: LlvmEnv, test: ForkRegressionTest):
     pre_fork = [env.action_space[f] for f in test.pre_fork.split()]
     post_fork = [env.action_space[f] for f in test.post_fork.split()]
 
-    _, _, done, info = env.step(pre_fork)
+    _, _, done, info = env.multistep(pre_fork)
     assert not done, info
 
     with env.fork() as fkd:
         assert env.state == fkd.state  # Sanity check
 
-        env.step(post_fork)
-        fkd.step(post_fork)
+        env.multistep(post_fork)
+        fkd.multistep(post_fork)
         # Verify that the environment states no longer line up.
         assert env.state != fkd.state
 

--- a/tests/llvm/llvm_env_test.py
+++ b/tests/llvm/llvm_env_test.py
@@ -221,7 +221,7 @@ def test_step_multiple_actions_list(env: LlvmEnv):
         env.action_space.flags.index("-mem2reg"),
         env.action_space.flags.index("-reg2mem"),
     ]
-    _, _, done, _ = env.step(actions)
+    _, _, done, _ = env.multistep(actions)
     assert not done
     assert env.actions == actions
 
@@ -233,7 +233,7 @@ def test_step_multiple_actions_generator(env: LlvmEnv):
         env.action_space.flags.index("-mem2reg"),
         env.action_space.flags.index("-reg2mem"),
     )
-    _, _, done, _ = env.step(actions)
+    _, _, done, _ = env.multistep(actions)
     assert not done
     assert env.actions == [
         env.action_space.flags.index("-mem2reg"),

--- a/tests/llvm/multiprocessing_test.py
+++ b/tests/llvm/multiprocessing_test.py
@@ -12,11 +12,14 @@ import pytest
 from flaky import flaky
 
 from compiler_gym.envs import LlvmEnv
+from compiler_gym.util.gym_type_hints import ActionType
 from tests.pytest_plugins.common import macos_only
 from tests.test_main import main
 
 
-def process_worker(env_name: str, benchmark: str, actions: List[int], queue: mp.Queue):
+def process_worker(
+    env_name: str, benchmark: str, actions: List[ActionType], queue: mp.Queue
+):
     assert actions
     with gym.make(env_name) as env:
         env.reset(benchmark=benchmark)
@@ -28,7 +31,7 @@ def process_worker(env_name: str, benchmark: str, actions: List[int], queue: mp.
         queue.put((observation, reward, done, info))
 
 
-def process_worker_with_env(env: LlvmEnv, actions: List[int], queue: mp.Queue):
+def process_worker_with_env(env: LlvmEnv, actions: List[ActionType], queue: mp.Queue):
     assert actions
 
     for action in actions:

--- a/tests/llvm/threading_test.py
+++ b/tests/llvm/threading_test.py
@@ -10,13 +10,14 @@ import gym
 from flaky import flaky
 
 from compiler_gym import CompilerEnv
+from compiler_gym.util.gym_type_hints import ActionType
 from tests.test_main import main
 
 
 class ThreadedWorker(Thread):
     """Create an environment and run through a set of actions in a background thread."""
 
-    def __init__(self, env_name: str, benchmark: str, actions: List[int]):
+    def __init__(self, env_name: str, benchmark: str, actions: List[ActionType]):
         super().__init__()
         self.done = False
         self.env_name = env_name
@@ -38,7 +39,7 @@ class ThreadedWorker(Thread):
 class ThreadedWorkerWithEnv(Thread):
     """Create an environment and run through a set of actions in a background thread."""
 
-    def __init__(self, env: CompilerEnv, actions: List[int]):
+    def __init__(self, env: CompilerEnv, actions: List[ActionType]):
         super().__init__()
         self.done = False
         self.env = env

--- a/tests/util/minimize_trajectory_test.py
+++ b/tests/util/minimize_trajectory_test.py
@@ -152,7 +152,7 @@ def test_random_minimization_no_effect():
 def test_minimize_trajectory_iteratively_llvm_crc32(env):
     """Test trajectory minimization on a real environment."""
     env.reset(benchmark="cbench-v1/crc32")
-    env.step(
+    env.multistep(
         [
             env.action_space["-mem2reg"],
             env.action_space["-gvn"],

--- a/tests/util/minimize_trajectory_test.py
+++ b/tests/util/minimize_trajectory_test.py
@@ -10,6 +10,7 @@ from typing import List
 import pytest
 
 from compiler_gym.util import minimize_trajectory as mt
+from compiler_gym.util.gym_type_hints import ActionType
 from tests.test_main import main
 
 pytest_plugins = ["tests.pytest_plugins.llvm"]
@@ -38,7 +39,7 @@ class MockValidationResult:
 class MockEnv:
     """A mock environment for testing trajectory minimization."""
 
-    def __init__(self, actions: List[int], validate=lambda env: True):
+    def __init__(self, actions: List[ActionType], validate=lambda env: True):
         self.original_trajectory = actions
         self.actions = actions.copy()
         self.validate = lambda: MockValidationResult(validate(self))
@@ -49,7 +50,7 @@ class MockEnv:
         self.actions = []
         assert benchmark == self.benchmark
 
-    def step(self, actions):
+    def multistep(self, actions):
         for action in actions:
             assert action in self.original_trajectory
         self.actions += actions

--- a/tests/views/observation_test.py
+++ b/tests/views/observation_test.py
@@ -28,11 +28,11 @@ class MockRawStep:
         self.called_observation_spaces = []
         self.ret = list(reversed(ret or [None]))
 
-    def __call__(self, actions, observations, rewards):
+    def __call__(self, actions, observation_spaces, reward_spaces):
         assert not actions
-        assert len(observations) == 1
-        assert not rewards
-        self.called_observation_spaces.append(observations[0].id)
+        assert len(observation_spaces) == 1
+        assert not reward_spaces
+        self.called_observation_spaces.append(observation_spaces[0].id)
         ret = self.ret[-1]
         del self.ret[-1]
         return [ret], [], False, {}

--- a/tests/wrappers/core_wrappers_test.py
+++ b/tests/wrappers/core_wrappers_test.py
@@ -3,7 +3,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 """Unit tests for //compiler_gym/wrappers."""
-import numpy as np
 import pytest
 
 from compiler_gym.datasets import Datasets
@@ -107,6 +106,9 @@ def test_wrapped_step_custom_args(env: LlvmEnv, wrapper_type):
 
         def action(self, action):
             return action  # pass thru
+
+        def reward(self, reward):
+            return reward
 
     env = MyWrapper(env)
     env.reset()
@@ -259,22 +261,6 @@ def test_wrapped_observation_missing_definition(env: LlvmEnv):
         env.reset()
 
 
-def test_wrapped_observation_not_applied_to_non_default_observations(env: LlvmEnv):
-    class MyWrapper(ObservationWrapper):
-        def __init__(self, env):
-            super().__init__(env)
-            self.observation_space = "Ir"
-
-        def observation(self, observation):
-            return len(observation)
-
-    env = MyWrapper(env)
-    env.reset()
-    (observation,), _, _, _ = env.step(0, observation_spaces=["Autophase"])
-    print(observation)
-    assert isinstance(observation, np.ndarray)
-
-
 def test_wrapped_reward(env: LlvmEnv):
     class MyWrapper(RewardWrapper):
         def reward(self, reward):
@@ -286,11 +272,9 @@ def test_wrapped_reward(env: LlvmEnv):
     env.reset()
     _, reward, _, _ = env.step(0)
     assert reward == -5
-    assert env.episode_reward == -5
 
     _, reward, _, _ = env.step(0)
     assert reward == -5
-    assert env.episode_reward == -10
 
 
 if __name__ == "__main__":

--- a/tests/wrappers/core_wrappers_test.py
+++ b/tests/wrappers/core_wrappers_test.py
@@ -272,9 +272,11 @@ def test_wrapped_reward(env: LlvmEnv):
     env.reset()
     _, reward, _, _ = env.step(0)
     assert reward == -5
+    assert env.episode_reward == -5
 
     _, reward, _, _ = env.step(0)
     assert reward == -5
+    assert env.episode_reward == -10
 
 
 if __name__ == "__main__":

--- a/tests/wrappers/time_limit_wrappers_test.py
+++ b/tests/wrappers/time_limit_wrappers_test.py
@@ -28,7 +28,7 @@ def test_wrapped_fork_type(env: LlvmEnv):
 def test_wrapped_step_multi_step(env: LlvmEnv):
     env = TimeLimit(env, max_episode_steps=5)
     env.reset(benchmark="benchmark://cbench-v1/dijkstra")
-    env.step([0, 0, 0])
+    env.multistep([0, 0, 0])
 
     assert env.benchmark == "benchmark://cbench-v1/dijkstra"
     assert env.actions == [0, 0, 0]
@@ -37,7 +37,7 @@ def test_wrapped_step_multi_step(env: LlvmEnv):
 def test_wrapped_custom_step_args(env: LlvmEnv):
     env = TimeLimit(env, max_episode_steps=5)
     env.reset(benchmark="benchmark://cbench-v1/dijkstra")
-    (ic,), _, _, _ = env.step(0, observations=["IrInstructionCount"])
+    (ic,), _, _, _ = env.step(0, observation_spaces=["IrInstructionCount"])
     assert isinstance(ic, int)
 
 

--- a/www/www.py
+++ b/www/www.py
@@ -217,9 +217,9 @@ def _step(request: StepRequest) -> StepReply:
         if request.all_states:
             # Replay actions one at a time to receive incremental rewards. The
             # first item represents the state prior to any actions.
-            (instcount, autophase), _, done, info = env.step(
-                action=[],
-                observations=[
+            (instcount, autophase), _, done, info = env.raw_step(
+                actions=[],
+                observation_spaces=[
                     env.observation.spaces["InstCountDict"],
                     env.observation.spaces["AutophaseDict"],
                 ],
@@ -238,7 +238,7 @@ def _step(request: StepRequest) -> StepReply:
             for action in request.actions[:-1]:
                 (instcount, autophase), reward, done, info = env.step(
                     action,
-                    observations=[
+                    observation_spaces=[
                         env.observation.spaces["InstCountDict"],
                         env.observation.spaces["AutophaseDict"],
                     ],
@@ -265,12 +265,12 @@ def _step(request: StepRequest) -> StepReply:
         # Perform the final action.
         (ir, instcount, autophase), (reward,), done, _ = env.raw_step(
             actions=request.actions[-1:],
-            observations=[
+            observation_spaces=[
                 env.observation.spaces["Ir"],
                 env.observation.spaces["InstCountDict"],
                 env.observation.spaces["AutophaseDict"],
             ],
-            rewards=[env.reward_space],
+            reward_spaces=[env.reward_space],
         )
 
     states.append(

--- a/www/www.py
+++ b/www/www.py
@@ -217,7 +217,7 @@ def _step(request: StepRequest) -> StepReply:
         if request.all_states:
             # Replay actions one at a time to receive incremental rewards. The
             # first item represents the state prior to any actions.
-            (instcount, autophase), _, done, info = env.raw_step(
+            (instcount, autophase), _, done, info = env.multistep(
                 actions=[],
                 observation_spaces=[
                     env.observation.spaces["InstCountDict"],
@@ -263,7 +263,7 @@ def _step(request: StepRequest) -> StepReply:
                 )
 
         # Perform the final action.
-        (ir, instcount, autophase), (reward,), done, _ = env.raw_step(
+        (ir, instcount, autophase), (reward,), done, _ = env.multistep(
             actions=request.actions[-1:],
             observation_spaces=[
                 env.observation.spaces["Ir"],


### PR DESCRIPTION
This MR supersedes #611. It is the same thing except the source branch is different.