### PR TITLE
[www] Add support for user-provided benchmark source.

### DIFF
--- a/www/www.py
+++ b/www/www.py
@@ -224,7 +224,11 @@ def _make_benchmark(name: str, source: str) -> Benchmark:
         tmpfile = Path(d) / Path(name).name
         with open(tmpfile, "w") as f:
             f.write(source)
-        return make_benchmark(tmpfile, timeout=60)
+
+        try:
+            return make_benchmark(tmpfile, timeout=60)
+        except Exception as e:
+            raise ValueError(f"Failed to compiler benchmark {name}: {e}")
 
 
 def _step(request: StepRequest) -> StepReply:


### PR DESCRIPTION
This adds a `benchmark_source` attribute to the step API that enables users to provide their own code to use as a benchmark. To use your own benchmark source, you inline the contents of your source file into the `benchmark_source` attribute and set the `benchmark` attribute to the name of the local file:

```json
{
  "benchmark": "/tmp/foo.c",
  "benchmark_source": "int A() {\n  return 1;\n}",
   ...
}
```

The file name is important because we use the file extension to determine how to process it (e.g. `.c` files are compiled, `.ll` files are interpreted as bytecode, etc).

Here are two example files for testing.

The first is `example1.c`:

```
int A() {
  return 0;
}
```

The second is `example2.ll`:

```
; ModuleID = 'example1.c'
source_filename = "example1.c"
target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
target triple = "x86_64-unknown-linux-gnu"

; Function Attrs: noinline nounwind optnone uwtable
define dso_local i32 @A() #0 {
  ret i32 0
}

attributes #0 = { noinline nounwind optnone uwtable "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }

!llvm.module.flags = !{!0}
!llvm.ident = !{!1}

!0 = !{i32 1, !"wchar_size", i32 4}
!1 = !{!"clang version 10.0.0 "}
```