### PR TITLE
[Minor Bug] fix typo in argument & add flag

### DIFF
--- a/examples/sensitivity_analysis/action_sensitivity_analysis.py
+++ b/examples/sensitivity_analysis/action_sensitivity_analysis.py
@@ -40,10 +40,12 @@ from sensitivity_analysis.sensitivity_analysis_eval import (
 from compiler_gym.envs import CompilerEnv
 from compiler_gym.util.flags.benchmark_from_flags import benchmark_from_flags
 from compiler_gym.util.flags.env_from_flags import env_from_flags
+from compiler_gym.util.flags import nproc
 from compiler_gym.util.gym_type_hints import ActionType
 from compiler_gym.util.logs import create_logging_dir
 from compiler_gym.util.timer import Timer
 
+flags.adopt_module_key_flags(nproc)
 flags.DEFINE_integer(
     "num_action_sensitivity_trials",
     100,
@@ -68,11 +70,6 @@ flags.DEFINE_integer(
     "A trial may fail because the environment crashes, or an action produces an invalid state. "
     "Limit the total number of trials performed for each action to "
     "max_action_attempts_multiplier * num_trials.",
-)
-flags.DEFINE_integer(
-    "nproc",
-    cpu_count(),
-    "The number of cpus to use"
 )
 
 

--- a/examples/sensitivity_analysis/action_sensitivity_analysis.py
+++ b/examples/sensitivity_analysis/action_sensitivity_analysis.py
@@ -35,7 +35,6 @@ from sensitivity_analysis.sensitivity_analysis_eval import (
     SensitivityAnalysisResult,
     run_sensitivity_analysis,
 )
-
 from compiler_gym.envs import CompilerEnv
 from compiler_gym.util.flags.benchmark_from_flags import benchmark_from_flags
 from compiler_gym.util.flags.env_from_flags import env_from_flags

--- a/examples/sensitivity_analysis/action_sensitivity_analysis.py
+++ b/examples/sensitivity_analysis/action_sensitivity_analysis.py
@@ -69,6 +69,12 @@ flags.DEFINE_integer(
     "Limit the total number of trials performed for each action to "
     "max_action_attempts_multiplier * num_trials.",
 )
+flags.DEFINE_integer(
+    "nproc",
+    cpu_count(),
+    "The number of cpus to use"
+)
+
 
 FLAGS = flags.FLAGS
 
@@ -130,7 +136,7 @@ def run_action_sensitivity_analysis(
     reward_space: str,
     num_trials: int,
     max_warmup_steps: int,
-    nproc: int = cpu_count(),
+    nproc: int,
     max_attempts_multiplier: int = 5,
 ):
     """Estimate the immediate reward of a given list of actions."""
@@ -181,7 +187,7 @@ def main(argv):
         rewards_path=rewards_path,
         runtimes_path=runtimes_path,
         actions=actions,
-        reward=FLAGS.reward,
+        reward_space=FLAGS.reward,
         num_trials=FLAGS.num_action_sensitivity_trials,
         max_warmup_steps=FLAGS.max_warmup_steps,
         nproc=FLAGS.nproc,

--- a/examples/sensitivity_analysis/action_sensitivity_analysis.py
+++ b/examples/sensitivity_analysis/action_sensitivity_analysis.py
@@ -45,7 +45,6 @@ from compiler_gym.util.gym_type_hints import ActionType
 from compiler_gym.util.logs import create_logging_dir
 from compiler_gym.util.timer import Timer
 
-flags.adopt_module_key_flags(nproc)
 flags.DEFINE_integer(
     "num_action_sensitivity_trials",
     100,
@@ -71,7 +70,6 @@ flags.DEFINE_integer(
     "Limit the total number of trials performed for each action to "
     "max_action_attempts_multiplier * num_trials.",
 )
-
 
 FLAGS = flags.FLAGS
 

--- a/examples/sensitivity_analysis/action_sensitivity_analysis.py
+++ b/examples/sensitivity_analysis/action_sensitivity_analysis.py
@@ -26,7 +26,6 @@ Evaluate the single-step immediate reward of all actions on LLVM codesize:
 """
 import random
 from concurrent.futures import ThreadPoolExecutor
-from multiprocessing import cpu_count
 from pathlib import Path
 from typing import List, Optional
 
@@ -40,7 +39,7 @@ from sensitivity_analysis.sensitivity_analysis_eval import (
 from compiler_gym.envs import CompilerEnv
 from compiler_gym.util.flags.benchmark_from_flags import benchmark_from_flags
 from compiler_gym.util.flags.env_from_flags import env_from_flags
-from compiler_gym.util.flags import nproc
+from compiler_gym.util.flags import nproc  # noqa
 from compiler_gym.util.gym_type_hints import ActionType
 from compiler_gym.util.logs import create_logging_dir
 from compiler_gym.util.timer import Timer


### PR DESCRIPTION
PR to fix minor bug in `examples/sensitivity_analysis/action_sensitivity_analysis.py`

fix to https://github.com/facebookresearch/CompilerGym/blob/f30ebba819bc2f1bbdd4d511ab62d4758aa2b37b/examples/sensitivity_analysis/action_sensitivity_analysis.py#L126

1. no flag for `nproc`
2. wrong argument name `reward` -> `reward_space`