### PR TITLE
CI hardening patchset

### DIFF
--- a/tests/wrappers/llvm_test.py
+++ b/tests/wrappers/llvm_test.py
@@ -46,6 +46,7 @@ def test_reward_range_not_runnable_benchmark(env: LlvmEnv):
         env.reset(benchmark="benchmark://npb-v0/1")
 
 
+@flaky  # Runtime can fail
 def test_fork(env: LlvmEnv):
     env = RuntimePointEstimateReward(env)
     with env.fork() as fkd:


### PR DESCRIPTION
The original goal was to fix #657, but this turned out to be only a temporary network error, so instead this patch set contains fixes for a couple of sources of flakiness observed in the unit tests.