### PR TITLE
Add fork implementation to sqlite wrapper

### DIFF
--- a/compiler_gym/wrappers/sqlite_logger.py
+++ b/compiler_gym/wrappers/sqlite_logger.py
@@ -270,5 +270,10 @@ class SynchronousSqliteLogger(CompilerEnvWrapper):
         self.flush()
         self.env.close()
 
-    def fork(self):
-        raise NotImplementedError
+    def fork(self) -> "SynchronousSqliteLogger":
+        return SynchronousSqliteLogger(
+            env=LlvmEnv,
+            db_path=Path,
+            commit_frequency_in_seconds=300,
+            max_step_buffer_length=5000,
+        )


### PR DESCRIPTION
Fixes #744.

- Adds a fork() implementation to the `SynchronousSqliteLogger` class.

I'm just confused about what kind of test should be added due to this change.