### PR TITLE
attempt for #451

### DIFF
--- a/compiler_gym/envs/gcc/gcc_env.py
+++ b/compiler_gym/envs/gcc/gcc_env.py
@@ -17,6 +17,7 @@ from compiler_gym.service import ConnectionOpts
 from compiler_gym.service.client_service_compiler_env import ClientServiceCompilerEnv
 from compiler_gym.util.decorators import memoized_property
 from compiler_gym.util.gym_type_hints import ObservationType
+from compiler_gym.util.gym_type_hints import OptionalArgumentValue
 
 # The default gcc_bin argument.
 DEFAULT_GCC: str = "docker:gcc:11.2.0"
@@ -91,10 +92,14 @@ class GccEnv(ClientServiceCompilerEnv):
         benchmark: Optional[Union[str, Benchmark]] = None,
         action_space: Optional[str] = None,
         retry_count: int = 0,
+        reward_space=OptionalArgumentValue.UNCHANGED,
+        observation_space=OptionalArgumentValue.UNCHANGED,
     ) -> Optional[ObservationType]:
         """Reset the environment. This additionally sets the timeout to the
         correct value."""
-        observation = super().reset(benchmark, action_space, retry_count)
+        observation = super().reset(
+            benchmark, action_space, retry_count, reward_space, observation_space
+        )
         if self._timeout:
             self.send_param("timeout", str(self._timeout))
         return observation

--- a/compiler_gym/service/client_service_compiler_env.py
+++ b/compiler_gym/service/client_service_compiler_env.py
@@ -55,6 +55,7 @@ from compiler_gym.util.gym_type_hints import (
     ObservationType,
     RewardType,
     StepType,
+    OptionalArgumentValue,
 )
 from compiler_gym.util.shell_format import plural
 from compiler_gym.util.timer import Timer
@@ -627,6 +628,8 @@ class ClientServiceCompilerEnv(CompilerEnv):
         benchmark: Optional[Union[str, Benchmark]] = None,
         action_space: Optional[str] = None,
         retry_count: int = 0,
+        reward_space=OptionalArgumentValue.UNCHANGED,
+        observation_space=OptionalArgumentValue.UNCHANGED,
     ) -> Optional[ObservationType]:
         """Reset the environment state.
 
@@ -652,6 +655,12 @@ class ClientServiceCompilerEnv(CompilerEnv):
         :raises TypeError: If no benchmark has been set, and the environment
             does not have a default benchmark to select from.
         """
+
+        if reward_space != OptionalArgumentValue.UNCHANGED:
+            self.reward_space = reward_space
+
+        if observation_space != OptionalArgumentValue.UNCHANGED:
+            self.observation_space = observation_space
 
         def _retry(error) -> Optional[ObservationType]:
             """Abort and retry on error."""

--- a/compiler_gym/util/gym_type_hints.py
+++ b/compiler_gym/util/gym_type_hints.py
@@ -3,9 +3,15 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 from typing import Any, Dict, List, Optional, Tuple, TypeVar, Union
+from enum import Enum
 
 # A JSON dictionary.
 JsonDictType = Dict[str, Any]
+
+# A default value for the reward_space parameter in env.reset() and rev.observation_space() functions.
+class OptionalArgumentValue(Enum):
+    UNCHANGED = 1
+
 
 # Type hints for the values returned by gym.Env.step().
 ObservationType = TypeVar("ObservationType")

--- a/tests/compiler_env_test.py
+++ b/tests/compiler_env_test.py
@@ -36,26 +36,26 @@ def test_benchmark_set_in_reset(env: LlvmEnv):
 
 def test_reward_space_setter(env: LlvmEnv):
     env.reward_space = "IrInstructionCount"
-    assert env.reward_space != "IrInstructionCount"
+    assert str(env.reward_space) != "IrInstructionCount"
     env.reset()
-    assert env.reward_space == "IrInstructionCount"
+    assert str(env.reward_space) == "IrInstructionCount"
 
 
 def test_reward_space_set_in_reset(env: LlvmEnv):
     env.reset(reward_space="IrInstructionCount")
