### PR TITLE
CMake: fix custom target dependencies

### DIFF
--- a/build_tools/cmake/cg_genrule.cmake
+++ b/build_tools/cmake/cg_genrule.cmake
@@ -7,6 +7,7 @@ include_guard(GLOBAL)
 
 include(CMakeParseArguments)
 include(cg_macros)
+include(cg_target_outputs)
 
 # cg_genrule()
 #
@@ -55,10 +56,11 @@ function(cg_genrule)
     string(REPLACE "$(@D)" "${_OUTS_DIR}" _CMD "${_CMD}")
 
     if(_OUTS)
+        cg_target_outputs(TARGETS ${_DEPS} RESULT _DEPS_OUTPUTS)
         add_custom_command(
             OUTPUT ${_OUTS}
             COMMAND bash -c "${_CMD}"
-            DEPENDS ${_DEPS} ${_SRCS}
+            DEPENDS ${_DEPS} ${_DEPS_OUTPUTS} ${_SRCS}
             VERBATIM
             USES_TERMINAL
         )
@@ -83,7 +85,7 @@ function(cg_genrule)
         )
     endif()
 
-    set_target_properties(${_NAME} PROPERTIES OUTPUTS "${_OUTS}")
+    set_property(TARGET ${_NAME} PROPERTY OUTPUTS ${_OUTS})
 
     list(LENGTH _OUTS _OUTS_LENGTH)
     if(_OUTS_LENGTH EQUAL "1")

--- a/build_tools/cmake/cg_py_library.cmake
+++ b/build_tools/cmake/cg_py_library.cmake
@@ -75,6 +75,7 @@ function(cg_py_library)
         list(APPEND _BIN_PATHS "${_SRC_BIN_PATH}")
     endforeach()
 
+    list(APPEND _BIN_PATHS ${_RULE_GENERATED_SRCS})
     set(_DEPS ${_RULE_DEPS} ${_BIN_PATHS})
     add_custom_target(${_NAME} ALL DEPENDS ${_DEPS})
 

--- a/build_tools/cmake/cg_py_library.cmake
+++ b/build_tools/cmake/cg_py_library.cmake
@@ -42,6 +42,7 @@ function(cg_py_library)
 
     # TODO(boian): remove this renaming when call sites do not include ":" in target dependency names
     rename_bazel_targets(_RULE_DEPS "${_RULE_DEPS}")
+    cg_target_outputs(TARGETS ${_RULE_DEPS} RESULT _DEPS_OUTPUTS)
 
     # Prefix the library with the package name, so we get: cg_package_name.
     rename_bazel_targets(_NAME "${_RULE_NAME}")
@@ -64,18 +65,22 @@ function(cg_py_library)
             COMMAND
                 ${CMAKE_COMMAND} -E create_symlink
                 "${CMAKE_CURRENT_SOURCE_DIR}/${_SRC_FILE}" "${_SRC_BIN_PATH}"
-            DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/${_SRC_FILE}"
+            DEPENDS
+                "${CMAKE_CURRENT_SOURCE_DIR}/${_SRC_FILE}"
+                ${_RULE_DEPS}
+                ${_DEPS_OUTPUTS}
+                ${_RULE_GENERATED_SRCS}
             VERBATIM
         )
         list(APPEND _BIN_PATHS "${_SRC_BIN_PATH}")
     endforeach()
 
-    list(APPEND _BIN_PATHS ${_RULE_GENERATED_SRCS})
-
     set(_DEPS ${_RULE_DEPS} ${_BIN_PATHS})
     add_custom_target(${_NAME} ALL DEPENDS ${_DEPS})
 
     cg_add_data_dependencies(NAME ${_RULE_NAME} DATA ${_RULE_DATA})
+
+    set_property(TARGET ${_NAME} PROPERTY OUTPUTS ${_BIN_PATHS})
 
     # If only one src file set the LOCATION target property to point to it.
     list(LENGTH _BIN_PATHS _BIN_PATHS_LENGTH)

--- a/build_tools/cmake/cg_target_outputs.cmake
+++ b/build_tools/cmake/cg_target_outputs.cmake
@@ -1,0 +1,16 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+include_guard(GLOBAL)
+include(CMakeParseArguments)
+
+function(cg_target_outputs)
+    cmake_parse_arguments(ARG "" "RESULT" "TARGETS" ${ARGN})
+    unset(RES_)
+    foreach(TARGET_ ${ARG_TARGETS})
+        list(APPEND RES_ $<TARGET_PROPERTY:${TARGET_},OUTPUTS>)
+    endforeach()
+    set("${ARG_RESULT}" ${RES_} PARENT_SCOPE)
+endfunction()

--- a/build_tools/cmake/grpc.cmake
+++ b/build_tools/cmake/grpc.cmake
@@ -10,6 +10,7 @@ include_guard(GLOBAL)
 include(CMakeParseArguments)
 include(cg_macros)
 include(cg_py_library)
+include(cg_target_outputs)
 include(protobuf)
 
 function(get_cc_grpc_proto_out_files _PROTO_FILENAME _RESULT)
@@ -43,6 +44,7 @@ function(cc_grpc_library)
     endif()
 
     rename_bazel_targets(_DEPS "${_RULE_DEPS}")
+    cg_target_outputs(TARGETS ${_DEPS} RESULT _DEPS_OUTPUTS)
     rename_bazel_targets(_NAME "${_RULE_NAME}")
     rename_bazel_targets(_SRCS "${_RULE_SRCS}")
 
@@ -84,6 +86,7 @@ function(cc_grpc_library)
             "${_DESCRIPTOR_SET_FILE}"
             "${_PROTO_FILE}"
             ${_DEPS}
+            ${_DEPS_OUTPUTS}
         VERBATIM
     )
 
@@ -119,6 +122,7 @@ function(py_grpc_library)
     cmake_parse_arguments(_RULE "" "NAME;SRCS" "DEPS" ${ARGN})
 
     rename_bazel_targets(_DEPS "${_RULE_DEPS}")
+    cg_target_outputs(TARGETS ${_DEPS} RESULT _DEPS_OUTPUTS)
     rename_bazel_targets(_SRCS "${_RULE_SRCS}")
 
     get_target_property(_DESCRIPTOR_SET_FILE ${_SRCS} PROTO_DESCRIPTOR_SETS)
@@ -150,6 +154,7 @@ function(py_grpc_library)
             "${_DESCRIPTOR_SET_FILE}"
             "${_PROTO_FILE}"
             ${_DEPS}
+            ${_DEPS_OUTPUTS}
         VERBATIM
     )
 

--- a/compiler_gym/util/CMakeLists.txt
+++ b/compiler_gym/util/CMakeLists.txt
@@ -32,8 +32,6 @@ cg_py_library(
     "thread_pool.py"
     "timer.py"
     "truncate.py"
-  GENERATED_SRCS
-    "$<TARGET_PROPERTY:compiler_gym__util__make_version,LOCATION>"
   DEPS
     make_version
     compiler_gym::errors::errors


### PR DESCRIPTION
This fixes dependency issues where a dependency of a custom command
on a custom target guarantees only the order of building and does
not guarantee that the custom command would rerun every time
when the custom target is rebuilt.

The approach to fix this is for custom targets to record in the
OUTPUTS target property their output files. Then the dependent
custom command depends on the contents of the OUTPUTS property
using generator expressions. This creates a file level dependencies
that triggers rebuilds on change.

Fixes #636
