### PR TITLE
Add Python 3.10 support.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
 
             - uses: actions/setup-python@v2
               with:
-                  python-version: 3.9
+                  python-version: '3.10'
 
             - name: Install build dependencies
               uses: ./.github/actions/install-build-dependencies
@@ -47,7 +47,7 @@ jobs:
 
             - uses: actions/setup-python@v2
               with:
-                  python-version: 3.9
+                  python-version: '3.10'
 
             - name: Install build dependencies
               uses: ./.github/actions/install-cmake-build-dependencies
@@ -119,7 +119,7 @@ jobs:
 
             - uses: actions/setup-python@v2
               with:
-                  python-version: 3.9
+                  python-version: '3.10'
 
             - name: Install build dependencies
               uses: ./.github/actions/install-cmake-build-dependencies
@@ -171,7 +171,7 @@ jobs:
 
             - uses: actions/setup-python@v2
               with:
-                  python-version: 3.9
+                  python-version: '3.10'
 
             - name: Install build dependencies
               uses: ./.github/actions/install-build-dependencies
@@ -197,7 +197,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                python: [3.6, 3.7, 3.8, 3.9]
+                python: [3.6, 3.7, 3.8, 3.9, 3.10]
         steps:
             - uses: actions/checkout@v2
 
@@ -234,7 +234,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                python: [3.9]
+                python: [3.10]
         steps:
             - uses: actions/checkout@v2
 
@@ -294,7 +294,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                python: [3.6, 3.7, 3.8, 3.9]
+                python: [3.6, 3.7, 3.8, 3.9, 3.10]
         steps:
             - uses: actions/checkout@v2
 
@@ -326,7 +326,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                python: [3.8, 3.9]
+                python: [3.8, 3.9, 3.10]
         steps:
             - uses: actions/checkout@v2
 
@@ -363,7 +363,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                python: [3.6, 3.7, 3.8, 3.9]
+                python: [3.6, 3.7, 3.8, 3.9, 3.10]
         steps:
             - uses: actions/checkout@v2
 
@@ -397,7 +397,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                python: [3.9]
+                python: [3.10]
         steps:
             - uses: actions/checkout@v2
 
@@ -431,7 +431,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                python: [3.9]
+                python: [3.10]
         steps:
             - uses: actions/checkout@v2
 
@@ -472,7 +472,7 @@ jobs:
             - name: Set up Python
               uses: actions/setup-python@v2
               with:
-                  python-version: 3.9
+                  python-version: '3.10'
 
             - uses: actions/checkout@v2
 
@@ -505,7 +505,7 @@ jobs:
             - name: Set up Python
               uses: actions/setup-python@v2
               with:
-                  python-version: 3.9
+                  python-version: '3.10'
 
             - name: Download Python wheel
               uses: actions/download-artifact@v2
@@ -534,7 +534,7 @@ jobs:
             - name: Set up Python
               uses: actions/setup-python@v2
               with:
-                  python-version: 3.9
+                  python-version: '3.10'
 
             - uses: actions/checkout@v2
 
@@ -567,7 +567,7 @@ jobs:
             - name: Set up Python
               uses: actions/setup-python@v2
               with:
-                  python-version: 3.9
+                  python-version: '3.10'
 
             - name: Download Python wheel
               uses: actions/download-artifact@v2
@@ -595,7 +595,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                python: [3.6, 3.7, 3.8, 3.9]
+                python: [3.6, 3.7, 3.8, 3.9, 3.10]
         steps:
             - uses: actions/checkout@v2
 
@@ -630,7 +630,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                python: [3.9]
+                python: [3.10]
         steps:
             - uses: actions/checkout@v2
 
@@ -667,7 +667,7 @@ jobs:
             - name: Setup python
               uses: actions/setup-python@v2
               with:
-                  python-version: 3.9
+                  python-version: '3.10'
 
             - name: Install build dependencies
               uses: ./.github/actions/install-build-dependencies
@@ -700,7 +700,7 @@ jobs:
             - name: Setup python
               uses: actions/setup-python@v2
               with:
-                  python-version: 3.9
+                  python-version: '3.10'
 
             - name: Download Python wheel
               uses: actions/download-artifact@v2
@@ -753,7 +753,7 @@ jobs:
 
             - uses: actions/setup-python@v2
               with:
-                  python-version: 3.9
+                  python-version: '3.10'
 
             - uses: actions/setup-node@v2
               with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -197,7 +197,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                python: [3.6, 3.7, 3.8, 3.9, 3.10]
+                python: [3.6, 3.7, 3.8, 3.9, '3.10']
         steps:
             - uses: actions/checkout@v2
 
@@ -234,7 +234,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                python: [3.10]
+                python: ['3.10']
         steps:
             - uses: actions/checkout@v2
 
@@ -294,7 +294,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                python: [3.6, 3.7, 3.8, 3.9, 3.10]
+                python: [3.6, 3.7, 3.8, 3.9, '3.10']
         steps:
             - uses: actions/checkout@v2
 
