### PR TITLE
Fix build hang by removing USES_TERMINAL from Programl Cmake command

### DIFF
--- a/external/programl/CMakeLists.txt
+++ b/external/programl/CMakeLists.txt
@@ -44,5 +44,4 @@ externalproject_add_step(
         @labm8//labm8/cpp:string @labm8//labm8/cpp:stringpiece
     DEPENDEES update
     WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/programl/src/programl"
-    USES_TERMINAL TRUE
 )


### PR DESCRIPTION
On my local Linux VM, it seems that removing USES_TERMINAL solves the problem of that 3 hour hang after bazel build.
This was based on an uneducated guess :) Let's see if CI will speedup

Fixes #566
