### PR TITLE
[llvm] Fix the number of runtime observations in reward reset.

### DIFF
--- a/compiler_gym/envs/llvm/llvm_env.py
+++ b/compiler_gym/envs/llvm/llvm_env.py
@@ -28,7 +28,7 @@ from compiler_gym.envs.llvm.llvm_rewards import (
     CostFunctionReward,
     NormalizedReward,
 )
-from compiler_gym.errors import BenchmarkInitError
+from compiler_gym.errors import BenchmarkInitError, SessionNotFound
 from compiler_gym.service.client_service_compiler_env import ClientServiceCompilerEnv
 from compiler_gym.spaces import Box, Commandline
 from compiler_gym.spaces import Dict as DictSpace
@@ -363,7 +363,7 @@ class LlvmEnv(ClientServiceCompilerEnv):
 
     def reset(self, *args, **kwargs):
         try:
-            observation = super().reset(*args, **kwargs)
+            return super().reset(*args, **kwargs)
         except ValueError as e:
             # Catch and re-raise some known benchmark initialization errors with
             # a more informative error type.
@@ -378,15 +378,6 @@ class LlvmEnv(ClientServiceCompilerEnv):
             ):
                 raise BenchmarkInitError(str(e)) from e
             raise
-
-        # Resend the runtimes-per-observation session parameter, if it is a
-        # non-default value.
-        if self._runtimes_per_observation_count is not None:
-            self.runtime_observation_count = self._runtimes_per_observation_count
-        if self._runtimes_warmup_per_observation_count is not None:
-            self.runtime_warmup_runs_count = self._runtimes_warmup_per_observation_count
-
-        return observation
 
     def make_benchmark(
         self,
@@ -612,11 +603,15 @@ class LlvmEnv(ClientServiceCompilerEnv):
 
     @runtime_observation_count.setter
     def runtime_observation_count(self, n: int) -> None:
-        if self.in_episode:
-            self.send_param("llvm.set_runtimes_per_observation_count", str(n))
-        # NOTE(cummins): Keep this after the send_param() call because
-        # send_param() will raise an error if the valid is invalid.
-        self._runtimes_per_observation_count = n
+        try:
+            self.send_param(
+                "llvm.set_runtimes_per_observation_count", str(n), resend_on_reset=True
+            )
+            # NOTE(cummins): Keep this after the send_param() call because
+            # send_param() will raise an error if the valid is invalid.
+            self._runtimes_per_observation_count = n
+        except SessionNotFound:
+            pass  # Not in session yet, will be sent on reset().
 
     @property
     def runtime_warmup_runs_count(self) -> int:
@@ -648,13 +643,17 @@ class LlvmEnv(ClientServiceCompilerEnv):
 
     @runtime_warmup_runs_count.setter
     def runtime_warmup_runs_count(self, n: int) -> None:
-        if self.in_episode:
+        try:
             self.send_param(
-                "llvm.set_warmup_runs_count_per_runtime_observation", str(n)
+                "llvm.set_warmup_runs_count_per_runtime_observation",
+                str(n),
+                resend_on_reset=True,
             )
-        # NOTE(cummins): Keep this after the send_param() call because
-        # send_param() will raise an error if the valid is invalid.
-        self._runtimes_warmup_per_observation_count = n
+            # NOTE(cummins): Keep this after the send_param() call because
+            # send_param() will raise an error if the valid is invalid.
+            self._runtimes_warmup_per_observation_count = n
+        except SessionNotFound:
+            pass  # Not in session yet, will be sent on reset().
 
     def fork(self):
         fkd = super().fork()

--- a/compiler_gym/envs/llvm/llvm_env.py
+++ b/compiler_gym/envs/llvm/llvm_env.py
@@ -607,11 +607,9 @@ class LlvmEnv(ClientServiceCompilerEnv):
             self.send_param(
                 "llvm.set_runtimes_per_observation_count", str(n), resend_on_reset=True
             )
-            # NOTE(cummins): Keep this after the send_param() call because
-            # send_param() will raise an error if the valid is invalid.
-            self._runtimes_per_observation_count = n
         except SessionNotFound:
             pass  # Not in session yet, will be sent on reset().
+        self._runtimes_per_observation_count = n
 
     @property
     def runtime_warmup_runs_count(self) -> int:
@@ -649,11 +647,9 @@ class LlvmEnv(ClientServiceCompilerEnv):
                 str(n),
                 resend_on_reset=True,
             )
-            # NOTE(cummins): Keep this after the send_param() call because
-            # send_param() will raise an error if the valid is invalid.
-            self._runtimes_warmup_per_observation_count = n
         except SessionNotFound:
             pass  # Not in session yet, will be sent on reset().
+        self._runtimes_warmup_per_observation_count = n
 
     def fork(self):
         fkd = super().fork()

