### PR TITLE
Introduce RuntimeSeriesReward

### DIFF
--- a/compiler_gym/spaces/BUILD
+++ b/compiler_gym/spaces/BUILD
@@ -20,6 +20,7 @@ py_library(
         ":permutation",
         ":reward",
         ":runtime_reward",
+        ":runtime_series_reward",
         ":scalar",
         ":sequence",
         ":space_sequence",
@@ -79,6 +80,16 @@ py_library(
 py_library(
     name = "runtime_reward",
     srcs = ["runtime_reward.py"],
+    deps = [
+        ":reward",
+        "//compiler_gym/errors",
+        "//compiler_gym/util",
+    ],
+)
+
+py_library(
+    name = "runtime_series_reward",
+    srcs = ["runtime_series_reward.py"],
     deps = [
         ":reward",
         "//compiler_gym/errors",

--- a/compiler_gym/spaces/CMakeLists.txt
+++ b/compiler_gym/spaces/CMakeLists.txt
@@ -20,6 +20,7 @@ cg_py_library(
     ::permutation
     ::reward
     ::runtime_reward
+    ::runtime_series_reward
     ::scalar
     ::sequence
     ::space_sequence
@@ -83,6 +84,18 @@ cg_py_library(
     runtime_reward
   SRCS
     "runtime_reward.py"
+  DEPS
+    ::reward
+    compiler_gym::errors::errors
+    compiler_gym::util::util
+  PUBLIC
+)
+
+cg_py_library(
+  NAME
+    runtime_series_reward
+  SRCS
+    "runtime_series_reward.py"
   DEPS
     ::reward
     compiler_gym::errors::errors

--- a/compiler_gym/spaces/__init__.py
+++ b/compiler_gym/spaces/__init__.py
@@ -10,6 +10,7 @@ from compiler_gym.spaces.named_discrete import NamedDiscrete
 from compiler_gym.spaces.permutation import Permutation
 from compiler_gym.spaces.reward import DefaultRewardFromObservation, Reward
 from compiler_gym.spaces.runtime_reward import RuntimeReward
+from compiler_gym.spaces.runtime_series_reward import RuntimeSeriesReward
 from compiler_gym.spaces.scalar import Scalar
 from compiler_gym.spaces.sequence import Sequence
 from compiler_gym.spaces.space_sequence import SpaceSequence
@@ -26,6 +27,7 @@ __all__ = [
     "Permutation",
     "Reward",
     "RuntimeReward",
+    "RuntimeSeriesReward",
     "Scalar",
     "Sequence",
     "SpaceSequence",

--- a/compiler_gym/spaces/runtime_series_reward.py
+++ b/compiler_gym/spaces/runtime_series_reward.py
@@ -20,7 +20,7 @@ class RuntimeSeriesReward(Reward):
         default_value: int = 0,
     ):
         super().__init__(
-            name="runtime",
+            name="runtimeseries",
             observation_spaces=["Runtime"],
             default_value=default_value,
             min=None,

--- a/compiler_gym/spaces/runtime_series_reward.py
+++ b/compiler_gym/spaces/runtime_series_reward.py
@@ -1,0 +1,74 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import List, Optional
+
+from compiler_gym.errors import BenchmarkInitError, ServiceError
+from compiler_gym.spaces.reward import Reward
+from compiler_gym.util.gym_type_hints import ActionType, ObservationType
+
+import scipy
+import numpy as np
+
+class RuntimeSeriesReward(Reward):
+    def __init__(
+        self,
+        runtime_count: int,
+        warmup_count: int,
+        default_value: int = 0,
+    ):
+        super().__init__(
+            name="runtime",
+            observation_spaces=["Runtime"],
+            default_value=default_value,
+            min=None,
+            max=None,
+            default_negates_returns=True,
+            deterministic=False,
+            platform_dependent=True,
+        )
+        self.runtime_count = runtime_count
+        self.warmup_count = warmup_count
+        self.starting_runtimes: List[float] = None
+        self.previous_runtimes: List[float] = None
+        self.current_benchmark: Optional[str] = None
+
+    def reset(self, benchmark, observation_view) -> None:
+        # If we are changing the benchmark then check that it is runnable.
+        if benchmark != self.current_benchmark:
+            if not observation_view["IsRunnable"]:
+                raise BenchmarkInitError(f"Benchmark is not runnable: {benchmark}")
+            self.current_benchmark = benchmark
+            self.starting_runtimes = None
+
+        # Compute initial runtimes
+        if self.starting_runtimes is None:
+            self.starting_runtimes = observation_view["Runtime"]
+
+        self.previous_runtimes = self.starting_runtimes
+
+    def update(
+        self,
+        actions: List[ActionType],
+        observations: List[ObservationType],
+        observation_view,
+    ) -> float:
+        del actions  # unused
+        del observation_view  # unused
+        runtimes = observations[0]
+        if len(runtimes) != self.runtime_count:
+            raise ServiceError(
+                f"Expected {self.runtime_count} runtimes but received {len(runtimes)}"
+            )
+
+        # Use the Kruskal–Wallis test to determine if the medians are equal
+        # between the two series of runtimes. If the runtimes medians are
+        # significantly different, compute the reward by computing the
+        # difference between the two medians. Otherwise, set the reward as 0.
+        # https://en.wikipedia.org/wiki/Kruskal%E2%80%93Wallis_one-way_analysis_of_variance
+        _, pval = scipy.stats.kruskal(runtimes, self.previous_runtimes)
+        reward = np.median(runtimes) - np.median(self.previous_runtimes) if pval < 0.05 else 0
+        self.previous_runtimes = runtimes
+        return reward

--- a/compiler_gym/spaces/runtime_series_reward.py
+++ b/compiler_gym/spaces/runtime_series_reward.py
@@ -69,7 +69,6 @@ class RuntimeSeriesReward(Reward):
         # difference between the two medians. Otherwise, set the reward as 0.
         # https://en.wikipedia.org/wiki/Kruskal%E2%80%93Wallis_one-way_analysis_of_variance
         _, pval = scipy.stats.kruskal(runtimes, self.previous_runtimes)
-        diff = np.median(runtimes) - np.median(self.previous_runtimes)
-        reward = 2 * diff if pval < 0.05 else diff
+        reward = np.median(self.previous_runtimes) - np.median(runtimes) if pval < 0.05 else 0
         self.previous_runtimes = runtimes
         return reward

--- a/compiler_gym/spaces/runtime_series_reward.py
+++ b/compiler_gym/spaces/runtime_series_reward.py
@@ -69,6 +69,17 @@ class RuntimeSeriesReward(Reward):
         # difference between the two medians. Otherwise, set the reward as 0.
         # https://en.wikipedia.org/wiki/Kruskal%E2%80%93Wallis_one-way_analysis_of_variance
         _, pval = scipy.stats.kruskal(runtimes, self.previous_runtimes)
-        reward = np.median(self.previous_runtimes) - np.median(runtimes) if pval < 0.05 else 0
+
+        # If the pval is less than 0.05, this means that the current series of
+        # runtimes is significantly different from the previous series of
+        # runtimes. In this case, we compute the reward as the differences
+        # between the medians of the two series.
+        if pval < 0.05:
+            reward = np.median(self.previous_runtimes) - np.median(runtimes)
+        # If the runtimes are not significantly different, set reward as 0.
+        else:
+            reward = 0
+
+        # Update previous runtimes
         self.previous_runtimes = runtimes
         return reward

--- a/compiler_gym/spaces/runtime_series_reward.py
+++ b/compiler_gym/spaces/runtime_series_reward.py
@@ -69,6 +69,7 @@ class RuntimeSeriesReward(Reward):
         # difference between the two medians. Otherwise, set the reward as 0.
         # https://en.wikipedia.org/wiki/Kruskal%E2%80%93Wallis_one-way_analysis_of_variance
         _, pval = scipy.stats.kruskal(runtimes, self.previous_runtimes)
-        reward = np.median(runtimes) - np.median(self.previous_runtimes) if pval < 0.05 else 0
+        diff = np.median(runtimes) - np.median(self.previous_runtimes)
+        reward = 2 * diff if pval < 0.05 else diff
         self.previous_runtimes = runtimes
         return reward

--- a/compiler_gym/wrappers/__init__.py
+++ b/compiler_gym/wrappers/__init__.py
@@ -48,7 +48,10 @@ from compiler_gym.wrappers.datasets import (
 from compiler_gym.wrappers.fork import ForkOnStep
 
 if config.enable_llvm_env:
-    from compiler_gym.wrappers.llvm import RuntimePointEstimateReward  # noqa: F401
+    from compiler_gym.wrappers.llvm import (
+        RuntimePointEstimateReward, # noqa: F401
+        RuntimeSeriesEstimateReward,
+    )
     from compiler_gym.wrappers.sqlite_logger import (  # noqa: F401
         SynchronousSqliteLogger,
     )
@@ -76,4 +79,5 @@ __all__ = [
 
 if config.enable_llvm_env:
     __all__.append("RuntimePointEstimateReward")
+    __all__.append("RuntimeSeriesEstimateReward")
     __all__.append("SynchronousSqliteLogger")

--- a/compiler_gym/wrappers/llvm.py
+++ b/compiler_gym/wrappers/llvm.py
@@ -94,7 +94,7 @@ class RuntimeSeriesEstimateReward(CompilerEnvWrapper):
                 warmup_count=warmup_count,
             )
         )
-        self.env.unwrapped.reward_space = "runtime"
+        self.env.unwrapped.reward_space = "runtimeseries"
 
         self.env.unwrapped.runtime_observation_count = runtime_count
         self.env.unwrapped.runtime_warmup_runs_count = warmup_count
@@ -104,9 +104,9 @@ class RuntimeSeriesEstimateReward(CompilerEnvWrapper):
         # Remove the original "runtime" space so that we that new
         # RuntimeSeriesEstimateReward wrapper instance does not attempt to
         # redefine, raising a warning.
-        del fkd.unwrapped.reward.spaces["runtime"]
+        del fkd.unwrapped.reward.spaces["runtimeseries"]
         return RuntimeSeriesEstimateReward(
             env=fkd,
-            runtime_count=self.reward.spaces["runtime"].runtime_count,
-            warmup_count=self.reward.spaces["runtime"].warmup_count,
+            runtime_count=self.reward.spaces["runtimeseries"].runtime_count,
+            warmup_count=self.reward.spaces["runtimeseries"].warmup_count,
         )

--- a/compiler_gym/wrappers/llvm.py
+++ b/compiler_gym/wrappers/llvm.py
@@ -70,7 +70,15 @@ class RuntimePointEstimateReward(CompilerEnvWrapper):
         )
 
 class RuntimeSeriesEstimateReward(CompilerEnvWrapper):
-    """TODO: documentation
+    """LLVM wrapper that estimates the runtime of a program using N runtime
+    observations and uses it as the reward.
+
+    This class wraps an LLVM environment and registers a new runtime reward
+    space. It is similar to the RuntimePointEstimateReward except that it only
+    computes runtime differences if the change in runtime is significantly
+    different from the runtimes in the previous step.
+
+    See RuntimeSeriesReward for more details.
     """
 
     def __init__(
@@ -101,7 +109,7 @@ class RuntimeSeriesEstimateReward(CompilerEnvWrapper):
 
     def fork(self) -> "RuntimeSeriesEstimateReward":
         fkd = self.env.fork()
-        # Remove the original "runtime" space so that we that new
+        # Remove the original "runtimeseries" space so that we that new
         # RuntimeSeriesEstimateReward wrapper instance does not attempt to
         # redefine, raising a warning.
         del fkd.unwrapped.reward.spaces["runtimeseries"]

--- a/examples/llvm_autotuning/autotuners/nevergrad_.py
+++ b/examples/llvm_autotuning/autotuners/nevergrad_.py
@@ -29,7 +29,10 @@ def nevergrad(
 
         https://facebookresearch.github.io/nevergrad/
     """
-    if optimization_target == OptimizationTarget.RUNTIME:
+    if (
+        optimization_target == OptimizationTarget.RUNTIME or
+        optimization_target == OptimizationTarget.RUNTIME_SERIES
+    ):
 
         def calculate_negative_reward(actions: Tuple[ActionType]) -> float:
             env.reset()

--- a/examples/llvm_autotuning/optimization_target.py
+++ b/examples/llvm_autotuning/optimization_target.py
@@ -15,6 +15,7 @@ import compiler_gym
 from compiler_gym.datasets import Benchmark
 from compiler_gym.envs import LlvmEnv
 from compiler_gym.wrappers import RuntimePointEstimateReward
+from compiler_gym.wrappers import RuntimeSeriesEstimateReward
 
 logger = logging.getLogger(__name__)
 
@@ -25,6 +26,7 @@ class OptimizationTarget(str, Enum):
     CODESIZE = "codesize"
     BINSIZE = "binsize"
     RUNTIME = "runtime"
+    RUNTIME_SERIES = "runtimeseries"
 
     @property
     def optimization_space_enum_name(self) -> str:
@@ -32,6 +34,7 @@ class OptimizationTarget(str, Enum):
             OptimizationTarget.CODESIZE: "IrInstructionCount",
             OptimizationTarget.BINSIZE: "ObjectTextSizeBytes",
             OptimizationTarget.RUNTIME: "Runtime",
+            OptimizationTarget.RUNTIME_SERIES: "RuntimeSeries",
         }[self.value]
 
     def make_env(self, benchmark: Union[str, Benchmark]) -> LlvmEnv:
@@ -50,6 +53,8 @@ class OptimizationTarget(str, Enum):
             env.reward_space = "ObjectTextSizeOz"
         elif self.value == OptimizationTarget.RUNTIME:
             env = RuntimePointEstimateReward(env, warmup_count=0, runtime_count=3)
+        elif self.value == OptimizationTarget.RUNTIME_SERIES:
+            env = RuntimeSeriesEstimateReward(env, warmup_count=5, runtime_count=30)
         else:
             assert False, f"Unknown OptimizationTarget: {self.value}"
 

--- a/examples/llvm_autotuning/optimization_target.py
+++ b/examples/llvm_autotuning/optimization_target.py
@@ -94,29 +94,10 @@ class OptimizationTarget(str, Enum):
                 env.observation.ObjectTextSizeBytes(), 1
             )
 
-        if self.value == OptimizationTarget.RUNTIME:
-            with _RUNTIME_LOCK:
-                with compiler_gym.make("llvm-v0", benchmark=env.benchmark) as new_env:
-                    new_env.reset()
-                    new_env.runtime_observation_count = runtime_count
-                    new_env.runtime_warmup_count = 0
-                    new_env.apply(env.state)
-                    final_runtimes = new_env.observation.Runtime()
-                    assert len(final_runtimes) == runtime_count
-
-                    new_env.reset()
-                    new_env.send_param("llvm.apply_baseline_optimizations", "-O3")
-                    o3_runtimes = new_env.observation.Runtime()
-                    assert len(o3_runtimes) == runtime_count
-
-                logger.debug("O3 runtimes: %s", o3_runtimes)
-                logger.debug("Final runtimes: %s", final_runtimes)
-                speedup = np.median(o3_runtimes) / max(np.median(final_runtimes), 1e-12)
-                logger.debug("Speedup: %.4f", speedup)
-
-                return speedup
-
-        if self.value == OptimizationTarget.RUNTIME_SERIES:
+        if (
+            self.value == OptimizationTarget.RUNTIME or
+            self.value == OptimizationTarget.RUNTIME_SERIES
+        ):
             with _RUNTIME_LOCK:
                 with compiler_gym.make("llvm-v0", benchmark=env.benchmark) as new_env:
                     new_env.reset()

--- a/examples/llvm_autotuning/optimization_target.py
+++ b/examples/llvm_autotuning/optimization_target.py
@@ -116,4 +116,26 @@ class OptimizationTarget(str, Enum):
 
                 return speedup
 
+        if self.value == OptimizationTarget.RUNTIME_SERIES:
+            with _RUNTIME_LOCK:
+                with compiler_gym.make("llvm-v0", benchmark=env.benchmark) as new_env:
+                    new_env.reset()
+                    new_env.runtime_observation_count = runtime_count
+                    new_env.runtime_warmup_count = 0
+                    new_env.apply(env.state)
+                    final_runtimes = new_env.observation.Runtime()
+                    assert len(final_runtimes) == runtime_count
+
+                    new_env.reset()
+                    new_env.send_param("llvm.apply_baseline_optimizations", "-O3")
+                    o3_runtimes = new_env.observation.Runtime()
+                    assert len(o3_runtimes) == runtime_count
+
+                logger.debug("O3 runtimes: %s", o3_runtimes)
+                logger.debug("Final runtimes: %s", final_runtimes)
+                speedup = np.median(o3_runtimes) / max(np.median(final_runtimes), 1e-12)
+                logger.debug("Speedup: %.4f", speedup)
+
+                return speedup
+
         assert False, f"Unknown OptimizationTarget: {self.value}"


### PR DESCRIPTION
# Introduce RuntimeSeriesReward

Introduce a new implementation of comparing program runtimes that computes the reward as the difference of the medians between the current set of runtimes and the previous set of runtimes only if the runtime series are significantly different (determined by the [Kruskal–Wallis test](https://en.wikipedia.org/wiki/Kruskal%E2%80%93Wallis_one-way_analysis_of_variance)).

Source: https://htor.inf.ethz.ch/publications/img/hoefler-scientific-benchmarking.pdf

# Testing

I ran a series of tests comparing the new implementation with the existing implementation using the LLVM autotuner on the `cbench-v1` benchmark. The rewards are shown below:

| Benchmark | Runtime | Runtime Series|
|-----------|---------|---------------|
| cbench-v1/bitcount        |  0.847564  |  0.780826  |
| cbench-v1/blowfish        |  0.997087  |  0.997496  |
| cbench-v1/bzip2           |  2.505352  |  2.516984  |
| cbench-v1/crc32           |  1.003222  |  0.995800  |
| cbench-v1/dijkstra        |  1.001125  |  1.014525  |
| cbench-v1/gsm             |  0.785371  |  0.812009  |
| cbench-v1/jpeg-c          |  0.976613  |  0.989570  |
| cbench-v1/jpeg-d          |  1.004371  |  1.010437  |
| cbench-v1/patricia        |  0.992379  |  1.010707  |
| cbench-v1/qsort           |  0.958153  |  0.986507  |
| cbench-v1/sha             |  1.000886  |  0.990302  |
| cbench-v1/stringsearch    |  1.004281  |  1.006058  |
| cbench-v1/stringsearch2   |  1.009237  |  1.050334  |
| cbench-v1/susan           |  0.959058  |  0.975618  |
| cbench-v1/tiff2bw         |  1.016761  |  1.018933  |
| cbench-v1/tiff2rgba       |  1.105831  |  1.104215  |
| cbench-v1/tiffdither      |  1.042336  |  1.022278  |
| cbench-v1/tiffmedian      |  1.005050  |  1.010557  |

The new implementation is on par with the existing implementation, and even beats the existing implementation on 12/17 of the benchmarks.

I am proposing to merge this upstream and we can maybe work on other optimizations such as early stopping.
