### PR TITLE
Bumbing http-cache-semantics to 4.1.1 to fix cve

### DIFF
--- a/www/frontends/compiler_gym/package-lock.json
+++ b/www/frontends/compiler_gym/package-lock.json
@@ -8775,9 +8775,9 @@
       }
     },
     "node_modules/http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
     },
     "node_modules/http-deceiver": {
       "version": "1.2.7",
@@ -12458,7 +12458,7 @@
       }
     },
     "node_modules/npm/node_modules/http-cache-semantics": {
-      "version": "4.1.0",
+      "version": "4.1.1",
       "inBundle": true,
       "license": "BSD-2-Clause"
     },
@@ -25653,9 +25653,9 @@
       }
     },
     "http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==" 
     },
     "http-deceiver": {
       "version": "1.2.7",
@@ -28300,7 +28300,7 @@
           }
         },
         "http-cache-semantics": {
-          "version": "4.1.0",
+          "version": "4.1.1",
           "bundled": true
         },
         "http-proxy-agent": {

--- a/www/frontends/compiler_gym/package.json
+++ b/www/frontends/compiler_gym/package.json
@@ -49,6 +49,7 @@
     ]
   },
   "overrides": {
-    "autoprefixer": "10.4.5"
+    "autoprefixer": "10.4.5",
+    "http-cache-semantics": "4.1.1"
   }
 }


### PR DESCRIPTION
Fixes DoS issues from http-cache-semantics dependency version 4.1.0 by bumping to 4.1.1
[https://github.com/advisories/GHSA-rc47-6667-2j5j](https://github.com/advisories/GHSA-rc47-6667-2j5j)

Most of the dependencies are quite outdated but currently runs under node 13 with `npm ci` I tried to change as little as necessary

Does not work on more recent node version since py-gyp won't build probaby because the py-gyp is not maintained anymore
