### PR TITLE
Update and simplify Makefile commands.

### DIFF
--- a/.github/actions/install-build-dependencies/action.yaml
+++ b/.github/actions/install-build-dependencies/action.yaml
@@ -15,7 +15,6 @@ runs:
                   sudo apt-get install -y clang-9 patchelf
               fi
               python -m pip install -U pip wheel
-              python -m pip install -r compiler_gym/requirements_build.txt
           shell: bash
           env:
               LDFLAGS: -L/usr/local/opt/zlib/lib

--- a/.github/actions/install-build-dependencies/action.yaml
+++ b/.github/actions/install-build-dependencies/action.yaml
@@ -15,6 +15,7 @@ runs:
                   sudo apt-get install -y clang-9 patchelf
               fi
               python -m pip install -U pip wheel
+              python -m pip install -r compiler_gym/requirements_build.txt -r compiler_gym/requirements.txt
           shell: bash
           env:
               LDFLAGS: -L/usr/local/opt/zlib/lib

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,10 +52,6 @@ jobs:
             - name: Install build dependencies
               uses: ./.github/actions/install-cmake-build-dependencies
 
-            - name: Install Python dependencies
-              run: |
-                  python -m pip install -r compiler_gym/requirements_build.txt -r compiler_gym/requirements.txt
-
             - name: Download LLVM 10.0.0 release
               run: |
                   if [ "$(uname)" = "Darwin" ]; then
@@ -127,10 +123,6 @@ jobs:
 
             - name: Install build dependencies
               uses: ./.github/actions/install-cmake-build-dependencies
-
-            - name: Install Python dependencies
-              run: |
-                  python -m pip install -r compiler_gym/requirements_build.txt -r compiler_gym/requirements.txt
 
             - name: Download LLVM 14.0.0 release
               run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,6 +52,10 @@ jobs:
             - name: Install build dependencies
               uses: ./.github/actions/install-cmake-build-dependencies
 
+            - name: Install Python dependencies
+              run: |
+                  python -m pip install -r compiler_gym/requirements_build.txt -r compiler_gym/requirements.txt
+
             - name: Download LLVM 10.0.0 release
               run: |
                   if [ "$(uname)" = "Darwin" ]; then
@@ -123,6 +127,10 @@ jobs:
 
             - name: Install build dependencies
               uses: ./.github/actions/install-cmake-build-dependencies
+
+            - name: Install Python dependencies
+              run: |
+                  python -m pip install -r compiler_gym/requirements_build.txt -r compiler_gym/requirements.txt
 
             - name: Download LLVM 14.0.0 release
               run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -222,7 +222,7 @@ jobs:
 
             - name: Run the test suite
               run: |
-                  make install-test-cov \
+                  make test-cov \
                   PYTEST_ARGS="--ignore tests/llvm --ignore tests/gcc --ignore tests/loop_tool --ignore tests/mlir"
 
             - name: Upload coverage report to Codecov
@@ -286,7 +286,7 @@ jobs:
               shell: bash
 
             - name: Run the test suite
-              run: make install-test CI=1 PYTEST_ARGS="--ignore tests/mlir"
+              run: make test CI=1 PYTEST_ARGS="--ignore tests/mlir"
 
     test-mlir-env-linux-cmake:
         needs: build-mlir-env-linux-cmake
@@ -318,7 +318,7 @@ jobs:
               run: python -m pip install -r tests/requirements.txt
 
             - name: Run the test suite
-              run: make install-test-cov CI=1 TEST_TARGET="tests/mlir"
+              run: make test-cov CI=1 TEST_TARGET="tests/mlir"
 
     test-macos:
         needs: build-macos
@@ -351,7 +351,7 @@ jobs:
 
             - name: Run the test suite
               run: |
-                  make install-test-cov \
+                  make test-cov \
                   CI=1 \
                   PYTEST_ARGS="--ignore tests/llvm --ignore tests/gcc --ignore tests/loop_tool --ignore tests/mlir"
 
