### PR TITLE
In install instructions source ~/.profile

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -108,7 +108,7 @@ Requires CMake (>=3.20).
 wget https://github.com/Kitware/CMake/releases/download/v3.20.5/cmake-3.20.5-linux-x86_64.sh -O cmake.sh
 bash cmake.sh --prefix=$HOME/.local --exclude-subdir --skip-license
 rm cmake.sh
-source ~/.profile
+export PATH=$HOME/.local/bin:$PATH
 ```
 
 ### Dependency Arguments

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -108,6 +108,7 @@ Requires CMake (>=3.20).
 wget https://github.com/Kitware/CMake/releases/download/v3.20.5/cmake-3.20.5-linux-x86_64.sh -O cmake.sh
 bash cmake.sh --prefix=$HOME/.local --exclude-subdir --skip-license
 rm cmake.sh
+source ~/.profile
 ```
 
 ### Dependency Arguments


### PR DESCRIPTION
The CMake installation may be the first to create ~/.local/bin,
so it would not be in PATH without logging in again.
This change makes sure that it is added to PATH in the same shell session.