-    assert env.reward_space == "IrInstructionCount"
+    assert str(env.reward_space) == "IrInstructionCount"
 
 
 def test_observation_space_setter(env: LlvmEnv):
     env.observation_space = "Autophase"
-    assert env.observation_space != "Autophase"
+    assert str(env.observation_space) != "Autophase"
     env.reset()
-    assert env.observation_space == "Autophase"
+    assert str(env.observation_space) == "Autophase"
 
 
 def test_observation_space_set_in_reset(env: LlvmEnv):
     env.reset(observation_space="Autophase")
-    assert env.observation_space == "Autophase"
+    assert str(env.observation_space) == "Autophase"
 
 
 def test_logger_is_deprecated(env: LlvmEnv):

--- a/tests/compiler_env_test.py
+++ b/tests/compiler_env_test.py
@@ -147,9 +147,9 @@ def test_switch_default_reward_space_in_episode(env: LlvmEnv):
     """Test that switching reward space during an episode resets the cumulative
     episode reward.
     """
-    env.reward_space = None
+    # env.reward_space = None
 
-    env.reset()
+    env.reset(reward_space=None)
     _, _, done, info = env.step(0)
     assert not done, info
     assert env.episode_reward is None
@@ -167,9 +167,9 @@ def test_set_same_default_reward_space_in_episode(env: LlvmEnv):
     """Test that setting the reward space during an episode does not reset the
     cumulative episode reward if the reward space is unchanged.
     """
-    env.reward_space = "IrInstructionCount"
+    # env.reward_space = "IrInstructionCount"
 
-    env.reset()
+    env.reset(reward_space="IrInstructionCount")
 
     env.episode_reward = 10
 

--- a/tests/compiler_env_test.py
+++ b/tests/compiler_env_test.py
@@ -34,6 +34,30 @@ def test_benchmark_set_in_reset(env: LlvmEnv):
     assert env.benchmark == "benchmark://cbench-v1/dijkstra"
 
 
+def test_reward_space_setter(env: LlvmEnv):
+    env.reward_space = "IrInstructionCount"
+    assert env.reward_space != "IrInstructionCount"
+    env.reset()
+    assert env.reward_space == "IrInstructionCount"
+
+
+def test_reward_space_set_in_reset(env: LlvmEnv):
+    env.reset(reward_space="IrInstructionCount")
+    assert env.reward_space == "IrInstructionCount"
+
+
+def test_observation_space_setter(env: LlvmEnv):
+    env.observation_space = "Autophase"
+    assert env.observation_space != "Autophase"
+    env.reset()
+    assert env.observation_space == "Autophase"
+
+
+def test_observation_space_set_in_reset(env: LlvmEnv):
+    env.reset(observation_space="Autophase")
+    assert env.observation_space == "Autophase"
+
+
 def test_logger_is_deprecated(env: LlvmEnv):
     with pytest.deprecated_call(
         match="The `ClientServiceCompilerEnv.logger` attribute is deprecated"
@@ -64,7 +88,7 @@ def test_uri_substring_candidate_no_match_infer_scheme(env: LlvmEnv):
 
 
 def test_reset_to_force_benchmark(env: LlvmEnv):
-    """Reset that calling reset() with a benchmark forces that benchmark to
+    """Test that calling reset() with a benchmark forces that benchmark to
     be used for every subsequent episode.
     """
     env.reset(benchmark="benchmark://cbench-v1/crc32")
@@ -147,7 +171,6 @@ def test_switch_default_reward_space_in_episode(env: LlvmEnv):
     """Test that switching reward space during an episode resets the cumulative
     episode reward.
     """
-    # env.reward_space = None
 
     env.reset(reward_space=None)
     _, _, done, info = env.step(0)
@@ -167,7 +190,6 @@ def test_set_same_default_reward_space_in_episode(env: LlvmEnv):
     """Test that setting the reward space during an episode does not reset the
     cumulative episode reward if the reward space is unchanged.
     """
-    # env.reward_space = "IrInstructionCount"
 
     env.reset(reward_space="IrInstructionCount")
 


### PR DESCRIPTION
Modified the env.reset() function to add the reward_space and observation_space parameters. Modified the reset() func of the subclasses. Added a OptionalArgumentValue class in gym_type_hints.py for the default value.

Fixes #451 
