### PR TITLE
Update README for llvm_autotuning

### DIFF
--- a/examples/llvm_autotuning/README.md
+++ b/examples/llvm_autotuning/README.md
@@ -113,7 +113,7 @@ directory. Specify one or more different directories as command line arguments,
 e.g.:
 
 ```
-python -m llvm_autotuning.info /path/to/logs/dir/a ~/logs_dir_b
+python -m llvm_autotuning.info --log-dirs /path/to/logs/dir/a ~/logs_dir_b
 ```
 
 


### PR DESCRIPTION
To specify custom log directories for `llvm_autotuning.info` I think we need to explicitly spell out the option `--log-dirs`, otherwise it doesn't work.
