### PR TITLE
Tidy up some minor implementation details in timeout handling

### DIFF
--- a/compiler_gym/envs/compiler_env.py
+++ b/compiler_gym/envs/compiler_env.py
@@ -352,7 +352,7 @@ class CompilerEnv(gym.Env, ABC):
         reward_space: Union[
             OptionalArgumentValue, str, Reward
         ] = OptionalArgumentValue.UNCHANGED,
-        timeout: Optional[float] = 300,
+        timeout: float = 300,
     ) -> Optional[ObservationType]:
         """Reset the environment state.
 
@@ -389,8 +389,8 @@ class CompilerEnv(gym.Env, ABC):
             available spaces, see :class:`env.reward.spaces
             <compiler_gym.views.RewardView>`.
 
-        :param timeout: The maximum number of seconds to wait for an RPC method
-            call to succeed. Accepts a float value. The default is 300 seconds.
+        :param timeout: The maximum number of seconds to wait for reset to
+            succeed.
 
         :return: The initial observation.
 
@@ -410,7 +410,7 @@ class CompilerEnv(gym.Env, ABC):
         reward_spaces: Optional[Iterable[Union[str, Reward]]] = None,
         observations: Optional[Iterable[Union[str, ObservationSpaceSpec]]] = None,
         rewards: Optional[Iterable[Union[str, Reward]]] = None,
-        timeout: Optional[float] = 300,
+        timeout: float = 300,
     ) -> StepType:
         """Take a step.
 
@@ -422,13 +422,13 @@ class CompilerEnv(gym.Env, ABC):
             requested spaces. The default :code:`env.observation_space` is not
             returned.
 
-        :param reward_spaces: A list of reward spaces to compute rewards from. If
-            provided, this changes the :code:`reward` element of the return
+        :param reward_spaces: A list of reward spaces to compute rewards from.
+            If provided, this changes the :code:`reward` element of the return
             tuple to be a list of rewards from the requested spaces. The default
             :code:`env.reward_space` is not returned.
 
-        :param timeout: The maximum number of seconds to wait for an RPC method
-            call to succeed. Accepts a float value. The default is 300 seconds.
+        :param timeout: The maximum number of seconds to wait for the step to
+            succeed. Accepts a float value. The default is 300 seconds.
 
         :return: A tuple of observation, reward, done, and info. Observation and
             reward are None if default observation/reward is not set.
@@ -443,7 +443,7 @@ class CompilerEnv(gym.Env, ABC):
         reward_spaces: Optional[Iterable[Union[str, Reward]]] = None,
         observations: Optional[Iterable[Union[str, ObservationSpaceSpec]]] = None,
         rewards: Optional[Iterable[Union[str, Reward]]] = None,
-        timeout: Optional[float] = 300,
+        timeout: float = 300,
     ):
         """Take a sequence of steps and return the final observation and reward.
 
@@ -455,13 +455,13 @@ class CompilerEnv(gym.Env, ABC):
             requested spaces. The default :code:`env.observation_space` is not
             returned.
 
-        :param reward_spaces: A list of reward spaces to compute rewards from. If
-            provided, this changes the :code:`reward` element of the return
+        :param reward_spaces: A list of reward spaces to compute rewards from.
+            If provided, this changes the :code:`reward` element of the return
             tuple to be a list of rewards from the requested spaces. The default
             :code:`env.reward_space` is not returned.
 
-        :param timeout: The maximum number of seconds to wait for an RPC method
-            call to succeed. Accepts a float value. The default is 300 seconds.
+        :param timeout: The maximum number of seconds to wait for the steps to
+            succeed. Accepts a float value. The default is 300 seconds.
 
         :return: A tuple of observation, reward, done, and info. Observation and
             reward are None if default observation/reward is not set.

--- a/compiler_gym/envs/gcc/gcc_env.py
+++ b/compiler_gym/envs/gcc/gcc_env.py
@@ -39,7 +39,6 @@ class GccEnv(ClientServiceCompilerEnv):
         benchmark: Union[str, Benchmark] = "benchmark://chstone-v0/adpcm",
         datasets_site_path: Optional[Path] = None,
         connection_settings: Optional[ConnectionOpts] = None,
-        timeout: Optional[int] = None,
         **kwargs,
     ):
         """Create an environment.
