### PR TITLE
[llvm] Add utility functions to split and merge benchmarks.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -722,6 +722,7 @@ jobs:
                   rm *.whl
                   chmod +x compiler_gym-*/compiler_gym-*.data/purelib/compiler_gym/third_party/csmith/csmith/bin/csmith
                   chmod +x compiler_gym-*/compiler_gym-*.data/purelib/compiler_gym/envs/llvm/service/compute_observation
+                  chmod +x compiler_gym-*/compiler_gym-*.data/purelib/compiler_gym/envs/llvm/service/llvm-extract-one
                   mv compiler_gym-llvm-service compiler_gym-*/compiler_gym-*.data/purelib/compiler_gym/envs/llvm/service/compiler_gym-llvm-service
                   wheel pack compiler_gym-*
 

--- a/compiler_gym/datasets/benchmark.py
+++ b/compiler_gym/datasets/benchmark.py
@@ -6,14 +6,13 @@ from concurrent.futures import as_completed
 from pathlib import Path
 from typing import Callable, Iterable, List, NamedTuple, Optional, Union
 
-from compiler_gym.util.decorators import frozen_class
 import compiler_gym.errors
 from compiler_gym.datasets.uri import BenchmarkUri
 from compiler_gym.errors import ValidationError
 from compiler_gym.service.proto import Benchmark as BenchmarkProto
 from compiler_gym.service.proto import File
 from compiler_gym.util import thread_pool
-from compiler_gym.util.decorators import memoized_property
+from compiler_gym.util.decorators import frozen_class, memoized_property
 
 # A validation callback is a function that takes a single CompilerEnv instance
 # as its argument and returns an iterable sequence of zero or more

--- a/compiler_gym/envs/llvm/__init__.py
+++ b/compiler_gym/envs/llvm/__init__.py
@@ -12,6 +12,9 @@ from compiler_gym.envs.llvm.llvm_benchmark import (
     ClangInvocation,
     get_system_library_flags,
     make_benchmark,
+    make_benchmark_from_source,
+    merge_benchmarks,
+    split_benchmark_by_function,
 )
 from compiler_gym.envs.llvm.llvm_env import LlvmEnv
 
@@ -30,8 +33,11 @@ __all__ = [
     "LLVM_SERVICE_BINARY",
     "LlvmEnv",
     "make_benchmark",
+    "make_benchmark_from_source",
+    "merge_benchmarks",
     "observation_spaces",
     "reward_spaces",
+    "split_benchmark_by_function",
 ]
 
 LLVM_SERVICE_BINARY = runfiles_path(

--- a/compiler_gym/envs/llvm/service/BUILD
+++ b/compiler_gym/envs/llvm/service/BUILD
@@ -206,6 +206,50 @@ cc_library(
     ],
 )
 
