### PR TITLE
[WIP] Bump ProGraML to include the type graph patch.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -334,9 +334,9 @@ boost_deps()
 
 http_archive(
     name = "programl",
-    sha256 = "dbe16a96963c31620bcd7fb60cad7cab76f67e413c70f11ea38347e389f9e1de",
-    strip_prefix = "ProGraML-2b18ea3f1b7ba5668c4f594c555ccb52d735d4bc",
-    urls = ["https://github.com/ChrisCummins/ProGraML/archive/2b18ea3f1b7ba5668c4f594c555ccb52d735d4bc.tar.gz"],
+    sha256 = "f979e23c0b7bd39a5a77a02ce242befb5cc836e133999ef86a2c3b1f9c3e695a",
+    strip_prefix = "ProGraML-cd7d2939d485d989a9b105723fed989bcaca1f94",
+    urls = ["https://github.com/ChrisCummins/ProGraML/archive/cd7d2939d485d989a9b105723fed989bcaca1f94.tar.gz"],
 )
 
 load("@programl//tools:bzl/deps.bzl", "programl_deps")


### PR DESCRIPTION
This adds the patch from https://github.com/ChrisCummins/ProGraML/pull/199 to add type graphs to ProGraML representation.

```py
In [1]: import compiler_gym

In [2]: env = compiler_gym.make('llvm-v0')

In [3]: env.reset()

In [4]: G = env.observation.Programl()
```

![](https://user-images.githubusercontent.com/1636663/90944455-c4c6d580-e416-11ea-908c-b8e9c1c868fe.png)