@@ -55,8 +54,6 @@ class GccEnv(ClientServiceCompilerEnv):
             default benchmark is used.
 
         :param connection_settings: The connection settings to use.
-
-        :param timeout: The timeout to use when compiling.
 
         :raises EnvironmentNotSupported: If the runtime requirements for the GCC
             environment have not been met.
@@ -86,7 +83,6 @@ class GccEnv(ClientServiceCompilerEnv):
             rewards=[AsmSizeReward(), ObjSizeReward()],
             connection_settings=connection_settings,
         )
-        self._timeout = timeout
 
     def reset(
         self,
@@ -105,8 +101,6 @@ class GccEnv(ClientServiceCompilerEnv):
             observation_space=observation_space,
             reward_space=reward_space,
         )
-        if self._timeout:
-            self.send_param("timeout", str(self._timeout))
         return observation
 
     def commandline(self) -> str:
@@ -115,17 +109,6 @@ class GccEnv(ClientServiceCompilerEnv):
         :return: A string.
         """
         return self.observation["command_line"]
-
-    @property
-    def timeout(self) -> Optional[int]:
-        """Get the current compilation timeout"""
-        return self._timeout
-
-    @timeout.setter
-    def timeout(self, value: Optional[int]):
-        """Tell the service what the compilation timeout is."""
-        self._timeout = value
-        self.send_param("timeout", str(value) if value else "")
 
     @memoized_property
     def gcc_spec(self) -> GccSpec:

--- a/compiler_gym/service/client_service_compiler_env.py
+++ b/compiler_gym/service/client_service_compiler_env.py
@@ -652,7 +652,7 @@ class ClientServiceCompilerEnv(CompilerEnv):
         observation_space: Union[
             OptionalArgumentValue, str, ObservationSpaceSpec
         ] = OptionalArgumentValue.UNCHANGED,
-        timeout: Optional[float] = 300,
+        timeout: float = 300,
     ) -> Optional[ObservationType]:
         return self._reset(
             benchmark=benchmark,
@@ -669,7 +669,7 @@ class ClientServiceCompilerEnv(CompilerEnv):
         action_space: Optional[str],
         observation_space: Union[OptionalArgumentValue, str, ObservationSpaceSpec],
         reward_space: Union[OptionalArgumentValue, str, Reward],
-        timeout: Optional[float],
+        timeout: float,
         retry_count: int,
     ) -> Optional[ObservationType]:
         """Private implementation detail. Call `reset()`, not this."""
@@ -840,7 +840,7 @@ class ClientServiceCompilerEnv(CompilerEnv):
         actions: Iterable[ActionType],
         observation_spaces: List[ObservationSpaceSpec],
         reward_spaces: List[Reward],
-        timeout: Optional[float] = 300,
+        timeout: float = 300,
     ) -> StepType:
         """Take a step.
 
@@ -990,7 +990,7 @@ class ClientServiceCompilerEnv(CompilerEnv):
         reward_spaces: Optional[Iterable[Union[str, Reward]]] = None,
         observations: Optional[Iterable[Union[str, ObservationSpaceSpec]]] = None,
         rewards: Optional[Iterable[Union[str, Reward]]] = None,
-        timeout: Optional[float] = 300,
+        timeout: float = 300,
     ) -> StepType:
         """:raises SessionNotFound: If :meth:`reset()
         <compiler_gym.envs.ClientServiceCompilerEnv.reset>` has not been called.
@@ -1036,6 +1036,7 @@ class ClientServiceCompilerEnv(CompilerEnv):
         reward_spaces: Optional[Iterable[Union[str, Reward]]] = None,
         observations: Optional[Iterable[Union[str, ObservationSpaceSpec]]] = None,
         rewards: Optional[Iterable[Union[str, Reward]]] = None,
+        timeout: float = 300,
     ):
         """:raises SessionNotFound: If :meth:`reset()
         <compiler_gym.envs.ClientServiceCompilerEnv.reset>` has not been called.
