### PR TITLE
Misc fixes and improvements

### DIFF
--- a/compiler_gym/envs/compiler_env.py
+++ b/compiler_gym/envs/compiler_env.py
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 """This module defines the OpenAI gym interface for compilers."""
 from abc import ABC, abstractmethod
-from typing import Iterable, List, Optional, Union
+from typing import Iterable, List, Optional, Tuple, Union
 
 import gym
 from deprecated.sphinx import deprecated
@@ -255,6 +255,15 @@ class CompilerEnv(gym.Env, ABC):
     @observation.setter
     @abstractmethod
     def observation(self, observation: ObservationView) -> None:
+        raise NotImplementedError("abstract method")
+
+    @property
+    @abstractmethod
+    def reward_range(self) -> Tuple[float, float]:
+        """A tuple indicating the range of reward values.
+
+        Default range is (-inf, +inf).
+        """
         raise NotImplementedError("abstract method")
 
     @property

--- a/compiler_gym/envs/compiler_env.py
+++ b/compiler_gym/envs/compiler_env.py
@@ -13,7 +13,12 @@ from gym.spaces import Space
 from compiler_gym.compiler_env_state import CompilerEnvState
 from compiler_gym.datasets import Benchmark, BenchmarkUri, Dataset
 from compiler_gym.spaces import Reward
-from compiler_gym.util.gym_type_hints import ActionType, ObservationType, StepType
+from compiler_gym.util.gym_type_hints import (
+    ActionType,
+    ObservationType,
+    OptionalArgumentValue,
+    StepType,
+)
 from compiler_gym.validation_result import ValidationResult
 from compiler_gym.views import ObservationSpaceSpec, ObservationView, RewardView
 
@@ -294,11 +299,58 @@ class CompilerEnv(gym.Env, ABC):
 
     @abstractmethod
     def reset(  # pylint: disable=arguments-differ
-        self, *args, **kwargs
+        self,
+        benchmark: Optional[Union[str, Benchmark]] = None,
+        action_space: Optional[str] = None,
+        reward_space: Union[
+            OptionalArgumentValue, str, Reward
+        ] = OptionalArgumentValue.UNCHANGED,
+        observation_space: Union[
+            OptionalArgumentValue, str, ObservationSpaceSpec
+        ] = OptionalArgumentValue.UNCHANGED,
     ) -> Optional[ObservationType]:
         """Reset the environment state.
 
         This method must be called before :func:`step()`.
+
+        :param benchmark: The name of the benchmark to use. If provided, it
+            overrides any value that was set during :func:`__init__`, and
+            becomes subsequent calls to :code:`reset()` will use this benchmark.
+            If no benchmark is provided, and no benchmark was provided to
+            :func:`__init___`, the service will randomly select a benchmark to
+            use.
+
+        :param action_space: The name of the action space to use. If provided,
+            it overrides any value that set during :func:`__init__`, and
+            subsequent calls to :code:`reset()` will use this action space. If
+            no action space is provided, the default action space is used.
+
+        :param observation_space: Compute and return observations at each
+            :func:`step()` from this space. Accepts a string name or an
+            :class:`ObservationSpaceSpec
+            <compiler_gym.views.ObservationSpaceSpec>`. If :code:`None`,
+            :func:`step()` returns :code:`None` for the observation value. If
+            :code:`OptionalArgumentValue.UNCHANGED` (the default value), the
+            observation space remains unchanged from the previous episode. For
+            available spaces, see :class:`env.observation.spaces
+            <compiler_gym.views.ObservationView>`.
+
+        :param reward_space: Compute and return reward at each :func:`step()`
+            from this space. Accepts a string name or a :class:`Reward
+            <compiler_gym.spaces.Reward>`. If :code:`None`, :func:`step()`
+            returns :code:`None` for the reward value.  If
+            :code:`OptionalArgumentValue.UNCHANGED` (the default value), the
+            observation space remains unchanged from the previous episode. For
+            available spaces, see :class:`env.reward.spaces
+            <compiler_gym.views.RewardView>`.
+
+        :return: The initial observation.
+
+        :raises BenchmarkInitError: If the benchmark is invalid. In this case,
+            another benchmark must be used.
+
+        :raises TypeError: If no benchmark has been set, and the environment
+            does not have a default benchmark to select from.
         """
         raise NotImplementedError("abstract method")
 