@@ -387,7 +387,7 @@ jobs:
               run: python -m pip install -r tests/requirements.txt
 
             - name: Run the test suite
-              run: make install-test-cov CI=1 TEST_TARGET="tests/llvm"
+              run: make test-cov CI=1 TEST_TARGET="tests/llvm"
 
             - name: Upload coverage report to Codecov
               uses: codecov/codecov-action@v2
@@ -421,7 +421,7 @@ jobs:
               run: python -m pip install -r tests/requirements.txt
 
             - name: Run the test suite
-              run: make install-test-cov CI=1 TEST_TARGET="tests/llvm"
+              run: make test-cov CI=1 TEST_TARGET="tests/llvm"
 
             - name: Upload coverage report to Codecov
               uses: codecov/codecov-action@v2
@@ -455,7 +455,7 @@ jobs:
               run: python -m pip install -r tests/requirements.txt
 
             - name: Run the test suite
-              run: make install-test-cov CI=1 TEST_TARGET="tests/gcc"
+              run: make test-cov CI=1 TEST_TARGET="tests/gcc"
 
             - name: Upload coverage report to Codecov
               uses: codecov/codecov-action@v2
@@ -491,7 +491,7 @@ jobs:
               run: python -m pip install -r tests/requirements.txt
 
             - name: Run the test suite
-              run: make install-test-cov CI=1 TEST_TARGET="tests/gcc"
+              run: make test-cov CI=1 TEST_TARGET="tests/gcc"
 
             - name: Upload coverage report to Codecov
               uses: codecov/codecov-action@v2
@@ -522,7 +522,7 @@ jobs:
               run: python -m pip install -r tests/requirements.txt
 
             - name: Run the test suite
-              run: make install-test-cov CI=1 TEST_TARGET="tests/gcc"
+              run: make test-cov CI=1 TEST_TARGET="tests/gcc"
 
             - name: Upload coverage report to Codecov
               uses: codecov/codecov-action@v2
@@ -553,7 +553,7 @@ jobs:
               run: python -m pip install -r tests/requirements.txt
 
             - name: Run the test suite
-              run: make install-test-cov CI=1 TEST_TARGET="tests/loop_tool"
+              run: make test-cov CI=1 TEST_TARGET="tests/loop_tool"
 
             - name: Upload coverage report to Codecov
               uses: codecov/codecov-action@v2
@@ -584,7 +584,7 @@ jobs:
               run: python -m pip install -r tests/requirements.txt
 
             - name: Run the test suite
-              run: make install-test-cov CI=1 TEST_TARGET="tests/loop_tool"
+              run: make test-cov CI=1 TEST_TARGET="tests/loop_tool"
 
             - name: Upload coverage report to Codecov
               uses: codecov/codecov-action@v2
@@ -735,7 +735,7 @@ jobs:
               run: python -m pip install -r tests/requirements.txt
 
             - name: Test
-              run: make install-test CI=1 TEST_TARGET=tests/llvm
+              run: make test CI=1 TEST_TARGET=tests/llvm
               env:
                   ASAN_OPTIONS: detect_leaks=1
                   CC: clang

--- a/.github/workflows/fuzz.yaml
+++ b/.github/workflows/fuzz.yaml
@@ -52,4 +52,4 @@ jobs:
               run: python -m pip install -r tests/requirements.txt
 
             - name: Fuzz test
-              run: FUZZ_TIME=600 make install-fuzz
+              run: FUZZ_TIME=600 make fuzz

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -93,27 +93,26 @@ environment using:
     conda deactivate
     conda env remove -n compiler_gym
 
-## Building from source with CMake
+### Building from source with CMake
 
-Building with CMake is still experimental. Darwin is not supported with CMake.
+Building with CMake is experimental and supports only Linux.
 
-### Dependency instructions for Ubuntu
+Install the dependencies using:
 