@@ -1083,7 +1084,10 @@ class ClientServiceCompilerEnv(CompilerEnv):
 
         # Perform the underlying environment step.
         observation_values, reward_values, done, info = self.raw_step(
-            actions, observation_spaces_to_compute, reward_spaces_to_compute
+            actions,
+            observation_spaces_to_compute,
+            reward_spaces_to_compute,
+            timeout=timeout,
         )
 
         # Translate observations lists back to the appropriate types.

--- a/compiler_gym/service/client_service_compiler_env.py
+++ b/compiler_gym/service/client_service_compiler_env.py
@@ -71,11 +71,11 @@ _logger = logger
 
 
 def _wrapped_step(
-    service: CompilerGymServiceConnection, request: StepRequest
+    service: CompilerGymServiceConnection, request: StepRequest, timeout: float
 ) -> StepReply:
     """Call the Step() RPC endpoint."""
     try:
-        return service(service.stub.Step, request)
+        return service(service.stub.Step, request, timeout=timeout)
     except FileNotFoundError as e:
         if str(e).startswith("Session not found"):
             raise SessionNotFound(str(e))
@@ -139,7 +139,6 @@ class ClientServiceCompilerEnv(CompilerEnv):
         connection_settings: Optional[ConnectionOpts] = None,
         service_connection: Optional[CompilerGymServiceConnection] = None,
         logger: Optional[logging.Logger] = None,
-        timeout: Optional[float] = 300,
     ):
         """Construct and initialize a CompilerGym environment.
 
@@ -195,9 +194,6 @@ class ClientServiceCompilerEnv(CompilerEnv):
         :param service_connection: An existing compiler gym service connection
             to use.
 
-        :param timeout: The maximum number of seconds to wait for an RPC method
-            call to succeed. Accepts a float value. The default is 300 seconds.
-
         :raises FileNotFoundError: If service is a path to a file that is not
             found.
 
@@ -230,8 +226,6 @@ class ClientServiceCompilerEnv(CompilerEnv):
         self._datasets = Datasets(datasets or [])
 
         self.action_space_name = action_space
-
-        self._timeout = timeout
 
         # If no reward space is specified, generate some from numeric observation spaces
         rewards = rewards or [
@@ -548,7 +542,6 @@ class ClientServiceCompilerEnv(CompilerEnv):
             "benchmark": self.benchmark,
             "connection_settings": self._connection_settings,
             "service": self._service_endpoint,
-            "timeout": self._timeout,
         }
 
     def fork(self) -> "ClientServiceCompilerEnv":
@@ -860,9 +853,6 @@ class ClientServiceCompilerEnv(CompilerEnv):
         :param rewards: A list of reward spaces to compute rewards from. These
             are evaluated after the actions are applied.
 
-        :param timeout: The maximum number of seconds to wait for an RPC method
-            call to succeed. Accepts a float value. The default is 300 seconds.
-
         :return: A tuple of observations, rewards, done, and info. Observations
             and rewards are lists.
 
@@ -894,8 +884,6 @@ class ClientServiceCompilerEnv(CompilerEnv):
             for i, observation_space in enumerate(observations_to_compute)
         }
 
-        self._timeout = timeout
-
         # Record the actions.
         self._actions += actions
 
@@ -910,7 +898,7 @@ class ClientServiceCompilerEnv(CompilerEnv):
             ],
         )
         try:
-            reply = _wrapped_step(self.service, request)
+            reply = _wrapped_step(self.service, request, timeout)
         except (
             ServiceError,
             ServiceTransportError,
@@ -1034,7 +1022,12 @@ class ClientServiceCompilerEnv(CompilerEnv):
                 category=DeprecationWarning,
             )
             reward_spaces = rewards
-        return self.multistep([action], observation_spaces, reward_spaces)
+        return self.multistep(
+            actions=[action],
+            observation_spaces=observation_spaces,
+            reward_spaces=reward_spaces,
+            timeout=timeout,
+        )
 
     def multistep(
         self,


### PR DESCRIPTION
- Timeout is not optional, it must be a float (with default value)
- Comments for `CompilerEnv` should not mention gRPC (this is an implementation detail)