### PR TITLE
Fix LocalShellCommand::checkCall() does not kill process on timeout.

### DIFF
--- a/compiler_gym/util/Subprocess.cc
+++ b/compiler_gym/util/Subprocess.cc
@@ -60,6 +60,7 @@ Status LocalShellCommand::checkCall() const {
     bp::child process(arguments(), bp::std_out > bp::null, bp::std_err > stderrFuture, bp::shell,
                       stderrStream, env());
     if (!wait_for(process, timeout())) {
+      process.terminate();
       return Status(StatusCode::DEADLINE_EXCEEDED,
                     fmt::format("Command '{}' failed to complete within {} seconds", commandline(),
                                 timeoutSeconds()));


### PR DESCRIPTION
Fixes #677
