### PR TITLE
Add missing BUILD file for //compiler_gym/third_party/programl.

### DIFF
--- a/compiler_gym/third_party/programl/BUILD
+++ b/compiler_gym/third_party/programl/BUILD
@@ -1,0 +1,23 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+load("@rules_cc//cc:defs.bzl", "cc_binary")
+
+cc_binary(
+    name = "compute_programl",
+    srcs = ["compute_programl.cc"],
+    copts = [
+        "-DGOOGLE_PROTOBUF_NO_RTTI",
+        "-fno-rtti",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@glog",
+        "@llvm//10.0.0",
+        "@nlohmann_json//:json",
+        "@programl//programl/graph/format:node_link_graph",
+        "@programl//programl/ir/llvm:llvm-10",
+    ],
+)


### PR DESCRIPTION
Fixes #623.