### PR TITLE
[llmv] Remove broken random_benchmark() implementation for POJ104.

### DIFF
--- a/compiler_gym/envs/llvm/datasets/poj104.py
+++ b/compiler_gym/envs/llvm/datasets/poj104.py
@@ -8,9 +8,6 @@ import subprocess
 import sys
 from concurrent.futures import as_completed
 from pathlib import Path
-from typing import Optional
-
-import numpy as np
 
 from compiler_gym.datasets import Benchmark, TarDatasetWithManifest
 from compiler_gym.datasets.benchmark import BenchmarkWithSource
@@ -139,12 +136,6 @@ class POJ104Dataset(TarDatasetWithManifest):
                 )
 
         return BenchmarkWithSource.create(uri, bitcode_path, "source.cc", cc_file_path)
-
-    def random_benchmark(
-        self, random_state: Optional[np.random.Generator] = None
-    ) -> Benchmark:
-        random_state = random_state or np.random.default_rng()
-        return self._get_benchmark_by_index(random_state.integers(self.size))
 
     @staticmethod
     def preprocess_poj104_source(src: str) -> str:

--- a/tests/llvm/datasets/poj104_test.py
+++ b/tests/llvm/datasets/poj104_test.py
@@ -47,5 +47,12 @@ def test_poj104_random_select(
     assert (tmpwd / "source.cc").is_file()
 
 
+@skip_on_ci
+def test_poj104_random_benchmark(env: LlvmEnv, poj104_dataset: POJ104Dataset):
+    benchmark = poj104_dataset.random_benchmark()
+    env.reset(benchmark=benchmark)
+    assert benchmark.source
+
+
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Fix for:

```py
Traceback (most recent call last):
  File "scratch.py", line 70, in <module>
    main()
  File "scratch.py", line 65, in main
    for b in sbs:
  File "scratch.py", line 55, in simple_benchmark_sampler
    yield(datasets[index].random_benchmark(rng))
  File "/Users/hleather/opt/miniconda3/envs/compiler_gym/lib/python3.8/site-packages/compiler_gym/envs/llvm/datasets/poj104.py", line 146, in random_benchmark
    return self._get_benchmark_by_index(random_state.integers(self.size))
AttributeError: 'POJ104Dataset' object has no attribute '_get_benchmark_by_index'
```

Now produces:

```py
$ python
Python 3.10.4 (main, Mar 31 2022, 08:41:55) [GCC 7.5.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import compiler_gym
>>> env = compiler_gym.make("llvm-v0")
>>> env.reset()
>>> env.datasets["poj104-v0"].random_benchmark()
Installing the benchmark://poj104-v0 dataset. This may take a few moments ...
benchmark://poj104-v0/12837
>>> env.datasets["poj104-v0"].random_benchmark()
benchmark://poj104-v0/20713
```