### PR TITLE
[examples] Fix path to clang in example services.

### DIFF
--- a/examples/example_unrolling_service/service_py/example_service.py
+++ b/examples/example_unrolling_service/service_py/example_service.py
@@ -245,7 +245,7 @@ class UnrollingCompilationSession(CompilationSession):
             # build object file to binary
             run_command(
                 [
-                    "clang",
+                    self._clang,
                     self._obj_path,
                     "-O3",
                     "-o",
@@ -289,7 +289,7 @@ class UnrollingCompilationSession(CompilationSession):
             # build object file to binary
             run_command(
                 [
-                    "clang",
+                    self._clang,
                     self._obj_path,
                     "-Oz",
                     "-o",

--- a/examples/loop_optimizations_service/service_py/loops_opt_service.py
+++ b/examples/loop_optimizations_service/service_py/loops_opt_service.py
@@ -329,7 +329,7 @@ class LoopsOptCompilationSession(CompilationSession):
             # build object file to binary
             run_command(
                 [
-                    "clang",
+                    self._clang,
                     self._obj_path,
                     "-O3",
                     "-o",
@@ -373,7 +373,7 @@ class LoopsOptCompilationSession(CompilationSession):
             # build object file to binary
             run_command(
                 [
-                    "clang",
+                    self._clang,
                     self._obj_path,
                     "-Oz",
                     "-o",


### PR DESCRIPTION
Use the version of clang that is bundled with CompilerGym, since the
user may not have a compatible version of clang in their $PATH.
