### PR TITLE
[tests] Make CI=1 explicit for CI jobs.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -295,7 +295,7 @@ jobs:
               shell: bash
 
             - name: Run the test suite
-              run: make install-test PYTEST_ARGS="--ignore tests/mlir"
+              run: make install-test CI=1 PYTEST_ARGS="--ignore tests/mlir"
 
     test-mlir-env-linux-cmake:
         needs: build-mlir-env-linux-cmake
@@ -327,7 +327,7 @@ jobs:
               run: python -m pip install -r tests/requirements.txt
 
             - name: Run the test suite
-              run: make install-test-cov TEST_TARGET="tests/mlir"
+              run: make install-test-cov CI=1 TEST_TARGET="tests/mlir"
 
     test-macos:
         needs: build-macos
@@ -361,6 +361,7 @@ jobs:
             - name: Run the test suite
               run: |
                   make install-test-cov \
+                  CI=1 \
                   PYTEST_ARGS="--ignore tests/llvm --ignore tests/gcc --ignore tests/loop_tool --ignore tests/mlir"
 
             - name: Upload coverage report to Codecov
@@ -395,7 +396,7 @@ jobs:
               run: python -m pip install -r tests/requirements.txt
 
             - name: Run the test suite
-              run: make install-test-cov TEST_TARGET="tests/llvm"
+              run: make install-test-cov CI=1 TEST_TARGET="tests/llvm"
 
             - name: Upload coverage report to Codecov
               uses: codecov/codecov-action@v2
@@ -429,7 +430,7 @@ jobs:
               run: python -m pip install -r tests/requirements.txt
 
             - name: Run the test suite
-              run: make install-test-cov TEST_TARGET="tests/llvm"
+              run: make install-test-cov CI=1 TEST_TARGET="tests/llvm"
 
             - name: Upload coverage report to Codecov
               uses: codecov/codecov-action@v2
@@ -463,7 +464,7 @@ jobs:
               run: python -m pip install -r tests/requirements.txt
 
             - name: Run the test suite
-              run: make install-test-cov TEST_TARGET="tests/gcc"
+              run: make install-test-cov CI=1 TEST_TARGET="tests/gcc"
 
             - name: Upload coverage report to Codecov
               uses: codecov/codecov-action@v2
@@ -499,7 +500,7 @@ jobs:
               run: python -m pip install -r tests/requirements.txt
 
             - name: Run the test suite
-              run: make install-test-cov TEST_TARGET="tests/gcc"
+              run: make install-test-cov CI=1 TEST_TARGET="tests/gcc"
 
             - name: Upload coverage report to Codecov
               uses: codecov/codecov-action@v2
@@ -530,7 +531,7 @@ jobs:
               run: python -m pip install -r tests/requirements.txt
 
             - name: Run the test suite
-              run: make install-test-cov TEST_TARGET="tests/gcc"
+              run: make install-test-cov CI=1 TEST_TARGET="tests/gcc"
 
             - name: Upload coverage report to Codecov
               uses: codecov/codecov-action@v2
@@ -561,7 +562,7 @@ jobs:
               run: python -m pip install -r tests/requirements.txt
 
             - name: Run the test suite
-              run: make install-test-cov TEST_TARGET="tests/loop_tool"
+              run: make install-test-cov CI=1 TEST_TARGET="tests/loop_tool"
 
             - name: Upload coverage report to Codecov
               uses: codecov/codecov-action@v2
@@ -592,7 +593,7 @@ jobs:
               run: python -m pip install -r tests/requirements.txt
 
             - name: Run the test suite
-              run: make install-test-cov TEST_TARGET="tests/loop_tool"
+              run: make install-test-cov CI=1 TEST_TARGET="tests/loop_tool"
 
             - name: Upload coverage report to Codecov
               uses: codecov/codecov-action@v2
@@ -743,7 +744,7 @@ jobs:
               run: python -m pip install -r tests/requirements.txt
 
             - name: Test
-              run: make install-test TEST_TARGET=tests/llvm
+              run: make install-test CI=1 TEST_TARGET=tests/llvm
               env:
                   ASAN_OPTIONS: detect_leaks=1
                   CC: clang


### PR DESCRIPTION
Hmm, looks like #708 didn't affect the Cmake test job runtime. Let's pass in `CI=1` explicitly and see if that fixes it.