### PR TITLE
Fix datasets contains false

### DIFF
--- a/compiler_gym/datasets/datasets.py
+++ b/compiler_gym/datasets/datasets.py
@@ -159,7 +159,7 @@ class Datasets:
     @staticmethod
     def _dataset_key_from_uri(uri: BenchmarkUri) -> str:
         if not (uri.scheme and uri.dataset):
-            raise ValueError(f"Invalid benchmark URI: '{uri}'")
+            raise LookupError(f"Invalid benchmark URI: '{uri}'")
         return f"{uri.scheme}://{uri.dataset}"
 
     def __getitem__(self, dataset: str) -> Dataset:

--- a/tests/datasets/datasets_test.py
+++ b/tests/datasets/datasets_test.py
@@ -138,6 +138,11 @@ def test_datasets_get_item():
     assert datasets.dataset("benchmark://foo-v0") == da
     assert datasets["benchmark://foo-v0"] == da
 
+def test_datasets_contains():
+    da = MockDataset("benchmark://foo-v0")
+    datasets = Datasets([da])
+
+    assert "benchmark://foo-v0" in datasets
 
 def test_datasets_get_item_default_scheme():
     da = MockDataset("benchmark://foo-v0")
@@ -156,6 +161,12 @@ def test_datasets_get_item_lookup_miss():
 
     with pytest.raises(LookupError, match=r"^Dataset not found: benchmark://bar-v0$"):
         _ = datasets["benchmark://bar-v0"]
+
+def test_datasets_contains_lookup_miss():
+    da = MockDataset("benchmark://foo-v0")
+    datasets = Datasets([da])
+
+    assert "benchmark://bar-v0" not in datasets
 
 
 def test_benchmark_lookup_by_uri():


### PR DESCRIPTION
I faced an issue where calling:
```
if "non_existent_data" in env.datasets:
   ...
```
would throw:
>   File "/private/home/melhoushi/miniconda3/envs/wmc/lib/python3.10/site-packages/compiler_gym/datasets/datasets.py", line 209, in __contains__
    self.dataset(dataset)
  File "/private/home/melhoushi/miniconda3/envs/wmc/lib/python3.10/site-packages/compiler_gym/datasets/datasets.py", line 137, in dataset
    return self.dataset_from_parsed_uri(BenchmarkUri.from_string(dataset))
  File "/private/home/melhoushi/miniconda3/envs/wmc/lib/python3.10/site-packages/compiler_gym/datasets/datasets.py", line 152, in dataset_from_parsed_uri
    key = self._dataset_key_from_uri(uri)
  File "/private/home/melhoushi/miniconda3/envs/wmc/lib/python3.10/site-packages/compiler_gym/datasets/datasets.py", line 162, in _dataset_key_from_uri
    raise ValueError(f"Invalid benchmark URI: '{uri}'")
ValueError: Invalid benchmark URI: 'benchmark:/checkpoint/melhoushi/wmc/corpus/src/'

this is because `__contains__` function in `Datasets` is handling `LookupError`:
https://github.com/facebookresearch/CompilerGym/blob/2b2061380bc42627396b05d5420823b3c31180e6/compiler_gym/datasets/datasets.py#LL206-L212C25
while `_dataset_key_from_uri` was throwing `ValueError`:
https://github.com/facebookresearch/CompilerGym/blob/2b2061380bc42627396b05d5420823b3c31180e6/compiler_gym/datasets/datasets.py#LL159-L163C17

This PR fixes the issue by replacing `ValueError` in `_dataset_key_from_uri` and adding some unit test cases for `__contains__`.
Not sure if this is the best way, or if you think there is a more proper solution. Perhaps `_dataset_key_from_uri` should throw both `ValueError` and `LookupError` ?
