### PR TITLE
[wrappers] Add a ForkOnStep wrapper.

### DIFF
--- a/compiler_gym/wrappers/BUILD
+++ b/compiler_gym/wrappers/BUILD
@@ -11,6 +11,7 @@ py_library(
         "commandline.py",
         "core.py",
         "datasets.py",
+        "fork.py",
         "llvm.py",
         "sqlite_logger.py",
         "time_limit.py",

--- a/compiler_gym/wrappers/CMakeLists.txt
+++ b/compiler_gym/wrappers/CMakeLists.txt
@@ -10,6 +10,7 @@ set(WRAPPERS_SRCS
     "commandline.py"
     "core.py"
     "datasets.py"
+    "fork.py"
     "time_limit.py"
     "validation.py"
 )

--- a/compiler_gym/wrappers/__init__.py
+++ b/compiler_gym/wrappers/__init__.py
@@ -44,6 +44,7 @@ from compiler_gym.wrappers.datasets import (
     IterateOverBenchmarks,
     RandomOrderBenchmarks,
 )
+from compiler_gym.wrappers.fork import ForkOnStep
 
 if config.enable_llvm_env:
     from compiler_gym.wrappers.llvm import RuntimePointEstimateReward  # noqa: F401
@@ -62,6 +63,7 @@ __all__ = [
     "ConstrainedCommandline",
     "CycleOverBenchmarks",
     "CycleOverBenchmarksIterator",
+    "ForkOnStep",
     "IterateOverBenchmarks",
     "ObservationWrapper",
     "RandomOrderBenchmarks",

--- a/compiler_gym/wrappers/fork.py
+++ b/compiler_gym/wrappers/fork.py
@@ -1,0 +1,75 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""This module implements fork wrappers."""
+from typing import List
+
+from compiler_gym.envs import CompilerEnv
+from compiler_gym.wrappers import CompilerEnvWrapper
+
+
+class ForkOnStep(CompilerEnvWrapper):
+    """A wrapper that creates a fork of the environment before every step.
+
+    This wrapper creates a new fork of the environment before every call to
+    :meth:`env.reset() <compiler_gym.envs.CompilerEnv.reset>`. Because of this,
+    this environment supports an additional :meth:`env.undo()
+    <compiler_gym.wrappers.ForkOnStep.undo>` method that can be used to
+    backtrack.
+
+    Example usage:
+
+        >>> env = ForkOnStep(compiler_gym.make("llvm-v0"))
+        >>> env.step(0)
+        >>> env.actions
+        [0]
+        >>> env.undo()
+        >>> env.actions
+        []
+
+    :ivar stack: A fork of the environment before every previous call to
+        :meth:`env.reset() <compiler_gym.envs.CompilerEnv.reset>`, ordered
+        oldest to newest.
+
+    :vartype stack: List[CompilerEnv]
+    """
+
+    def __init__(self, env: CompilerEnv):
+        """Constructor.
+
+        :param env: The environment to wrap.
+        """
+        super().__init__(env)
+        self.stack: List[CompilerEnv] = []
+
+    def undo(self) -> CompilerEnv:
+        """Undo the previous action.
+
+        :returns: Self.
+        """
+        if not self.stack:
+            return
+        self.env.close()
+        self.env = self.stack.pop()
+        return self.env
+
+    def close(self) -> None:
+        for env in self.stack:
+            env.close()
+        self.stack: List[CompilerEnv] = []
+        self.env.close()
+        self.custom_close = True
+
+    def reset(self, *args, **kwargs):
+        self.env.reset()
+        for env in self.stack:
+            env.close()
+        self.stack: List[CompilerEnv] = []
+
+    def step(self, *args, **kwargs):
+        self.stack.append(self.env.fork())
+        return self.env.step(*args, **kwargs)
+
+    def fork(self):
+        raise NotImplementedError

--- a/docs/source/compiler_gym/wrappers.rst
+++ b/docs/source/compiler_gym/wrappers.rst
@@ -49,6 +49,15 @@ Action space wrappers
 
 .. autoclass:: TimeLimit
 
+    .. automethod:: __init__
+
+
+.. autoclass:: ForkOnStep
+
+    .. automethod:: __init__
+
+    .. automethod:: undo
+
 
 Datasets wrappers
 -----------------

--- a/tests/wrappers/BUILD
+++ b/tests/wrappers/BUILD
@@ -38,6 +38,18 @@ py_test(
 )
 
 py_test(
+    name = "fork_test",
+    srcs = ["fork_test.py"],
+    deps = [
+        "//compiler_gym/envs/llvm",
+        "//compiler_gym/errors",
+        "//compiler_gym/wrappers",
+        "//tests:test_main",
+        "//tests/pytest_plugins:llvm",
+    ],
+)
+
+py_test(
     name = "llvm_test",
     timeout = "long",
     srcs = ["llvm_test.py"],

--- a/tests/wrappers/CMakeLists.txt
+++ b/tests/wrappers/CMakeLists.txt
@@ -43,6 +43,17 @@ cg_py_test(
 )
 
 cg_py_test(
+  NAME fork_test
+  SRCS "fork_test.py"
+  DEPS
+    compiler_gym::envs::llvm::llvm
+    compiler_gym::errors::errors
+    compiler_gym::wrappers::wrappers
+    tests::test_main
+    tests::pytest_plugins::llvm
+)
+
+cg_py_test(
   NAME llvm_test
   SRCS "llvm_test.py"
   DEPS

--- a/tests/wrappers/core_wrappers_test.py
+++ b/tests/wrappers/core_wrappers_test.py
@@ -311,5 +311,24 @@ def test_wrapped_env_close(env: LlvmEnv):
     assert wrapped.service is None
 
 
+def test_wrapped_env_custom_close(env: LlvmEnv):
+    """Test that a custom close() method is called on wrapped environments."""
+
+    class MyWrapper(CompilerEnvWrapper):
+        def __init__(self, env: LlvmEnv):
+            super().__init__(env)
+            self.custom_close = False
+
+        def close(self):
+            self.custom_close = True
+            self.env.close()
+
+    env = MyWrapper(env)
+    assert not env.custom_close
+
+    env.close()
+    assert env.custom_close
+
+
 if __name__ == "__main__":
     main()

--- a/tests/wrappers/fork_test.py
+++ b/tests/wrappers/fork_test.py
@@ -1,0 +1,68 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Unit tests for //compiler_gym/wrappers."""
+from compiler_gym.envs.llvm import LlvmEnv
+from compiler_gym.wrappers import ForkOnStep
+from tests.test_main import main
+
+pytest_plugins = ["tests.pytest_plugins.llvm"]
+
+
+def test_ForkOnStep_step(env: LlvmEnv):
+    with ForkOnStep(env) as env:
+        env.reset()
+        assert env.stack == []
+
+        env.step(0)
+        assert env.actions == [0]
+        assert len(env.stack) == 1
+        assert env.stack[0].actions == []
+
+        env.step(1)
+        assert env.actions == [0, 1]
+        assert len(env.stack) == 2
+        assert env.stack[1].actions == [0]
+        assert env.stack[0].actions == []
+
+
+def test_ForkOnStep_reset(env: LlvmEnv):
+    with ForkOnStep(env) as env:
+        env.reset()
+
+        env.step(0)
+        assert env.actions == [0]
+        assert len(env.stack) == 1
+
+        env.reset()
+        assert env.actions == []
+        assert env.stack == []
+
+
+def test_ForkOnStep_double_close(env: LlvmEnv):
+    with ForkOnStep(env) as env:
+        env.close()
+        env.close()
+
+
+def test_ForkOnStep_undo(env: LlvmEnv):
+    with ForkOnStep(env) as env:
+        env.reset()
+
+        env.step(0)
+        assert env.actions == [0]
+        assert len(env.stack) == 1
+
+        env.undo()
+        assert env.actions == []
+        assert not env.stack
+
+        # Undo of an empty stack:
+        env.undo()
+        assert env.actions == []
+        assert not env.stack
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This adds a new wrapper class, `ForkOnStep`, that can be used to backtrack by maintaining a stack of forked environments before every call to step().
