### PR TITLE
[Inst2vec] add string_of_items to fix inst2vec_preprocess.py

### DIFF
--- a/compiler_gym/third_party/inst2vec/inst2vec_preprocess.py
+++ b/compiler_gym/third_party/inst2vec/inst2vec_preprocess.py
@@ -34,6 +34,21 @@ from compiler_gym.third_party.inst2vec import rgx_utils as rgx
 
 
 ########################################################################################################################
+# Helper functions: list and stmt handling
+########################################################################################################################
+def string_of_items(dic):
+    """
+    Return a string containing all keys of a dictionary, separated by a comma
+    (Helper function for structure inlining)
+    :param dic: dictionary [key=string: value=string]
+    :return: string constructed of the dictionaries' keys
+    """
+    s = ''
+    for k, v in dic.items():
+        s += k + ': ' + v + '\n'
+    return s
+
+########################################################################################################################
 # LLVM IR preprocessing
 ########################################################################################################################
 def GetFunctionsDeclaredInFile(bytecode_lines):


### PR DESCRIPTION
There is an error when set " observation_space='Inst2vec' ":
`NameError: name 'string_of_items' is not defined`
