### PR TITLE
[tests] Reduce the number of cBench validation datasets for CI, 7.2x speedup.

### DIFF
--- a/compiler_gym/envs/llvm/datasets/cbench.py
+++ b/compiler_gym/envs/llvm/datasets/cbench.py
@@ -725,7 +725,14 @@ validator(
     cmd="$BIN 512",
 )
 
-for i in range(1, 21):
+# The cBench benchmarks contain 20 runtime datasets. When use all 20 datasets
+# when validating the correctness of one of these benchmarks, we use all 20
+# datasets. However, this takes a long time, so for CI jobs (determined by the
+# presence of the $CI environment variable), we use only a single dataset for
+# testing.
+NUM_DATASETS = 1 if os.environ.get("CI", "") == "1" else 20
+
+for i in range(1, NUM_DATASETS + 1):
 
     # NOTE(cummins): Disabled due to timeout errors, further investigation
     # needed.

--- a/compiler_gym/envs/llvm/datasets/cbench.py
+++ b/compiler_gym/envs/llvm/datasets/cbench.py
@@ -728,9 +728,8 @@ validator(
 # The cBench benchmarks contain 20 runtime datasets. When use all 20 datasets
 # when validating the correctness of one of these benchmarks, we use all 20
 # datasets. However, this takes a long time, so for CI jobs (determined by the
-# presence of the $CI environment variable), we use only a single dataset for
-# testing.
-NUM_DATASETS = 1 if os.environ.get("CI", "") == "1" else 20
+# presence of the $CI environment variable), we use only 2 datasets for testing.
+NUM_DATASETS = 2 if os.environ.get("CI", "") == "1" else 20
 
 for i in range(1, NUM_DATASETS + 1):
 

--- a/examples/llvm_rl/model/model.py
+++ b/examples/llvm_rl/model/model.py
@@ -4,12 +4,12 @@
 # LICENSE file in the root directory of this source tree.
 import json
 import logging
+import warnings
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional
 
 import pandas as pd
-import ray
 import yaml
 from pydantic import BaseModel, Field
 from ray import tune
@@ -23,6 +23,11 @@ from .environment import Environment
 from .inference_result import InferenceResult
 from .testing import Testing
 from .training import Training
+
+# Ignore import deprecation warnings from ray.
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", category=DeprecationWarning)
+    import ray
 
 logger = logging.getLogger(__name__)
 

--- a/tests/loop_tool/actions_test.py
+++ b/tests/loop_tool/actions_test.py
@@ -14,6 +14,7 @@ from tests.test_main import main
 
 @flaky
 @pytest.mark.parametrize("backend", lt.backends())
+@pytest.mark.timeout(600)
 def test_basic(backend):
     with compiler_gym.make("loop_tool-v0") as env:
         env.observation_space = "flops"
@@ -37,6 +38,7 @@ def test_basic(backend):
 
 @flaky
 @pytest.mark.parametrize("backend", lt.backends())
+@pytest.mark.timeout(600)
 def test_rand(backend):
     with compiler_gym.make("loop_tool-v0") as env:
         env.observation_space = "flops"
@@ -58,6 +60,7 @@ def test_rand(backend):
 
 @flaky
 @pytest.mark.parametrize("backend", lt.backends())
+@pytest.mark.timeout(600)
 def test_induced_remainder(backend):
     with compiler_gym.make("loop_tool-v0") as env:
         env.observation_space = "loop_tree"
@@ -97,6 +100,7 @@ for a in 341 r 1 : L0 {'cpu_parallel ' if backend=='cpu' else ''}[thread]
 
 @flaky
 @pytest.mark.parametrize("backend", lt.backends())
+@pytest.mark.timeout(600)
 def test_thread_removal(backend):
     with compiler_gym.make("loop_tool-v0") as env:
         env.observation_space = "loop_tree"
@@ -128,6 +132,7 @@ for a in 1024 : L0
 
 @flaky
 @pytest.mark.parametrize("backend", lt.backends())
+@pytest.mark.timeout(600)
 def test_thread_addition(backend):
     with compiler_gym.make("loop_tool-v0") as env:
         env.observation_space = "loop_tree"

--- a/tests/mlir/rllib_ppo_smoke_test.py
+++ b/tests/mlir/rllib_ppo_smoke_test.py
@@ -3,11 +3,11 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 import random
+import warnings
 
 import gym
 import numpy as np
 import pytest
-import ray
 import torch
 from flaky import flaky
 from ray.rllib.agents.ppo import PPOTrainer
@@ -15,6 +15,11 @@ from ray.tune.registry import register_env
 
 from compiler_gym.wrappers.mlir import make_mlir_rl_wrapper_env
 from tests.test_main import main
+
+# Ignore import deprecation warnings from ray.
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", category=DeprecationWarning)
+    import ray
 
 
 @flaky(max_runs=3, min_passes=1)


### PR DESCRIPTION
As @mostafaelhoushi identified in #706, the CI tests take a long time. Here's `--durations` report for a recent run:

```
============================= slowest 5 durations ==============================
427.74s call     tests/loop_tool/actions_test.py::test_basic[cpu]
425.24s call     tests/llvm/datasets/cbench_validate_test.py::test_validate_benchmark_semantics[benchmark://cbench-v1/jpeg-d]
377.92s call     tests/llvm/datasets/cbench_validate_test.py::test_validate_benchmark_semantics[benchmark://cbench-v1/tiff2bw]
359.21s call     tests/llvm/datasets/cbench_validate_test.py::test_validate_benchmark_semantics[benchmark://cbench-v1/tiff2rgba]
350.26s call     tests/llvm/datasets/cbench_validate_test.py::test_validate_benchmark_semantics[benchmark://cbench-v1/dijkstra]
==== 1461 passed, 824 skipped, 1 xfailed, 12 xpassed in 3629.28s (1:00:29) =====
```

As can be seen, a lot of time is spent in only 4 of the `tests/llvm/datasets/cbench_validate_test.py` tests. To address this, this PR changes the runtime specification of the cBench validators so that only a single dataset is used for validation when running tests in the CI environment, rather than all 20. This reduces the wall time for the validation tests on my local 80-core dev machine from 5 minutes to 41 seconds, **7.2x speedup**.

Reference numbers from my local machine on `development`:

```
$ time make install-test PYTEST_ARGS='--durations=25' TEST_TARGET=tests/llvm/datasets/cbench_validate_test.py

 tests/llvm/datasets/cbench_validate_test.py ✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓                                                                    100% ██████████
================================================================ slowest 25 durations ================================================================
292.12s call     tests/llvm/datasets/cbench_validate_test.py::test_validate_benchmark_semantics[benchmark://cbench-v1/tiff2rgba]
280.66s call     tests/llvm/datasets/cbench_validate_test.py::test_validate_benchmark_semantics[benchmark://cbench-v1/tiffmedian]
280.35s call     tests/llvm/datasets/cbench_validate_test.py::test_validate_benchmark_semantics[benchmark://cbench-v1/tiff2bw]
277.63s call     tests/llvm/datasets/cbench_validate_test.py::test_validate_benchmark_semantics[benchmark://cbench-v1/tiffdither]
251.51s call     tests/llvm/datasets/cbench_validate_test.py::test_validate_benchmark_semantics[benchmark://cbench-v1/jpeg-d]
240.96s call     tests/llvm/datasets/cbench_validate_test.py::test_validate_benchmark_semantics[benchmark://cbench-v1/dijkstra]
156.03s call     tests/llvm/datasets/cbench_validate_test.py::test_validate_benchmark_semantics[benchmark://cbench-v1/jpeg-c]
151.85s call     tests/llvm/datasets/cbench_validate_test.py::test_validate_benchmark_semantics[benchmark://cbench-v1/bzip2]
94.80s call     tests/llvm/datasets/cbench_validate_test.py::test_validate_benchmark_semantics[benchmark://cbench-v1/gsm]
76.82s call     tests/llvm/datasets/cbench_validate_test.py::test_validate_benchmark_semantics[benchmark://cbench-v1/susan]
32.07s call     tests/llvm/datasets/cbench_validate_test.py::test_validate_benchmark_semantics[benchmark://cbench-v1/blowfish]
25.58s call     tests/llvm/datasets/cbench_validate_test.py::test_validate_benchmark_semantics[benchmark://cbench-v1/patricia]
24.55s call     tests/llvm/datasets/cbench_validate_test.py::test_validate_benchmark_semantics[benchmark://cbench-v1/stringsearch]
21.69s call     tests/llvm/datasets/cbench_validate_test.py::test_validate_benchmark_semantics[benchmark://cbench-v1/qsort]
16.54s call     tests/llvm/datasets/cbench_validate_test.py::test_validate_benchmark_semantics[benchmark://cbench-v1/crc32]
13.05s call     tests/llvm/datasets/cbench_validate_test.py::test_validate_benchmark_semantics[benchmark://cbench-v1/sha]
5.90s call     tests/llvm/datasets/cbench_validate_test.py::test_non_validatable_benchmark_validate[benchmark://cbench-v1/lame]
3.45s call     tests/llvm/datasets/cbench_validate_test.py::test_validate_benchmark_semantics[benchmark://cbench-v1/bitcount]
2.31s call     tests/llvm/datasets/cbench_validate_test.py::test_non_validatable_benchmark_validate[benchmark://cbench-v1/ispell]
1.06s call     tests/llvm/datasets/cbench_validate_test.py::test_validate_benchmark_semantics[benchmark://cbench-v1/stringsearch2]
0.60s call     tests/llvm/datasets/cbench_validate_test.py::test_non_validatable_benchmark_validate[benchmark://cbench-v1/rijndael]
0.42s teardown tests/llvm/datasets/cbench_validate_test.py::test_validate_benchmark_semantics[benchmark://cbench-v1/tiff2rgba]
0.40s teardown tests/llvm/datasets/cbench_validate_test.py::test_validate_benchmark_semantics[benchmark://cbench-v1/tiffmedian]
0.38s teardown tests/llvm/datasets/cbench_validate_test.py::test_validate_benchmark_semantics[benchmark://cbench-v1/jpeg-d]
0.38s teardown tests/llvm/datasets/cbench_validate_test.py::test_validate_benchmark_semantics[benchmark://cbench-v1/dijkstra]

Results (299.33s):
      22 passed
make install-test PYTEST_ARGS='--durations=25'   2225.02s user 314.10s system 845% cpu 5:00.37 total
```

And with the new CI environment tests:

```
$ time make install-test CI=1 PYTEST_ARGS='--durations=25' TEST_TARGET=tests/llvm/datasets/cbench_validate_test.py

 tests/llvm/datasets/cbench_validate_test.py ✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓                                                                   100% ██████████
================================================================ slowest 25 durations ================================================================
34.52s call     tests/llvm/datasets/cbench_validate_test.py::test_non_validatable_benchmark_validate[benchmark://cbench-v1/ghostscript]
18.94s call     tests/llvm/datasets/cbench_validate_test.py::test_validate_benchmark_semantics[benchmark://cbench-v1/tiffmedian]
18.28s call     tests/llvm/datasets/cbench_validate_test.py::test_validate_benchmark_semantics[benchmark://cbench-v1/tiff2bw]
17.80s call     tests/llvm/datasets/cbench_validate_test.py::test_validate_benchmark_semantics[benchmark://cbench-v1/tiffdither]
17.80s call     tests/llvm/datasets/cbench_validate_test.py::test_validate_benchmark_semantics[benchmark://cbench-v1/tiff2rgba]
17.11s call     tests/llvm/datasets/cbench_validate_test.py::test_validate_benchmark_semantics[benchmark://cbench-v1/jpeg-d]
11.91s call     tests/llvm/datasets/cbench_validate_test.py::test_validate_benchmark_semantics[benchmark://cbench-v1/jpeg-c]
10.60s call     tests/llvm/datasets/cbench_validate_test.py::test_validate_benchmark_semantics[benchmark://cbench-v1/bzip2]
5.31s call     tests/llvm/datasets/cbench_validate_test.py::test_non_validatable_benchmark_validate[benchmark://cbench-v1/lame]
5.19s call     tests/llvm/datasets/cbench_validate_test.py::test_validate_benchmark_semantics[benchmark://cbench-v1/gsm]
5.07s call     tests/llvm/datasets/cbench_validate_test.py::test_validate_benchmark_semantics[benchmark://cbench-v1/susan]
3.19s call     tests/llvm/datasets/cbench_validate_test.py::test_validate_benchmark_semantics[benchmark://cbench-v1/bitcount]
2.20s call     tests/llvm/datasets/cbench_validate_test.py::test_non_validatable_benchmark_validate[benchmark://cbench-v1/ispell]
2.07s call     tests/llvm/datasets/cbench_validate_test.py::test_validate_benchmark_semantics[benchmark://cbench-v1/blowfish]
1.65s call     tests/llvm/datasets/cbench_validate_test.py::test_validate_benchmark_semantics[benchmark://cbench-v1/qsort]
1.62s call     tests/llvm/datasets/cbench_validate_test.py::test_validate_benchmark_semantics[benchmark://cbench-v1/stringsearch]
1.27s call     tests/llvm/datasets/cbench_validate_test.py::test_validate_benchmark_semantics[benchmark://cbench-v1/patricia]
1.12s call     tests/llvm/datasets/cbench_validate_test.py::test_validate_benchmark_semantics[benchmark://cbench-v1/stringsearch2]
1.12s call     tests/llvm/datasets/cbench_validate_test.py::test_validate_benchmark_semantics[benchmark://cbench-v1/dijkstra]
1.03s call     tests/llvm/datasets/cbench_validate_test.py::test_validate_benchmark_semantics[benchmark://cbench-v1/sha]
1.02s call     tests/llvm/datasets/cbench_validate_test.py::test_validate_benchmark_semantics[benchmark://cbench-v1/crc32]
0.58s call     tests/llvm/datasets/cbench_validate_test.py::test_non_validatable_benchmark_validate[benchmark://cbench-v1/rijndael]
0.23s setup    tests/llvm/datasets/cbench_validate_test.py::test_validate_benchmark_semantics[benchmark://cbench-v1/crc32]
0.20s setup    tests/llvm/datasets/cbench_validate_test.py::test_validate_benchmark_semantics[benchmark://cbench-v1/jpeg-c]
0.20s call     tests/llvm/datasets/cbench_validate_test.py::test_non_validatable_benchmark_validate[benchmark://cbench-v1/adpcm]

Results (41.61s):
      23 passed
make install-test PYTEST_ARGS='--durations=25'   270.05s user 194.57s system 1085% cpu 42.806 total
```

This does not affect the behavior of `make install-test` when run on a local machine.