+filegroup(
+    name = "llvm-extract-one-files",
+    srcs = [
+        ":llvm-extract-one",
+    ] + select({
+        "@llvm//:darwin": [],
+        "//conditions:default": [
+            ":libLLVMPolly",
+        ],
+    }),
+    visibility = ["//visibility:public"],
+)
+
+cc_binary(
+    name = "llvm-extract-one-prelinked",
+    srcs = ["LlvmExtractOne.cc"],
+    copts = [
+        "-DGOOGLE_PROTOBUF_NO_RTTI",
+        "-fno-rtti",
+        "-std=c++17",
+    ],
+    deps = [
+        "@llvm//10.0.0",
+    ],
+)
+
+genrule(
+    name = "llvm-extract-one-bin",
+    srcs = [":llvm-extract-one-prelinked"],
+    outs = ["llvm-extract-one"],
+    cmd = select({
+        "@llvm//:darwin": (
+            "cp $(location :llvm-extract-one-prelinked) $@"
+        ),
+        "//conditions:default": (
+            "cp $(location :llvm-extract-one-prelinked) $@ && " +
+            "chmod 666 $@ && " +
+            "patchelf --set-rpath '$$ORIGIN' $@ && " +
+            "chmod 555 $@"
+        ),
+    }),
+    visibility = ["//visibility:public"],
+)
+
 cc_library(
     name = "LlvmSession",
     srcs = ["LlvmSession.cc"],

--- a/compiler_gym/envs/llvm/service/CMakeLists.txt
+++ b/compiler_gym/envs/llvm/service/CMakeLists.txt
@@ -169,6 +169,20 @@ cg_cc_library(
   PUBLIC
 )
 
+llvm_map_components_to_libnames(_LLVM_LIBS support core irreader ipo)
+cg_cc_binary(
+  NAME llvm-extract-one
+  SRCS LlvmExtractOne.cc
+  COPTS
+    "-fno-rtti"
+  ABS_DEPS
+    ${_LLVM_LIBS}
+  INCLUDES
+    ${LLVM_INCLUDE_DIRS}
+  DEFINES
+    ${LLVM_DEFINITIONS}
+)
+
 llvm_map_components_to_libnames(_LLVM_LIBS
   core analysis coroutines objcarcopts target codegen
   x86codegen x86asmparser #TODO(boian): can these be found programmatically

--- a/compiler_gym/envs/llvm/service/LlvmExtractOne.cc
+++ b/compiler_gym/envs/llvm/service/LlvmExtractOne.cc
@@ -1,0 +1,142 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+//=============================================================================
+// This file is a small tool to extract single functions from LLVM bitcode
+#include <cstdlib>
+#include <ctime>
+#include <iostream>
+#include <vector>
+
+#include "llvm/Bitcode/BitcodeWriterPass.h"
+#include "llvm/IR/IRPrintingPasses.h"
+#include "llvm/IR/LegacyPassManager.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IR/Verifier.h"
+#include "llvm/IRReader/IRReader.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Error.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/SourceMgr.h"
+#include "llvm/Support/SystemUtils.h"
+#include "llvm/Support/ToolOutputFile.h"
+#include "llvm/Transforms/IPO.h"
+
+using namespace llvm;
+
+// Command line options
+static cl::OptionCategory ExtractOneOptions("llvm-extract-one Options");
+static cl::opt<std::string> InputFileName(cl::Positional, cl::desc("[input file]"),
+                                          cl::value_desc("filename"), cl::init("-"));
+static cl::opt<std::string> OutputFileName("o",
+                                           cl::desc("Specify output filename (default=stdout)"),
+                                           cl::value_desc("filename"), cl::init("-"));
+static cl::opt<unsigned int> Seed("seed", cl::desc("Random number seed (default=0)"),
+                                  cl::value_desc("unsigned int"), cl::init(0),
+                                  cl::cat(ExtractOneOptions));
+static cl::opt<int> Nth("n", cl::desc("Extract the n-th function"), cl::value_desc("unsigned int"),
+                        cl::init(-1), cl::cat(ExtractOneOptions));
+static cl::opt<bool> CountOnly("count-only", cl::desc("Only count the number of funtions"),
+                               cl::init(false), cl::cat(ExtractOneOptions));
+static cl::opt<bool> Force("f", cl::desc("Enable binary output on terminals"),
+                           cl::cat(ExtractOneOptions));
+static cl::opt<bool> OutputAssembly("S", cl::desc("Write output as LLVM assembly"), cl::Hidden,
+                                    cl::cat(ExtractOneOptions));
+static cl::opt<bool> PreserveBitcodeUseListOrder(
+    "preserve-bc-uselistorder", cl::desc("Preserve use-list order when writing LLVM bitcode."),
+    cl::init(true), cl::Hidden, cl::cat(ExtractOneOptions));
+static cl::opt<bool> PreserveAssemblyUseListOrder(
+    "preserve-ll-uselistorder", cl::desc("Preserve use-list order when writing LLVM assembly."),
+    cl::init(false), cl::Hidden, cl::cat(ExtractOneOptions));
+
+/// Reads a module from a file.
+/// On error, messages are written to stderr and null is returned.
+///
+/// \param Context LLVM Context for the module.
+/// \param Name Input file name.
+static std::unique_ptr<Module> readModule(LLVMContext& Context, StringRef Name) {
+  SMDiagnostic Diag;
+  std::unique_ptr<Module> Module = parseIRFile(Name, Diag, Context);
+
+  if (!Module)
+    Diag.print("llvm-extract-one", errs());
+
+  return Module;
+}
+
+// The main tool
+int main(int argc, char** argv) {
+  cl::ParseCommandLineOptions(argc, argv,
+                              " llvm-extract-one\n\n"
+                              " Extract a single, random function from a bitcode file.\n\n"
+                              " If no input file is given, or it is given as '-', then the input "
+                              "file is read from stdin.\n");
+
+  if (Seed)
+    std::srand(Seed);
+  else
+    std::srand(std::time(nullptr));
+
+  LLVMContext Context;
+
+  std::unique_ptr<Module> Module = readModule(Context, InputFileName);
+
+  if (!Module)
+    return 1;
+
+  // Find functions that might be kept
+  std::vector<Function*> Functions;
+  for (auto& Function : *Module) {
+    if (!Function.empty()) {
+      Functions.push_back(&Function);
+    }
+  }
+  if (CountOnly) {
+    std::cout << Functions.size() << std::endl;
+    return 0;
+  }
+
+  if (Functions.empty()) {
+    errs() << "No suitable functions\n";
+    return 1;
+  }
+  // Choose one
+  int keeperIndex = (Nth == -1 ? std::rand() : Nth) % Functions.size();
+  Function* Keeper = Functions[keeperIndex];
+
+  // Extract the function
+  ExitOnError ExitOnErr(std::string(*argv) + ": extracting function : ");
+  ExitOnErr(Keeper->materialize());
+  legacy::PassManager Passes;
+  std::vector<GlobalValue*> GVs = {Keeper};
+  Passes.add(createGVExtractionPass(GVs));      // Extract the one function
+  Passes.add(createGlobalDCEPass());            // Delete unreachable globals
+  Passes.add(createStripDeadDebugInfoPass());   // Remove dead debug info
+  Passes.add(createStripDeadPrototypesPass());  // Remove dead func decls
+
+  if (verifyModule(*Module, &errs()))
+    return 1;
+
+  std::error_code EC;
+  ToolOutputFile Out(OutputFileName, EC, sys::fs::OF_None);
+
+  if (EC) {
+    errs() << EC.message() << '\n';
+    return 1;
+  }
+
+  if (OutputAssembly) {
+    Out.os() << "; KeeperIndex = " << keeperIndex << '\n';
+    Passes.add(createPrintModulePass(Out.os(), "", PreserveAssemblyUseListOrder));
+  } else if (Force || !CheckBitcodeOutputToConsole(Out.os())) {
+    Passes.add(createBitcodeWriterPass(Out.os(), PreserveBitcodeUseListOrder));
+  }
+  Passes.run(*Module);
+
+  // Declare success.
+  Out.keep();
+
+  return 0;
+}

--- a/compiler_gym/third_party/llvm/BUILD
+++ b/compiler_gym/third_party/llvm/BUILD
@@ -8,6 +8,7 @@ load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 py_library(
     name = "llvm",
     srcs = ["__init__.py"],
+    data = ["//compiler_gym/envs/llvm/service:llvm-extract-one-files"],
     visibility = ["//visibility:public"],
     deps = [
         "//compiler_gym/util",

--- a/compiler_gym/third_party/llvm/CMakeLists.txt
+++ b/compiler_gym/third_party/llvm/CMakeLists.txt
@@ -14,6 +14,8 @@ cg_py_library(
     llvm
   SRCS
     "__init__.py"
+  DATA
+    compiler_gym::envs::llvm::service::llvm-extract-one
   DEPS
     compiler_gym::util::util
   PUBLIC

--- a/compiler_gym/third_party/llvm/__init__.py
+++ b/compiler_gym/third_party/llvm/__init__.py
@@ -16,7 +16,7 @@ from fasteners import InterProcessLock
 
 from compiler_gym.util.download import download
 from compiler_gym.util.filesystem import extract_tar
-from compiler_gym.util.runfiles_path import cache_path, site_data_path
+from compiler_gym.util.runfiles_path import cache_path, runfiles_path, site_data_path
 
 logger = logging.getLogger(__name__)
 
@@ -113,6 +113,11 @@ def llvm_as_path() -> Path:
 def llvm_dis_path() -> Path:
     """Return the path of llvm-as."""
     return download_llvm_files() / "bin/llvm-dis"
+
+
+def llvm_extract_one_path() -> Path:
+    """Return the path of llvm-extract-one."""
+    return runfiles_path("compiler_gym/envs/llvm/service/llvm-extract-one")
 
 
 def llvm_link_path() -> Path:

--- a/docs/source/llvm/api.rst
+++ b/docs/source/llvm/api.rst
@@ -15,6 +15,12 @@ Constructing Benchmarks
 
 .. autofunction:: make_benchmark
 
+.. autofunction:: make_benchmark_from_source
+
+.. autofunction:: split_benchmark_by_function
+
+.. autofunction:: merge_benchmarks
+
 .. autoclass:: BenchmarkFromCommandLine
    :members:
 

--- a/setup.py
+++ b/setup.py
@@ -190,6 +190,7 @@ if config.enable_llvm_env:
         [
             "envs/llvm/service/compiler_gym-llvm-service",
             "envs/llvm/service/compute_observation",
+            "envs/llvm/service/llvm-extract-one",
             "envs/llvm/service/libLLVMPolly.so",
             "third_party/cbench/benchmarks.txt",
             "third_party/cbench/cbench-v*/crc32.bc",

--- a/tests/llvm/llvm_benchmark_test.py
+++ b/tests/llvm/llvm_benchmark_test.py
@@ -3,6 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 """Integrations tests for the LLVM CompilerGym environments."""
+import re
 import tempfile
 from pathlib import Path
 
@@ -10,7 +11,8 @@ import pytest
 
 from compiler_gym.datasets import Benchmark
 from compiler_gym.envs import CompilerEnv
-from compiler_gym.envs.llvm import llvm_benchmark
+from compiler_gym.envs.llvm import llvm_benchmark as llvm
+from compiler_gym.errors.dataset_errors import BenchmarkInitError
 from compiler_gym.service.proto import Benchmark as BenchmarkProto
 from compiler_gym.service.proto import File
 from tests.pytest_plugins.common import macos_only
@@ -45,51 +47,213 @@ def test_add_benchmark_invalid_path(env: CompilerEnv):
 
 def test_get_system_library_flags_not_found():
     with pytest.raises(
-        llvm_benchmark.HostCompilerFailure, match="Failed to invoke 'not-a-real-binary'"
+        llvm.HostCompilerFailure, match="Failed to invoke 'not-a-real-binary'"
     ):
-        llvm_benchmark.get_system_library_flags("not-a-real-binary")
+        llvm.get_system_library_flags("not-a-real-binary")
 
 
 def test_get_system_library_flags_nonzero_exit_status():
     """Test that setting the $CXX to an invalid binary raises an error."""
-    with pytest.raises(
-        llvm_benchmark.HostCompilerFailure, match="Failed to invoke 'false'"
-    ):
-        llvm_benchmark.get_system_library_flags("false")
+    with pytest.raises(llvm.HostCompilerFailure, match="Failed to invoke 'false'"):
+        llvm.get_system_library_flags("false")
 
 
 def test_get_system_library_flags_output_parse_failure():
     """Test that setting the $CXX to an invalid binary raises an error."""
     with pytest.raises(
-        llvm_benchmark.UnableToParseHostCompilerOutput,
+        llvm.UnableToParseHostCompilerOutput,
         match="Failed to parse '#include <...>' search paths from 'echo'",
     ):
-        llvm_benchmark.get_system_library_flags("echo")
+        llvm.get_system_library_flags("echo")
 
 
 def test_get_system_library_flags():
-    flags = llvm_benchmark.get_system_library_flags()
+    flags = llvm.get_system_library_flags()
     assert flags
     assert "-isystem" in flags
 
 
 @macos_only
 def test_get_system_library_flags_system_libraries():
-    flags = llvm_benchmark.get_system_library_flags()
+    flags = llvm.get_system_library_flags()
     assert flags
     assert flags[-1] == "-L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib"
 
 
 def test_ClangInvocation_system_libs():
-    cmd = llvm_benchmark.ClangInvocation(["foo.c"]).command("a.out")
+    cmd = llvm.ClangInvocation(["foo.c"]).command("a.out")
     assert "-isystem" in cmd
 
 
 def test_ClangInvocation_no_system_libs():
-    cmd = llvm_benchmark.ClangInvocation(["foo.c"], system_includes=False).command(
-        "a.out"
-    )
+    cmd = llvm.ClangInvocation(["foo.c"], system_includes=False).command("a.out")
     assert "-isystem" not in cmd
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "",
+        "int A() {return 0;}",
+        """
+int A() {return 0;}
+int B() {return A();}
+int C() {return 0;}
+    """,
+    ],
+)
+@pytest.mark.parametrize("system_includes", [False, True])
+def test_make_benchmark_from_source_valid_source(
+    env: CompilerEnv, source: str, system_includes: bool
+):
+    benchmark = llvm.make_benchmark_from_source(source, system_includes=system_includes)
+    env.reset(benchmark=benchmark)
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "@syntax error!!!",  # invalid syntax
+        "int A() {return a;}",  # undefined variable
+        '#include "missing.h"',  # missing include
+    ],
+)
+@pytest.mark.parametrize("system_includes", [False, True])
+def test_make_benchmark_from_source_invalid_source(source: str, system_includes: bool):
+    with pytest.raises(
+        BenchmarkInitError, match="Failed to make benchmark with compiler error:"
+    ):
+        llvm.make_benchmark_from_source(source, system_includes=system_includes)
+
+
+def test_make_benchmark_from_source_invalid_copt():
+    with pytest.raises(
+        BenchmarkInitError, match="Failed to make benchmark with compiler error:"
+    ):
+        llvm.make_benchmark_from_source(
+            "int A() {return 0;}", copt=["-invalid-argument!"]
+        )
+
+
+def test_make_benchmark_from_source_missing_system_includes():
+    with pytest.raises(
+        BenchmarkInitError, match="Failed to make benchmark with compiler error:"
+    ):
+        llvm.make_benchmark_from_source("#include <stdio.h>", system_includes=False)
+
+
+def test_make_benchmark_from_source_with_system_includes():
+    assert llvm.make_benchmark_from_source("#include <stdio.h>", system_includes=True)
+
+
+def test_split_benchmark_by_function_no_functions():
+    benchmark = llvm.make_benchmark_from_source("")
+    with pytest.raises(ValueError, match="No functions found"):
+        llvm.split_benchmark_by_function(benchmark)
+
+
+def is_defined(signature: str, ir: str):
+    """Return whether the function signature is defined in the IR."""
+    return re.search(f"^define .*{signature}", ir, re.MULTILINE)
+
+
+def is_declared(signature: str, ir: str):
+    """Return whether the function signature is defined in the IR."""
+    return re.search(f"^declare .*{signature}", ir, re.MULTILINE)
+
+
+def test_split_benchmark_by_function_repeated_split_single_function(env: CompilerEnv):
+    benchmark = llvm.make_benchmark_from_source("int A() {return 0;}", lang="c")
+    for _ in range(10):
+        benchmarks = llvm.split_benchmark_by_function(benchmark)
+        assert len(benchmarks) == 1
+        env.reset(benchmark=benchmarks[0])
+        assert is_defined("i32 @A()", env.ir)
+        benchmark = benchmarks[0]
+
+
+def test_split_benchmark_by_function_multiple_functions(env: CompilerEnv):
+    benchmark = llvm.make_benchmark_from_source(
+        """
+int A() {return 0;}
+int B() {return A();}
+""",
+        lang="c",
+    )
+
+    benchmarks = llvm.split_benchmark_by_function(benchmark)
+    assert len(benchmarks) == 2
+    A, B = benchmarks
+
+    env.reset(benchmark=A)
+    assert is_defined("i32 @A()", env.ir)
+    assert not is_defined("i32 @B()", env.ir)
+
+    assert not is_declared("i32 @A()", env.ir)
+    assert not is_declared("i32 @B()", env.ir)
+
+    env.reset(benchmark=B)
+    assert not is_defined("i32 @A()", env.ir)
+    assert is_defined("i32 @B()", env.ir)
+
+    assert is_declared("i32 @A()", env.ir)
+    assert not is_declared("i32 @B()", env.ir)
+
+
+def test_split_benchmark_by_function_maximum_function_count(env: CompilerEnv):
+    benchmark = llvm.make_benchmark_from_source(
+        """
+int A() {return 0;}
+int B() {return A();}
+""",
+        lang="c",
+    )
+
+    benchmarks = llvm.split_benchmark_by_function(
+        benchmark,
+        maximum_function_count=1,
+    )
+    assert len(benchmarks) == 1
+
+    env.reset(benchmark=benchmarks[0])
+    assert is_defined("i32 @A()", env.ir)
+
+
+def test_merge_benchmarks_single_input(env: CompilerEnv):
+    A = llvm.make_benchmark_from_source("int A() {return 0;}", lang="c")
+
+    merged = llvm.merge_benchmarks([A])
+    env.reset(benchmark=merged)
+
+    assert is_defined("i32 @A()", env.ir)
+
+
+def test_merge_benchmarks_independent(env: CompilerEnv):
+    A = llvm.make_benchmark_from_source("int A() {return 0;}", lang="c")
+    B = llvm.make_benchmark_from_source("int B() {return 0;}", lang="c")
+
+    merged = llvm.merge_benchmarks([A, B])
+    env.reset(benchmark=merged)
+
+    assert is_defined("i32 @A()", env.ir)
+    assert is_defined("i32 @B()", env.ir)
+
+
+def test_merge_benchmarks_multiply_defined():
+    A = llvm.make_benchmark_from_source("int A() {return 0;}", lang="c")
+    with pytest.raises(ValueError, match="symbol multiply defined"):
+        llvm.merge_benchmarks([A, A])
+
+
+def test_merge_benchmarks_declarations(env: CompilerEnv):
+    A = llvm.make_benchmark_from_source("int A() {return 0;}", lang="c")
+    B = llvm.make_benchmark_from_source("int A(); int B() {return A();}", lang="c")
+
+    merged = llvm.merge_benchmarks([A, B])
+    env.reset(benchmark=merged)
+
+    assert is_defined("i32 @A()", env.ir)
+    assert is_defined("i32 @B()", env.ir)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This adds three new utility functions for constructing LLVM benchmarks:

```py
def make_benchmark_from_source(
    source: str,
    copt: Optional[List[str]] = None,
    lang: str = "c++",
    system_includes: bool = True,
    timeout: int = 600,
) -> Benchmark:
    ...

def split_benchmark_by_function(
    benchmark: Benchmark, timeout: float = 300
) -> List[Benchmark]:
    ...

def merge_benchmarks(
    benchmarks: List[Benchmark], timeout: float = 300
) -> Benchmark:
   ...
```

Credit to @hughleat for `llvm-extract-one`, an extension of LLVM's `llvm-extract` that enables functions to be extracted by an integer index rather than by name. This enables extracting anonymous functions.

## Todo before land

- [x] Merge #767 and rebase on v0.2.5 (no conflicts).
- [x] Confirm CMake + bazel builds succeed.
- [x] Add test coverage for the two new functions.