--- a/tests/llvm/BUILD
+++ b/tests/llvm/BUILD
@@ -259,6 +259,8 @@ py_test(
     deps = [
         "//compiler_gym/envs/llvm",
         "//compiler_gym/service:connection",
+        "//compiler_gym/spaces",
+        "//compiler_gym/util",
         "//tests:test_main",
         "//tests/pytest_plugins:llvm",
     ],

--- a/tests/llvm/runtime_test.py
+++ b/tests/llvm/runtime_test.py
@@ -191,10 +191,10 @@ def test_correct_number_of_observations_during_reset(
 
     # Check that the number of observations that you are receive during reset()
     # matches the amount that you asked for.
-    # FIXME(github.com/facebookresearch/CompilerGym/issues/756): This is broken.
-    # Only a single observation is received, irrespective of how many you ask
-    # for.
-    assert len(env.reward.spaces["runtimeseries"].last_runtime_observation) == 1
+    assert (
+        len(env.reward.spaces["runtimeseries"].last_runtime_observation)
+        == runtime_observation_count
+    )
 
     # Check that the number of observations that you are receive during step()
     # matches the amount that you asked for.

--- a/tests/llvm/runtime_test.py
+++ b/tests/llvm/runtime_test.py
@@ -4,12 +4,15 @@
 # LICENSE file in the root directory of this source tree.
 """Integrations tests for LLVM runtime support."""
 from pathlib import Path
+from typing import List
 
 import numpy as np
 import pytest
 from flaky import flaky
 
 from compiler_gym.envs.llvm import LlvmEnv, llvm_benchmark
+from compiler_gym.spaces.reward import Reward
+from compiler_gym.util.gym_type_hints import ActionType, ObservationType
 from tests.test_main import main
 
 pytest_plugins = ["tests.pytest_plugins.llvm"]
@@ -142,6 +145,65 @@ def test_default_runtime_observation_count_fork(env: LlvmEnv):
     with env.fork() as fkd:
         assert fkd.runtime_observation_count == rc
         assert fkd.runtime_warmup_runs_count == wc
+
+
+class RewardDerivedFromRuntime(Reward):
+    """A custom reward space that is derived from the Runtime observation space."""
+
+    def __init__(self):
+        super().__init__(
+            name="runtimeseries",
+            observation_spaces=["Runtime"],
+            default_value=0,
+            min=None,
+            max=None,
+            default_negates_returns=True,
+            deterministic=False,
+            platform_dependent=True,
+        )
+        self.last_runtime_observation: List[float] = None
+
+    def reset(self, benchmark, observation_view) -> None:
+        del benchmark  # unused
+        self.last_runtime_observation = observation_view["Runtime"]
+
+    def update(
+        self,
+        actions: List[ActionType],
+        observations: List[ObservationType],
+        observation_view,
+    ) -> float:
+        del actions  # unused
+        del observation_view  # unused
+        self.last_runtime_observation = observations[0]
+        return 0
+
+
+@flaky  # runtime may fail
+@pytest.mark.parametrize("runtime_observation_count", [1, 3, 5])
+def test_correct_number_of_observations_during_reset(
+    env: LlvmEnv, runtime_observation_count: int
+):
+    env.reward.add_space(RewardDerivedFromRuntime())
+    env.runtime_observation_count = runtime_observation_count
+    env.reset(reward_space="runtimeseries")
+    assert env.runtime_observation_count == runtime_observation_count
+
+    # Check that the number of observations that you are receive during reset()
+    # matches the amount that you asked for.
+    # FIXME(github.com/facebookresearch/CompilerGym/issues/756): This is broken.
+    # Only a single observation is received, irrespective of how many you ask
+    # for.
+    assert len(env.reward.spaces["runtimeseries"].last_runtime_observation) == 1
+
+    # Check that the number of observations that you are receive during step()
+    # matches the amount that you asked for.
+    env.reward.spaces["runtimeseries"].last_runtime_observation = None
+    env.step(0)
+    assert (
+        len(env.reward.spaces["runtimeseries"].last_runtime_observation)
+        == runtime_observation_count
+    )
 
 
 if __name__ == "__main__":

--- a/tox.ini
+++ b/tox.ini
@@ -14,5 +14,6 @@ filterwarnings =
     error
     ignore::pytest.PytestAssertRewriteWarning:
     ignore::ResourceWarning:
+    ignore:SelectableGroups dict interface is deprecated. Use select:DeprecationWarning
 # Global timeout applied to all test functions:
 timeout = 300


### PR DESCRIPTION
This adds a `resend_on_reset` flag to the `send_params()` method that
enables parameters to be resent immediately after a service is
reset. This is required by the LLVM environment to ensure that the
runtime observation parameters are sent before the reward space is
reset.

Fixes https://github.com/facebookresearch/CompilerGym/issues/756.