### PR TITLE
[bugfix] fix bug where we are not running the correct number of warmu…

### DIFF
--- a/compiler_gym/envs/llvm/service/Benchmark.cc
+++ b/compiler_gym/envs/llvm/service/Benchmark.cc
@@ -239,7 +239,7 @@ Status Benchmark::computeRuntime(Event& observation) {
   // Run the warmup runs.
   VLOG(3) << "Running " << getWarmupRunsPerRuntimeObservationCount()
           << " warmup iterations of binary";
-  for (int i = 0; i < getRuntimesPerObservationCount(); ++i) {
+  for (int i = 0; i < getWarmupRunsPerRuntimeObservationCount(); ++i) {
     RETURN_IF_ERROR(cfg.runCommand().checkCall());
   }
 


### PR DESCRIPTION
This seems like a typo in the original code.
We are running warmup runs `getRuntimesPerObservationCount` times where we should be actually running it `getWarmupRunsPerRuntimeObservationCount` times