@@ -326,7 +326,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                python: [3.8, 3.9, 3.10]
+                python: [3.8, 3.9, '3.10']
         steps:
             - uses: actions/checkout@v2
 
@@ -363,7 +363,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                python: [3.6, 3.7, 3.8, 3.9, 3.10]
+                python: [3.6, 3.7, 3.8, 3.9, '3.10']
         steps:
             - uses: actions/checkout@v2
 
@@ -397,7 +397,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                python: [3.10]
+                python: ['3.10']
         steps:
             - uses: actions/checkout@v2
 
@@ -431,7 +431,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                python: [3.10]
+                python: ['3.10']
         steps:
             - uses: actions/checkout@v2
 
@@ -595,7 +595,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                python: [3.6, 3.7, 3.8, 3.9, 3.10]
+                python: [3.6, 3.7, 3.8, 3.9, '3.10']
         steps:
             - uses: actions/checkout@v2
 
@@ -630,7 +630,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                python: [3.10]
+                python: ['3.10']
         steps:
             - uses: actions/checkout@v2
 

--- a/compiler_gym/envs/gcc/gcc.py
+++ b/compiler_gym/envs/gcc/gcc.py
@@ -22,6 +22,7 @@ import os
 import pickle
 import re
 import subprocess
+import warnings
 from functools import lru_cache
 from pathlib import Path
 from typing import Dict, List, NamedTuple, Optional, Union
@@ -222,15 +223,18 @@ class GccParamIntOption(Option):
 @lru_cache(maxsize=2)
 def get_docker_client():
     """Fetch the docker client singleton."""
-    try:
-        return docker.from_env()
-    except docker.errors.DockerException as e:
-        raise EnvironmentNotSupported(
-            f"Failed to initialize docker client needed by GCC environment: {e}.\n"
-            "Have you installed the runtime dependencies?\n See "
-            "<https://facebookresearch.github.io/CompilerGym/envs/gcc.html#installation> "
-            "for details."
-        ) from e
+    # Ignore deprecation warnings from docker.from_env().
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=DeprecationWarning)
+        try:
+            return docker.from_env()
+        except docker.errors.DockerException as e:
+            raise EnvironmentNotSupported(
+                f"Failed to initialize docker client needed by GCC environment: {e}.\n"
+                "Have you installed the runtime dependencies?\n See "
+                "<https://facebookresearch.github.io/CompilerGym/envs/gcc.html#installation> "
+                "for details."
+            ) from e
 
 
 # We only need to run this function once per image.

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -1,5 +1,5 @@
 aioredis<2.0.0  # Pin version for ray.
-dgl==0.1.0
+dgl==0.9.0
 geneticalgorithm>=1.0.2
 hydra-core==1.1.0
 keras==2.8.0

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -2,7 +2,8 @@ aioredis<2.0.0  # Pin version for ray.
 dgl==0.9.0
 geneticalgorithm>=1.0.2
 hydra-core==1.1.0
-keras==2.8.0
+keras==2.6.0;python_version<"3.7"
+keras==2.8.0;python_version>="3.7"
 matplotlib>=3.3.4
 nevergrad>=0.4.3
 opentuner>=0.8.5
@@ -10,6 +11,7 @@ pandas>=1.1.5
 ray[default,rllib]==1.13.0
 submitit>=1.2.0
 submitit>=1.2.0
-tensorflow==2.8.0
+tensorflow==2.6.2;python_version<"3.7"
+tensorflow==2.8.0;python_version>="3.7"
 torch>=1.6.0
 typer[all]>=0.3.2

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -1,15 +1,15 @@
 aioredis<2.0.0  # Pin version for ray.
-dgl==0.6.1
+dgl==0.1.0
 geneticalgorithm>=1.0.2
 hydra-core==1.1.0
-keras==2.6.0
+keras==2.8.0
 matplotlib>=3.3.4
 nevergrad>=0.4.3
 opentuner>=0.8.5
 pandas>=1.1.5
-ray[default,rllib]==1.9.0
+ray[default,rllib]==1.13.0
 submitit>=1.2.0
 submitit>=1.2.0
-tensorflow==2.6.1
+tensorflow==2.8.0
 torch>=1.6.0
 typer[all]>=0.3.2

--- a/tests/mlir/rllib_ppo_smoke_test.py
+++ b/tests/mlir/rllib_ppo_smoke_test.py
@@ -54,7 +54,10 @@ def test_rllib_ppo_smoke():
         "rollout_fragment_length": 2,
     }
     trainer = PPOTrainer(config=config)
-    trainer.train()
+    with warnings.catch_warnings():
+        # Ignore deprecation warnings from internal rllib implementation.
+        warnings.filterwarnings("ignore", category=DeprecationWarning)
+        trainer.train()
     ray.shutdown()
 
 


### PR DESCRIPTION
This bumps several dependencies to enable Python 3.10 support, and
switches the default version of python used for single-python CI
jobs from 3.9 to 3.10.