-```bash
+```sh
 sudo apt-get install g++ lld \
   autoconf libtool ninja-build ccache git \
 ```
 
 Requires CMake (>=3.20).
 
-```bash
+```sh
 wget https://github.com/Kitware/CMake/releases/download/v3.20.5/cmake-3.20.5-linux-x86_64.sh -O cmake.sh
 bash cmake.sh --prefix=$HOME/.local --exclude-subdir --skip-license
 rm cmake.sh
 export PATH=$HOME/.local/bin:$PATH
 ```
 
-### Dependency Arguments
 By default most dependencies are built together with Compiler Gym. To search for a dependency instead use:
 
 ```
@@ -129,7 +128,7 @@ By default most dependencies are built together with Compiler Gym. To search for
 * `COMPILER_GYM_NLOHMANN_JSON_PROVIDER`
 * `COMPILER_GYM_PROTOBUF_PROVIDER`
 
-```bash
+```sh
 cmake \
   -DCMAKE_C_COMPILER=clang \
   -DCMAKE_CXX_COMPILER=clang++ \
@@ -145,30 +144,30 @@ Additional optional configuration arguments:
 
 * Enables testing.
 
-    ```bash
-    -DCOMPILER_GYM_BUILD_TESTS=ON
-    ```
+```sh
+-DCOMPILER_GYM_BUILD_TESTS=ON
+```
 
 * Builds additional tools required by some examples.
 
-    ```bash
-    -DCOMPILER_GYM_BUILD_EXAMPLES=ON
-    ```
+```sh
+-DCOMPILER_GYM_BUILD_EXAMPLES=ON
+```
 
 * For faster rebuilds.
 
-    ```bash
-    -DCMAKE_C_COMPILER_LAUNCHER=ccache
-    -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
-    ```
+```sh
+-DCMAKE_C_COMPILER_LAUNCHER=ccache
+-DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+```
 
 * For faster linking.
 
-    ```bash
-    -DCMAKE_EXE_LINKER_FLAGS_INIT="-fuse-ld=lld"
-    -DCMAKE_MODULE_LINKER_FLAGS_INIT="-fuse-ld=lld"
-    -DCMAKE_SHARED_LINKER_FLAGS_INIT="-fuse-ld=lld"
-    ```
+```sh
+-DCMAKE_EXE_LINKER_FLAGS_INIT="-fuse-ld=lld"
+-DCMAKE_MODULE_LINKER_FLAGS_INIT="-fuse-ld=lld"
+-DCMAKE_SHARED_LINKER_FLAGS_INIT="-fuse-ld=lld"
+```
 
 By default, CompilerGym builds LLVM from source. This takes a long time and a
 lot of compute resources. To prevent this, download a pre-compiled clang+llvm
@@ -177,7 +176,7 @@ page](https://github.com/llvm/llvm-project/releases/tag/llvmorg-10.0.0), unpack
 it, and pass path of the `lib/cmake/llvm` subdirectory in the archive you just
 extracted to `LLVM_DIR`:
 
-```
+```sh
 $ cmake ... \
     -DCOMPILER_GYM_LLVM_PROVIDER=external \
     -DLLVM_DIR=/path/to/llvm/lib/cmake/llvm

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -61,31 +61,31 @@ Then clone the CompilerGym source code using:
     git clone https://github.com/facebookresearch/CompilerGym.git
     cd CompilerGym
 
-There are two primary git branches: `stable` tracks the latest release;
-`development` is for bleeding edge features that may not yet be mature. Checkout
-your preferred branch and install the python development dependencies using:
+If you plan to contribute to CompilerGym, install the development environment
+requirements using:
 
-    git checkout stable
-    make init
+    make dev-init
 
-The `make init` target only needs to be run on initial setup and after pulling
-remote changes to the CompilerGym repository.
 
-## Building from source with Bazel
-
-It is recomended to build with Bazel.
-
-Run the test suite to confirm that everything is working:
-
-    make test
+### Building from source with Bazel
 
 To build and install the `compiler_gym` python package, run:
 
     make install
 
+Once this has completed, run the test suite on the installed package using:
+
+    make test
+
+This may take a while. There are a number of options to `make test`, see `make
+help` for more information.
+
+Each time you modify the sources it is necessary to rerun `make install` before
+`make test`.
+
 **NOTE:** To use the `compiler_gym` package that is installed by `make install`
 you must leave the root directory of this repository. Attempting to import
-`compiler_gym` while in the root of this repository will cause import errors.
+`compiler_gym` while in the root of this repository will cause an import error.
 
 When you are finished, you can deactivate and delete the conda
 environment using:

--- a/Makefile
+++ b/Makefile
@@ -177,6 +177,7 @@ bazel-fetch:
 	done
 
 bazel-build: bazel-fetch
+	$(PYTHON) -m pip install -r compiler_gym/requirements.txt -r compiler_gym/requirements_build.txt
 	$(BAZEL) $(BAZEL_OPTS) build $(BAZEL_BUILD_OPTS) $(BUILD_TARGET)
 
 bdist_wheel: bazel-build
@@ -345,7 +346,6 @@ fuzz: install-test-setup
 
 
 install: | bazel-build
-	$(PYTHON) -m pip install -r compiler_gym/requirements.txt -r compiler_gym/requirements_build.txt
 	$(PYTHON) -m pip install . --force-reinstall --no-deps
 
 .PHONY: install

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -28,7 +28,7 @@ PYTHON ?= python3
 PYTEST_ARGS ?=
 
 # The path of the XML pytest coverage report to generate when running the
-# install-test-cov target.
+# test-cov target.
 COV_REPORT ?= $(ROOT)/coverage.xml
 
 DISTTOOLS_OUTS := \

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -5,6 +5,9 @@ hydra-core==1.1.0
 keras==2.6.0
 matplotlib>=3.3.4
 nevergrad>=0.4.3
+# NOTE(github.com/facebookresearch/CompilerGym/issues/750) Pin numpy version back
+# as workaround for numpy.object_ use in ray 1.9.0.
+numpy>=1.19.3,<1.20.0
 opentuner>=0.8.5
 pandas>=1.1.5
 ray[default,rllib]==1.9.0

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -154,12 +154,7 @@ file(
     "${CMAKE_CURRENT_SOURCE_DIR}"
 )
 set(_TESTS_BIN_DIR "${CMAKE_CURRENT_BINARY_DIR}/py_pkg")
-string(
-    CONCAT
-    _CMD
-    "cd \"${CMAKE_CURRENT_SOURCE_DIR}/..\""
-    " && make install-test"
-)
+string(CONCAT _CMD "cd \"${CMAKE_CURRENT_SOURCE_DIR}/..\"" " && make test")
 cg_genrule(
   NAME python_package_tests
   COMMAND "${_CMD}"

--- a/tests/pytest_plugins/common.py
+++ b/tests/pytest_plugins/common.py
@@ -56,9 +56,9 @@ macos_only = pytest.mark.skipif(
 # Decorator to mark a test as skipped if not running under bazel.
 bazel_only = pytest.mark.skipif(not in_bazel(), reason="bazel only")
 
-# Decorator to mark a test as skipped if not running in the `install-test`
+# Decorator to mark a test as skipped if not running in the `make test`
 # environment.
-install_test_only = pytest.mark.skipif(in_bazel(), reason="install-test only")
+install_test_only = pytest.mark.skipif(in_bazel(), reason="test only")
 
 # Decorator to skip a test if docker is not available.
 with_docker = pytest.mark.skipif(


### PR DESCRIPTION
This:

- Removes the 'make init' command, instead installing the dependencies
of each rule when it is run. This ensures that users don't end up with
'stale' dependencies when pulling upstream changes.

- Renames the 'make test' command to 'make bazel-test', and 'make
install-test' to 'make test'. This is in preparation for the migration
to CMake.

- Updates and clarifies the installation instructions.