--- a/compiler_gym/envs/compiler_env.py
+++ b/compiler_gym/envs/compiler_env.py
@@ -311,11 +311,11 @@ class CompilerEnv(gym.Env, ABC):
         self,
         benchmark: Optional[Union[str, Benchmark]] = None,
         action_space: Optional[str] = None,
-        reward_space: Union[
-            OptionalArgumentValue, str, Reward
-        ] = OptionalArgumentValue.UNCHANGED,
         observation_space: Union[
             OptionalArgumentValue, str, ObservationSpaceSpec
+        ] = OptionalArgumentValue.UNCHANGED,
+        reward_space: Union[
+            OptionalArgumentValue, str, Reward
         ] = OptionalArgumentValue.UNCHANGED,
     ) -> Optional[ObservationType]:
         """Reset the environment state.

--- a/compiler_gym/envs/gcc/gcc_env.py
+++ b/compiler_gym/envs/gcc/gcc_env.py
@@ -15,9 +15,10 @@ from compiler_gym.envs.gcc.gcc import Gcc, GccSpec
 from compiler_gym.envs.gcc.gcc_rewards import AsmSizeReward, ObjSizeReward
 from compiler_gym.service import ConnectionOpts
 from compiler_gym.service.client_service_compiler_env import ClientServiceCompilerEnv
+from compiler_gym.spaces import Reward
 from compiler_gym.util.decorators import memoized_property
-from compiler_gym.util.gym_type_hints import ObservationType
-from compiler_gym.util.gym_type_hints import OptionalArgumentValue
+from compiler_gym.util.gym_type_hints import ObservationType, OptionalArgumentValue
+from compiler_gym.views import ObservationSpaceSpec
 
 # The default gcc_bin argument.
 DEFAULT_GCC: str = "docker:gcc:11.2.0"
@@ -91,14 +92,18 @@ class GccEnv(ClientServiceCompilerEnv):
         self,
         benchmark: Optional[Union[str, Benchmark]] = None,
         action_space: Optional[str] = None,
-        retry_count: int = 0,
-        reward_space=OptionalArgumentValue.UNCHANGED,
-        observation_space=OptionalArgumentValue.UNCHANGED,
+        observation_space: Union[
+            OptionalArgumentValue, str, ObservationSpaceSpec
+        ] = OptionalArgumentValue.UNCHANGED,
+        reward_space: Union[
+            OptionalArgumentValue, str, Reward
+        ] = OptionalArgumentValue.UNCHANGED,
     ) -> Optional[ObservationType]:
-        """Reset the environment. This additionally sets the timeout to the
-        correct value."""
         observation = super().reset(
-            benchmark, action_space, retry_count, reward_space, observation_space
+            benchmark=benchmark,
+            action_space=action_space,
+            observation_space=observation_space,
+            reward_space=reward_space,
         )
         if self._timeout:
             self.send_param("timeout", str(self._timeout))

--- a/compiler_gym/envs/llvm/llvm_benchmark.py
+++ b/compiler_gym/envs/llvm/llvm_benchmark.py
@@ -6,7 +6,6 @@
 import logging
 import os
 import random
-import shlex
 import subprocess
 import sys
 import tempfile
@@ -20,6 +19,7 @@ from compiler_gym.datasets import Benchmark, BenchmarkInitError
 from compiler_gym.third_party import llvm
 from compiler_gym.util.commands import Popen, communicate, run_command
 from compiler_gym.util.runfiles_path import transient_cache_path
+from compiler_gym.util.shell_format import join_cmd
 from compiler_gym.util.thread_pool import get_thread_pool_executor
 
 logger = logging.getLogger(__name__)
@@ -78,7 +78,7 @@ def _get_system_library_flags(compiler: str) -> Iterable[str]:
                 ) from e
         else:
             raise HostCompilerFailure(
-                f"Compiler invocation '{shlex.join(cmd)}' timed out after 3 attempts."
+                f"Compiler invocation '{join_cmd(cmd)}' timed out after 3 attempts."
             )
 
     # Parse the compiler output that matches the conventional output format

--- a/compiler_gym/service/client_service_compiler_env.py
+++ b/compiler_gym/service/client_service_compiler_env.py
@@ -118,12 +118,6 @@ class ClientServiceCompilerEnv(CompilerEnv):
     :ivar service: A connection to the underlying compiler service.
 
     :vartype service: compiler_gym.service.CompilerGymServiceConnection
-
-
-    :ivar reward_range: A tuple indicating the range of reward values. Default
-        range is (-inf, +inf).
-
-    :vartype reward_range: Tuple[float, float]
     """
 
     def __init__(
@@ -302,7 +296,7 @@ class ClientServiceCompilerEnv(CompilerEnv):
         self.observation_space: Optional[Space] = None
 
         # Mutable state initialized in reset().
-        self.reward_range: Tuple[float, float] = (-np.inf, np.inf)
+        self._reward_range: Tuple[float, float] = (-np.inf, np.inf)
         self.episode_reward = None
         self.episode_start_time: float = time()
         self._actions: List[ActionType] = []
@@ -482,7 +476,7 @@ class ClientServiceCompilerEnv(CompilerEnv):
             if reward_space == self.reward_space:
                 return
             self.reward_space_spec = self.reward.spaces[reward_space]
-            self.reward_range = (
+            self._reward_range = (
                 self.reward_space_spec.min,
                 self.reward_space_spec.max,
             )
@@ -493,7 +487,11 @@ class ClientServiceCompilerEnv(CompilerEnv):
             # If no reward space is being used then set the reward range to
             # unbounded.
             self.reward_space_spec = None
-            self.reward_range = (-np.inf, np.inf)
+            self._reward_range = (-np.inf, np.inf)
+
+    @property
+    def reward_range(self) -> Tuple[float, float]:
+        return self._reward_range
 
     @property
     def reward(self) -> RewardView:

--- a/compiler_gym/service/client_service_compiler_env.py
+++ b/compiler_gym/service/client_service_compiler_env.py
@@ -662,7 +662,7 @@ class ClientServiceCompilerEnv(CompilerEnv):
         if hasattr(self, "service") and getattr(self, "service"):
             self.close()
 
-    def reset(  # pylint: disable=arguments-differ
+    def reset(
         self,
         benchmark: Optional[Union[str, Benchmark]] = None,
         action_space: Optional[str] = None,
@@ -673,49 +673,6 @@ class ClientServiceCompilerEnv(CompilerEnv):
             OptionalArgumentValue, str, ObservationSpaceSpec
         ] = OptionalArgumentValue.UNCHANGED,
     ) -> Optional[ObservationType]:
-        """Reset the environment state.
-
-        This method must be called before :func:`step()`.
-
-        :param benchmark: The name of the benchmark to use. If provided, it
-            overrides any value that was set during :func:`__init__`, and
-            becomes subsequent calls to :code:`reset()` will use this benchmark.
-            If no benchmark is provided, and no benchmark was provided to
-            :func:`__init___`, the service will randomly select a benchmark to
-            use.
-
-        :param action_space: The name of the action space to use. If provided,
-            it overrides any value that set during :func:`__init__`, and
-            subsequent calls to :code:`reset()` will use this action space. If
-            no action space is provided, the default action space is used.
-
-        :param observation_space: Compute and return observations at each
-            :func:`step()` from this space. Accepts a string name or an
-            :class:`ObservationSpaceSpec
-            <compiler_gym.views.ObservationSpaceSpec>`. If :code:`None`,
-            :func:`step()` returns :code:`None` for the observation value. If
-            :code:`OptionalArgumentValue.UNCHANGED` (the default value), the
-            observation space remains unchanged from the previous episode. For
-            available spaces, see :class:`env.observation.spaces
-            <compiler_gym.views.ObservationView>`.
-
-        :param reward_space: Compute and return reward at each :func:`step()`
-            from this space. Accepts a string name or a :class:`Reward
-            <compiler_gym.spaces.Reward>`. If :code:`None`, :func:`step()`
-            returns :code:`None` for the reward value.  If
-            :code:`OptionalArgumentValue.UNCHANGED` (the default value), the
-            observation space remains unchanged from the previous episode. For
-            available spaces, see :class:`env.reward.spaces
-            <compiler_gym.views.RewardView>`.
-
-        :return: The initial observation.
-
-        :raises BenchmarkInitError: If the benchmark is invalid. In this case,
-            another benchmark must be used.
-
-        :raises TypeError: If no benchmark has been set, and the environment
-            does not have a default benchmark to select from.
-        """
         return self._reset(
             benchmark=benchmark,
             action_space=action_space,

--- a/compiler_gym/service/client_service_compiler_env.py
+++ b/compiler_gym/service/client_service_compiler_env.py
@@ -735,6 +735,8 @@ class ClientServiceCompilerEnv(CompilerEnv):
                 return self._reset(
                     benchmark=benchmark,
                     action_space=action_space,
+                    observation_space=observation_space,
+                    reward_space=reward_space,
                     retry_count=retry_count + 1,
                 )
 

--- a/compiler_gym/service/client_service_compiler_env.py
+++ b/compiler_gym/service/client_service_compiler_env.py
@@ -85,11 +85,15 @@ def _wrapped_step(
 
 class ServiceMessageConverters:
     """Allows for customization of conversion to/from gRPC messages for the
-    <ClientServiceCompilerEnv>.
+    :class:`ClientServiceCompilerEnv
+    <compiler_gym.service.client_service_compiler_env.ClientServiceCompilerEnv>`.
 
     Supports conversion customizations:
-    * <compiler_gym.service.proto.ActionSpace> -> <gym.spaces.Space>.
-    * <compiler_gym.util.gym_type_hints.ActionType> -> <compiler_gym.service.proto.Event>.
+
+        - :code:`compiler_gym.service.proto.ActionSpace` ->
+          :code:`gym.spaces.Space`.
+        - :code:`compiler_gym.util.gym_type_hints.ActionType` ->
+          :code:`compiler_gym.service.proto.Event`.
     """
 
     action_space_converter: Callable[[ActionSpace], Space]
@@ -100,6 +104,7 @@ class ServiceMessageConverters:
         action_space_converter: Optional[Callable[[ActionSpace], Space]] = None,
         action_converter: Optional[Callable[[Any], Event]] = None,
     ):
+        """Constructor."""
         self.action_space_converter = (
             py_converters.make_message_default_converter()
             if action_space_converter is None
@@ -113,7 +118,8 @@ class ServiceMessageConverters:
 
 
 class ClientServiceCompilerEnv(CompilerEnv):
-    """Implementation using gRPC for a client-server communication.
+    """Implementation of :class:`CompilerEnv <compiler_gym.envs.CompilerEnv>`
+    using gRPC for client-server communication.
 
     :ivar service: A connection to the underlying compiler service.
 

--- a/compiler_gym/service/client_service_compiler_env.py
+++ b/compiler_gym/service/client_service_compiler_env.py
@@ -732,7 +732,7 @@ class ClientServiceCompilerEnv(CompilerEnv):
                     f"Last error ({type(error).__name__}): {error}"
                 ) from error
             else:
-                return self.reset(
+                return self._reset(
                     benchmark=benchmark,
                     action_space=action_space,
                     retry_count=retry_count + 1,

--- a/compiler_gym/util/shell_format.py
+++ b/compiler_gym/util/shell_format.py
@@ -2,7 +2,9 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-from typing import Any
+import shlex
+import sys
+from typing import Any, Iterable
 
 
 class ShellFormatCodes:
@@ -33,3 +35,14 @@ def plural(quantity: int, singular: str, plural: str) -> str:
 def indent(string: str, n=4) -> str:
     """Indent a multi-line string by given number of spaces."""
     return "\n".join(" " * n + x for x in str(string).split("\n"))
+
+
+def join_cmd(cmd: Iterable[str]) -> str:
+    """Join a list of command line arguments into a single string.
+
+    This is intended for logging purposes only. It does not provide any safety
+    guarantees.
+    """
+    if sys.version_info >= (3, 8, 0):
+        return shlex.join(cmd)
+    return " ".join(cmd)

--- a/docs/source/compiler_gym/service.rst
+++ b/docs/source/compiler_gym/service.rst
@@ -14,10 +14,10 @@ client and service is managed by the :class:`CompilerGymServiceConnection
     :local:
 
 
-ServiceMessageConverters
-------------------------
+The CompilationSession Interface
+--------------------------------
 
-.. autoclass:: ClientServiceCompilerEnv
+.. autoclass:: CompilationSession
    :members:
 
    .. automethod:: __init__
@@ -26,16 +26,13 @@ ServiceMessageConverters
 ClientServiceCompilerEnv
 ------------------------
 
-.. autoclass:: ClientServiceCompilerEnv
+.. autoclass:: compiler_gym.service.client_service_compiler_env.ClientServiceCompilerEnv
    :members:
 
    .. automethod:: __init__
 
 
-The CompilationSession Interface
---------------------------------
-
-.. autoclass:: CompilationSession
+.. autoclass:: compiler_gym.service.client_service_compiler_env.ServiceMessageConverters
    :members:
 
    .. automethod:: __init__

--- a/tests/llvm/datasets/csmith_test.py
+++ b/tests/llvm/datasets/csmith_test.py
@@ -62,7 +62,14 @@ def test_csmith_from_seed_retry_count_exceeded(csmith_dataset: CsmithDataset):
         csmith_dataset.benchmark_from_seed(seed=1, max_retries=3, retry_count=5)
 
 
-@flaky(max_runs=5, rerun_filter=lambda err, *args: issubclass(err[0], ServiceError))
+csmith_runtime_flaky = flaky(
+    max_runs=5,
+    rerun_filter=lambda err, *args: issubclass(err[0], ServiceError)
+    or isinstance(err[0], TimeoutError),
+)
+
+
+@csmith_runtime_flaky
 def test_csmith_positive_runtimes(env: LlvmEnv, csmith_dataset: CsmithDataset):
     benchmark = next(csmith_dataset.benchmarks())
     env.reset(benchmark=benchmark)
@@ -71,7 +78,7 @@ def test_csmith_positive_runtimes(env: LlvmEnv, csmith_dataset: CsmithDataset):
     assert np.all(np.greater(val, 0))
 
 
-@flaky(max_runs=5, rerun_filter=lambda err, *args: issubclass(err[0], ServiceError))
+@csmith_runtime_flaky
 def test_csmith_positive_buildtimes(env: LlvmEnv, csmith_dataset: CsmithDataset):
     benchmark = next(csmith_dataset.benchmarks())
     env.reset(benchmark=benchmark)

--- a/tests/util/shell_format_test.py
+++ b/tests/util/shell_format_test.py
@@ -13,5 +13,9 @@ def test_indent():
     assert fmt.indent("abc\ndef") == "    abc\n    def"
 
 
+def test_join_cmd():
+    assert fmt.join_cmd(["a", "b", "c"]) == "a b c"
+
+
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
- Fix HTML documentation for client/service CompilerEnv implementation.
- Moves `reward_range` from ClientServiceCompilerEnv to CompilerEnv base class.
- Specifies the arguments to `CompilerEnv.reset()` method.
- Adds docstring entries for new `reset()` method args.
